### PR TITLE
function-invoker: Mark the web process as default

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- The `web` process is now marked as the default process type ([#60](https://github.com/heroku/buildpacks-nodejs/pull/60))
 - The function runtime download is now cleaned up after installation ([#57](https://github.com/heroku/buildpacks-nodejs/pull/57))
 
 ## [0.1.1] 2021/05/10

--- a/buildpacks/nodejs-function-invoker/lib/build.sh
+++ b/buildpacks/nodejs-function-invoker/lib/build.sh
@@ -57,5 +57,6 @@ write_launch_toml() {
 		[[processes]]
 		type = "web"
 		command = "sf-fx-runtime-nodejs serve ${app_dir} -h 0.0.0.0 -p \${PORT:-8080}"
+		default = true
 	EOF
 }

--- a/buildpacks/nodejs-function-invoker/shpec/build_shpec.sh
+++ b/buildpacks/nodejs-function-invoker/shpec/build_shpec.sh
@@ -110,6 +110,7 @@ describe "lib/build.sh"
 					[[processes]]
 					type = "web"
 					command = "sf-fx-runtime-nodejs serve ${app_dir} -h 0.0.0.0 -p \${PORT:-8080}"
+					default = true
 				EOF
 			)
 			assert equal "${actual}" "${expected}"


### PR DESCRIPTION
Buildpack API 0.6 and above requires that buildpacks mark at least one process type as default, otherwise there will be no default process set:
https://github.com/buildpacks/spec/releases/tag/platform%2Fv0.6
https://github.com/buildpacks/rfcs/blob/main/text/0064-buildpacks-contribute-default-process-type.md

The Node.js invoker buildpack is using API 0.6 (compared to some of the other buildpacks that are using older API versions), so needs the default process declared explicitly, to prevent errors at runtime.

Closes GUS-W-9260453.