### PR TITLE
Update heroku/nodejs-function to use heroku/nodejs-function-invoker

### DIFF
--- a/meta-buildpacks/nodejs-function/CHANGELOG.md
+++ b/meta-buildpacks/nodejs-function/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0]
+## [Unreleased]
+### Changed
+* Switch from the Riff based invoker buildpacks to `heroku/nodejs-function` ([#48](https://github.com/heroku/buildpacks-node/pull/48))
 
+## [0.4.0]
+### Added
 * Initial port from heroku/pack-images

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-function"
-version = "0.4.1"
+version = "0.5.0"
 name = "Node.js Function"
 
 [[buildpack.licenses]]
@@ -24,16 +24,8 @@ version = "0.2.3"
 optional = true
 
 [[order.group]]
-id = "heroku/streaming-http-adapter-buildpack"
-version = "1.4.0"
-
-[[order.group]]
-id = "heroku/node-function-buildpack"
-version = "1.5.0"
-
-[[order.group]]
-id = "salesforce/nodejs-fn"
-version = "2.0.6"
+id = "heroku/nodejs-function-invoker"
+version = "0.1.0"
 
 [metadata]
 

--- a/meta-buildpacks/nodejs-function/package.toml
+++ b/meta-buildpacks/nodejs-function/package.toml
@@ -11,10 +11,4 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:accfc74412af9702c86d370f6289dc9674acc33023369e68f9687b6b4a1b63bd"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/streaming-http-adapter-buildpack:1.4.0"
-
-[[dependencies]]
-uri = "docker://docker.io/heroku/node-function-buildpack:1.5.0"
-
-[[dependencies]]
-uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.6/nodejs-sf-fx-buildpack-v2.0.6.tgz"
+uri = "docker://public.ecr.aws/heroku-buildpacks/nodejs-function-invoker@sha256:TODO"

--- a/meta-buildpacks/nodejs-function/package.toml
+++ b/meta-buildpacks/nodejs-function/package.toml
@@ -11,4 +11,4 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:accfc74412af9702c86d370f6289dc9674acc33023369e68f9687b6b4a1b63bd"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/nodejs-function-invoker@sha256:TODO"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-invoker-buildpack@sha256:2688bb9c6f1b27fd67de960aaba922b922576037d2cd9ee01fe07d737e9d84e7"

--- a/test/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/test/meta-buildpacks/nodejs-function/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-function"
-version = "0.4.0"
+version = "0.5.0"
 name = "Node.js Function"
 
 [[buildpack.licenses]]
@@ -24,16 +24,8 @@ version = "0.2.3"
 optional = true
 
 [[order.group]]
-id = "heroku/streaming-http-adapter-buildpack"
-version = "1.4.0"
-
-[[order.group]]
-id = "heroku/node-function-buildpack"
-version = "1.5.0"
-
-[[order.group]]
-id = "salesforce/nodejs-fn"
-version = "2.0.6"
+id = "heroku/nodejs-function-invoker"
+version = "0.1.0"
 
 [metadata]
 

--- a/test/meta-buildpacks/nodejs-function/package.toml
+++ b/test/meta-buildpacks/nodejs-function/package.toml
@@ -11,10 +11,4 @@ uri = "../../../buildpacks/npm"
 uri = "../../../buildpacks/typescript"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/streaming-http-adapter-buildpack:1.4.0"
-
-[[dependencies]]
-uri = "docker://docker.io/heroku/node-function-buildpack:1.5.0"
-
-[[dependencies]]
-uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.6/nodejs-sf-fx-buildpack-v2.0.6.tgz"
+uri = "../../../buildpacks/nodejs-function-invoker"


### PR DESCRIPTION
This updates the `heroku/nodejs-function` metabuildpack to replace the Riff-based buildpack dependencies with `heroku/nodejs-function-invoker`.

This change is separate from #47, since it depends on that PR being merged and the new buildpack published, so that we have the ECR image URL for use by the metabuildpack.

Closes GUS-W-9228226.