### PR TITLE
Add tests to the nodejs-function meta-buildpack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,3 +105,4 @@ workflows:
                 - "buildpacks/typescript"
                 - "meta-buildpacks/nodejs"
                 - "test/meta-buildpacks/nodejs"
+                - "test/meta-buildpacks/nodejs-function"

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -11,8 +11,17 @@ type = "MIT"
 [[order]]
 
 [[order.group]]
-id = "heroku/nodejs"
-version = "0.3.3"
+id = "heroku/nodejs-engine"
+version = "0.7.4"
+
+[[order.group]]
+id = "heroku/nodejs-npm"
+version = "0.4.4"
+
+[[order.group]]
+id = "heroku/nodejs-typescript"
+version = "0.2.3"
+optional = true
 
 [[order.group]]
 id = "heroku/streaming-http-adapter-buildpack"

--- a/meta-buildpacks/nodejs-function/package.toml
+++ b/meta-buildpacks/nodejs-function/package.toml
@@ -2,13 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "../../../buildpacks/nodejs"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@sha256:4fa85f23b1df1138039ec6f5667da48da2af7858767b8840a754c54b39b42ca1"
 
 [[dependencies]]
-uri = "../../../buildpacks/npm"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha256:248ce84d07d2b9a11ca2433aee91bec48b2e029aac968e14f57711fe4270159a"
 
 [[dependencies]]
-uri = "../../../buildpacks/typescript"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:accfc74412af9702c86d370f6289dc9674acc33023369e68f9687b6b4a1b63bd"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/streaming-http-adapter-buildpack:1.4.0"

--- a/meta-buildpacks/nodejs-function/package.toml
+++ b/meta-buildpacks/nodejs-function/package.toml
@@ -2,7 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:33925c80a23b9592b4217fc5e8a6deea0fd412b7d2541a11610604cad131e8b4"
+uri = "../../../buildpacks/nodejs"
+
+[[dependencies]]
+uri = "../../../buildpacks/npm"
+
+[[dependencies]]
+uri = "../../../buildpacks/typescript"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/streaming-http-adapter-buildpack:1.4.0"

--- a/test/meta-buildpacks/nodejs-function/build.sh
+++ b/test/meta-buildpacks/nodejs-function/build.sh
@@ -1,0 +1,1 @@
+../../../common/meta-build.sh

--- a/test/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/test/meta-buildpacks/nodejs-function/buildpack.toml
@@ -1,0 +1,34 @@
+api = "0.2"
+
+[buildpack]
+id = "heroku/nodejs-function"
+version = "0.4.0"
+name = "Node.js Function"
+
+[[buildpack.licenses]]
+type = "MIT"
+
+[[order]]
+
+[[order.group]]
+id = "heroku/nodejs"
+version = "0.3.4"
+
+[[order.group]]
+id = "heroku/streaming-http-adapter-buildpack"
+version = "1.4.0"
+
+[[order.group]]
+id = "heroku/node-function-buildpack"
+version = "1.5.0"
+
+[[order.group]]
+id = "salesforce/nodejs-fn"
+version = "2.0.6"
+
+[metadata]
+
+[metadata.release]
+
+[metadata.release.docker]
+repository = "public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack"

--- a/test/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/test/meta-buildpacks/nodejs-function/buildpack.toml
@@ -11,8 +11,17 @@ type = "MIT"
 [[order]]
 
 [[order.group]]
-id = "heroku/nodejs"
-version = "0.3.4"
+id = "heroku/nodejs-engine"
+version = "0.7.3"
+
+[[order.group]]
+id = "heroku/nodejs-npm"
+version = "0.4.3"
+
+[[order.group]]
+id = "heroku/nodejs-typescript"
+version = "0.2.2"
+optional = true
 
 [[order.group]]
 id = "heroku/streaming-http-adapter-buildpack"

--- a/test/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/test/meta-buildpacks/nodejs-function/buildpack.toml
@@ -12,15 +12,15 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.7.3"
+version = "0.7.4"
 
 [[order.group]]
 id = "heroku/nodejs-npm"
-version = "0.4.3"
+version = "0.4.4"
 
 [[order.group]]
 id = "heroku/nodejs-typescript"
-version = "0.2.2"
+version = "0.2.3"
 optional = true
 
 [[order.group]]

--- a/test/meta-buildpacks/nodejs-function/package.toml
+++ b/test/meta-buildpacks/nodejs-function/package.toml
@@ -1,0 +1,14 @@
+[buildpack]
+uri = "."
+
+[[dependencies]]
+uri = "../../../meta-buildpacks/nodejs"
+
+[[dependencies]]
+uri = "docker://docker.io/heroku/streaming-http-adapter-buildpack:1.4.0"
+
+[[dependencies]]
+uri = "docker://docker.io/heroku/node-function-buildpack:1.5.0"
+
+[[dependencies]]
+uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.6/nodejs-sf-fx-buildpack-v2.0.6.tgz"

--- a/test/meta-buildpacks/nodejs-function/package.toml
+++ b/test/meta-buildpacks/nodejs-function/package.toml
@@ -2,13 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@sha256:4fa85f23b1df1138039ec6f5667da48da2af7858767b8840a754c54b39b42ca1"
+uri = "../../../buildpacks/nodejs"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha256:248ce84d07d2b9a11ca2433aee91bec48b2e029aac968e14f57711fe4270159a"
+uri = "../../../buildpacks/npm"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:accfc74412af9702c86d370f6289dc9674acc33023369e68f9687b6b4a1b63bd"
+uri = "../../../buildpacks/typescript"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/streaming-http-adapter-buildpack:1.4.0"

--- a/test/meta-buildpacks/nodejs-function/package.toml
+++ b/test/meta-buildpacks/nodejs-function/package.toml
@@ -2,7 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "../../../meta-buildpacks/nodejs"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@sha256:4fa85f23b1df1138039ec6f5667da48da2af7858767b8840a754c54b39b42ca1"
+
+[[dependencies]]
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha256:248ce84d07d2b9a11ca2433aee91bec48b2e029aac968e14f57711fe4270159a"
+
+[[dependencies]]
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:accfc74412af9702c86d370f6289dc9674acc33023369e68f9687b6b4a1b63bd"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/streaming-http-adapter-buildpack:1.4.0"


### PR DESCRIPTION
Ticket:

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000008mOuYAI/view

The "regular" nodejs metabuildpack is already tested under test/meta-buildpack/nodejs. This adds local files to ensure that the functions metabuildpack can be built without errors.