### PR TITLE
Fix nodejs-function dependency versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,5 +111,6 @@ workflows:
                 - "buildpacks/npm"
                 - "buildpacks/typescript"
                 - "meta-buildpacks/nodejs"
+                - "meta-buildpacks/nodejs-function"
                 - "test/meta-buildpacks/nodejs"
                 - "test/meta-buildpacks/nodejs-function"

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -12,15 +12,15 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.7.4"
+version = "0.7.3"
 
 [[order.group]]
 id = "heroku/nodejs-npm"
-version = "0.4.4"
+version = "0.4.3"
 
 [[order.group]]
 id = "heroku/nodejs-typescript"
-version = "0.2.3"
+version = "0.2.2"
 optional = true
 
 [[order.group]]

--- a/test/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/test/meta-buildpacks/nodejs-function/buildpack.toml
@@ -25,7 +25,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-function-invoker"
-version = "0.1.0"
+version = "0.1.1"
 
 [metadata]
 


### PR DESCRIPTION
Fixes for #48:

Those were using the versions of the next release, most likely copied from the test meta-buildpack. I also updated the CircleCI config to package this buildpack which would have prevented this issue.