### PR TITLE
function-invoker: Fix unbound variable error when using DEBUG_PORT

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fixed `NODE_OPTIONS` unbound variable error when using `DEBUG_PORT` ([#63](https://github.com/heroku/buildpacks-nodejs/pull/63))
 
 ## [0.1.2] 2021/05/11
 ### Added

--- a/buildpacks/nodejs-function-invoker/opt/run.sh
+++ b/buildpacks/nodejs-function-invoker/opt/run.sh
@@ -6,7 +6,7 @@ app_dir="${1:?}"
 
 if [[ -n "${DEBUG_PORT:-}" ]]; then
 	# Adds a space separator only if NODE_OPTIONS was already set.
-	export NODE_OPTIONS="${NODE_OPTIONS}${NODE_OPTIONS:+ }--inspect=0.0.0.0:${DEBUG_PORT}"
+	export NODE_OPTIONS="${NODE_OPTIONS:-}${NODE_OPTIONS:+ }--inspect=0.0.0.0:${DEBUG_PORT}"
 fi
 
 exec sf-fx-runtime-nodejs serve "${app_dir}" --host 0.0.0.0 --port "${PORT:-8080}"


### PR DESCRIPTION
If `DEBUG_PORT` is defined, but `NODE_OPTIONS` was not already set, the functions invocation would fail with:

```
...
Running on port :8080
Debugger running on port :9229
/layers/heroku_nodejs-function-invoker/opt/run.sh: line 9: NODE_OPTIONS: unbound variable
```

I would add a test, however we only have unit tests, and it's very hard to test the `run.sh` wrapper given `sf-fx-runtime-nodejs` is not installed during the unit tests. Cutlass tests are likely the answer to this in the future.

Follow-up to #59.

Refs GUS-W-9260143.