### PR TITLE
check for presence of nodejs.toml before reading for clearing cache

### DIFF
--- a/buildpacks/nodejs/CHANGELOG.md
+++ b/buildpacks/nodejs/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Change node engine version from 12 to 14 ([#40](https://github.com/heroku/buildpacks-node/pull/40))
 - Clear cache when node version changes ([#40](https://github.com/heroku/buildpacks-node/pull/40))
+- Check for nodejs.toml before read ([#53](https://github.com/heroku/buildpacks-nodejs/pull/53))
 
 ## [0.7.3] 2021/03/04
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))

--- a/buildpacks/nodejs/CHANGELOG.md
+++ b/buildpacks/nodejs/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change node engine version from 12 to 14 ([#40](https://github.com/heroku/buildpacks-node/pull/40))
 - Clear cache when node version changes ([#40](https://github.com/heroku/buildpacks-node/pull/40))
 - Check for nodejs.toml before read ([#53](https://github.com/heroku/buildpacks-nodejs/pull/53))
+- Change default Node.js version to 16 ([#53](https://github.com/heroku/buildpacks-nodejs/pull/53))
 
 ## [0.7.3] 2021/03/04
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -76,15 +76,16 @@ store_node_version() {
 	local layer_dir=$1
 	local prev_node_version
 
-	if [[ -z "${layer_dir}.toml" ]]; then
+	if [[ -f "${layer_dir}.toml" ]]; then
 		# shellcheck disable=SC2002
 		prev_node_version=$(cat "${layer_dir}.toml" | grep version | xargs | cut -d " " -f3)
-		echo "read prev node version"
 		mkdir -p "${layer_dir}/env.build"
+
 		if [[ -s "${layer_dir}/env.build/PREV_NODE_VERSION.override" ]]; then
 			rm -rf "${layer_dir}/env.build/PREV_NODE_VERSION.override"
 		fi
 
+		info "Storing previous Node v${prev_node_version}"
 		echo -e "$prev_node_version\c" >"${layer_dir}/env.build/PREV_NODE_VERSION.override"
 	fi
 }

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -75,13 +75,18 @@ install_or_reuse_toolbox() {
 store_node_version() {
 	local layer_dir=$1
 	local prev_node_version
-	# shellcheck disable=SC2002
-	prev_node_version=$(cat "${layer_dir}.toml" | grep version | xargs | cut -d " " -f3)
-	mkdir -p "${layer_dir}/env.build"
-	if [[ -s "${layer_dir}/env.build/PREV_NODE_VERSION.override" ]]; then
-		rm -rf "${layer_dir}/env.build/PREV_NODE_VERSION.override"
+
+	if [[ -z "${layer_dir}.toml" ]]; then
+		# shellcheck disable=SC2002
+		prev_node_version=$(cat "${layer_dir}.toml" | grep version | xargs | cut -d " " -f3)
+		echo "read prev node version"
+		mkdir -p "${layer_dir}/env.build"
+		if [[ -s "${layer_dir}/env.build/PREV_NODE_VERSION.override" ]]; then
+			rm -rf "${layer_dir}/env.build/PREV_NODE_VERSION.override"
+		fi
+
+		echo -e "$prev_node_version\c" >"${layer_dir}/env.build/PREV_NODE_VERSION.override"
 	fi
-	echo -e "$prev_node_version\c" >>"${layer_dir}/env.build/PREV_NODE_VERSION.override"
 }
 
 install_or_reuse_node() {
@@ -110,9 +115,8 @@ install_or_reuse_node() {
 		mkdir -p "${layer_dir}"
 		rm -rf "${layer_dir:?}"/*
 
-		echo "cache = true" >"${layer_dir}.toml"
-
 		{
+			echo "cache = true"
 			echo "build = true"
 			echo "launch = true"
 			echo -e "[metadata]\nversion = \"$node_version\""

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -100,7 +100,7 @@ install_or_reuse_node() {
 	status "Installing Node"
 	info "Getting Node version"
 	engine_node=$(json_get_key "$build_dir/package.json" ".engines.node")
-	node_version=${engine_node:-14.x}
+	node_version=${engine_node:-16.x}
 
 	info "Resolving Node version"
 	resolved_data=$(resolve-version node "$node_version")


### PR DESCRIPTION
There's a bug where if the nodejs.toml doesn't exist, the build will fail, so this checks to see if there's a file before it reads the file. (Bug fix for the initial build)