### PR TITLE
Add support for remote debugging via DEBUG_PORT

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Remote debugging is now enabled when the `DEBUG_PORT` environment variable is set ([#59](https://github.com/heroku/buildpacks-nodejs/pull/59))
+
 ### Changed
 - The `web` process is now marked as the default process type ([#60](https://github.com/heroku/buildpacks-nodejs/pull/60))
 - The function runtime download is now cleaned up after installation ([#57](https://github.com/heroku/buildpacks-nodejs/pull/57))

--- a/buildpacks/nodejs-function-invoker/bin/build
+++ b/buildpacks/nodejs-function-invoker/bin/build
@@ -11,4 +11,5 @@ source "${CNB_BUILDPACK_DIR}/lib/build.sh"
 run_initial_checks "$build_dir"
 
 install_runtime "${layers_dir}"
+install_scripts "${layers_dir}"
 write_launch_toml "${layers_dir}" "${build_dir}"

--- a/buildpacks/nodejs-function-invoker/lib/build.sh
+++ b/buildpacks/nodejs-function-invoker/lib/build.sh
@@ -49,6 +49,22 @@ install_runtime() {
 	info "Function runtime installation successful"
 }
 
+install_scripts() {
+	local layers_dir="${1:?}"
+	local opt_layer_dir="${layers_dir}/opt"
+	local opt_layer_toml="${layers_dir}/opt.toml"
+
+	mkdir -p "${opt_layer_dir}"
+	cat >"${opt_layer_toml}" <<-EOF
+		[types]
+		launch = true
+		build = false
+		cache = false
+	EOF
+
+	cp -a "${CNB_BUILDPACK_DIR}/opt/." "${opt_layer_dir}/"
+}
+
 write_launch_toml() {
 	local layers_dir="${1:?}"
 	local app_dir="${2:?}"
@@ -56,7 +72,7 @@ write_launch_toml() {
 	cat >"${layers_dir}/launch.toml" <<-EOF
 		[[processes]]
 		type = "web"
-		command = "sf-fx-runtime-nodejs serve ${app_dir} -h 0.0.0.0 -p \${PORT:-8080}"
+		command = "${layers_dir}/opt/run.sh ${app_dir}"
 		default = true
 	EOF
 }

--- a/buildpacks/nodejs-function-invoker/opt/run.sh
+++ b/buildpacks/nodejs-function-invoker/opt/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+app_dir="${1:?}"
+
+if [[ -n "${DEBUG_PORT:-}" ]]; then
+	# Adds a space separator only if NODE_OPTIONS was already set.
+	export NODE_OPTIONS="${NODE_OPTIONS}${NODE_OPTIONS:+ }--inspect=0.0.0.0:${DEBUG_PORT}"
+fi
+
+exec sf-fx-runtime-nodejs serve "${app_dir}" --host 0.0.0.0 --port "${PORT:-8080}"

--- a/buildpacks/nodejs-function-invoker/shpec/build_shpec.sh
+++ b/buildpacks/nodejs-function-invoker/shpec/build_shpec.sh
@@ -94,6 +94,30 @@ describe "lib/build.sh"
 		end
 	end
 
+	describe "install_scripts"
+		it "creates a runtime layer containing the runtime"
+			layers_dir=$(create_temp_layers_dir)
+
+			install_scripts "${layers_dir}"
+			result="${?}"
+
+			assert equal "${result}" 0
+
+			assert file_present "${layers_dir}/opt.toml"
+			actual_layer_manifest=$(cat "${layers_dir}/opt.toml")
+			expected_layer_manifest=$(cat <<-EOF
+					[types]
+					launch = true
+					build = false
+					cache = false
+				EOF
+			)
+			assert equal "${actual_layer_manifest}" "${expected_layer_manifest}"
+			assert file_present "${layers_dir}/opt/run.sh"
+			rm -rf "${layers_dir}"
+		end
+	end
+
 	describe "write_launch_toml"
 		it "configures sf-fx-runtime-nodejs as the web process"
 			layers_dir=$(create_temp_layers_dir)
@@ -109,7 +133,7 @@ describe "lib/build.sh"
 			expected=$(cat <<-EOF
 					[[processes]]
 					type = "web"
-					command = "sf-fx-runtime-nodejs serve ${app_dir} -h 0.0.0.0 -p \${PORT:-8080}"
+					command = "${layers_dir}/opt/run.sh ${app_dir}"
 					default = true
 				EOF
 			)


### PR DESCRIPTION
Now when the `DEBUG_PORT` env var is set, Node is started with debugger support enabled:
https://nodejs.org/en/docs/guides/debugging-getting-started/

This is based on the approach taken by the JVM invoker buildpack:
https://github.com/heroku/buildpacks-jvm/pull/85
https://github.com/heroku/buildpacks-jvm/pull/93

Closes GUS-W-9260143.