### PR TITLE
Fix Node.js function runtime startup command

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - Run check for "main" key and file in package.json ([#52](https://github.com/heroku/buildpacks-nodejs/pull/52))
+- Support for newer versions of the function runtime
 
 ## [0.1.0] 2021/05/06
 ### Added

--- a/buildpacks/nodejs-function-invoker/lib/build.sh
+++ b/buildpacks/nodejs-function-invoker/lib/build.sh
@@ -53,6 +53,6 @@ write_launch_toml() {
 	cat >"${layers_dir}/launch.toml" <<-EOF
 		[[processes]]
 		type = "web"
-		command = "sf-fx-runtime-nodejs ${app_dir}"
+		command = "sf-fx-runtime-nodejs serve ${app_dir} -h 0.0.0.0 -p \${PORT:-8080}"
 	EOF
 }

--- a/buildpacks/nodejs-function-invoker/shpec/build_shpec.sh
+++ b/buildpacks/nodejs-function-invoker/shpec/build_shpec.sh
@@ -109,7 +109,7 @@ describe "lib/build.sh"
 			expected=$(cat <<-EOF
 					[[processes]]
 					type = "web"
-					command = "sf-fx-runtime-nodejs ${app_dir}"
+					command = "sf-fx-runtime-nodejs serve ${app_dir} -h 0.0.0.0 -p \${PORT:-8080}"
 				EOF
 			)
 			assert equal "${actual}" "${expected}"


### PR DESCRIPTION
Newer versions of the function runtime require a different startup command.