### PR TITLE
function-invoker: Clean up runtime download after install

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The function runtime download is now cleaned up after installation ([#57](https://github.com/heroku/buildpacks-nodejs/pull/57))
 
 ## [0.1.1] 2021/05/10
 ### Added

--- a/buildpacks/nodejs-function-invoker/lib/build.sh
+++ b/buildpacks/nodejs-function-invoker/lib/build.sh
@@ -28,20 +28,23 @@ install_runtime() {
 		cache = false
 	EOF
 
-	runtime_tarball_url=$(toml_get_key_from_metadata "${CNB_BUILDPACK_DIR}/buildpack.toml" "runtime.url")
+	runtime_package_url=$(toml_get_key_from_metadata "${CNB_BUILDPACK_DIR}/buildpack.toml" "runtime.url")
 
 	info "Starting download of function runtime"
 
-	if ! download_file "${runtime_tarball_url}" "${runtime_layer_dir}/sf-fx-runtime-nodejs.tar.gz"; then
+	local runtime_package
+	runtime_package=$(mktemp -t sf-fx-runtime-nodejs.XXXXX.tar.gz)
+	if ! download_file "${runtime_package_url}" "${runtime_package}"; then
 		# Ideally this would be a multi-line error message explaining that the cause is
 		# likely network issues and to retry, but error() doesn't support multi-line.
-		error "Unable to download the function runtime from ${runtime_tarball_url}"
+		error "Unable to download the function runtime from ${runtime_package_url}"
 		exit 1
 	fi
 
 	info "Download of function runtime successful"
 
-	npm install -g --prefix "${runtime_layer_dir}" "${runtime_layer_dir}/sf-fx-runtime-nodejs.tar.gz"
+	npm install -g --prefix "${runtime_layer_dir}" "${runtime_package}"
+	rm "${runtime_package}"
 
 	info "Function runtime installation successful"
 }


### PR DESCRIPTION
Previously the runtime package tarball was left behind in the runtime layer after the package was installed, so ended up in the built image.

Now the file is downloaded to a temporary directory instead of the layer, and cleaned up after the npm install.

The `local runtime_package` statement being on a separate line is required due to:
https://github.com/koalaman/shellcheck/wiki/SC2155#problematic-code-in-the-case-of-local

Closes GUS-W-9238585.