### PR TITLE
install yj before detect script

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Detect for `type=function` in `project.toml` ([#58](https://github.com/heroku/buildpacks-nodejs/pull/58))
+- Install `yj` before `bin/detect` ([#66](https://github.com/heroku/buildpacks-nodejs/pull/66))
 
 ## [0.1.3] 2021/05/12
 ### Changed

--- a/buildpacks/nodejs-function-invoker/bin/detect
+++ b/buildpacks/nodejs-function-invoker/bin/detect
@@ -6,6 +6,7 @@ set -euo pipefail
 app_dir=$(pwd)
 build_plan="${2:?}"
 
+# shellcheck source=/dev/null
 source "${CNB_BUILDPACK_DIR}/utils/download.sh"
 source "${CNB_BUILDPACK_DIR}/lib/detect.sh"
 

--- a/buildpacks/nodejs-function-invoker/bin/detect
+++ b/buildpacks/nodejs-function-invoker/bin/detect
@@ -6,7 +6,11 @@ set -euo pipefail
 app_dir=$(pwd)
 build_plan="${2:?}"
 
+source "${CNB_BUILDPACK_DIR}/utils/download.sh"
 source "${CNB_BUILDPACK_DIR}/lib/detect.sh"
+
+install_yj "$CNB_BUILDPACK_DIR"
+export PATH=$CNB_BUILDPACK_DIR/bin:$PATH
 
 if detect_function_app "${app_dir}"; then
 	write_to_build_plan "${build_plan}"

--- a/buildpacks/nodejs-function-invoker/bin/detect
+++ b/buildpacks/nodejs-function-invoker/bin/detect
@@ -10,8 +10,8 @@ build_plan="${2:?}"
 source "${CNB_BUILDPACK_DIR}/utils/download.sh"
 source "${CNB_BUILDPACK_DIR}/lib/detect.sh"
 
-install_yj "$CNB_BUILDPACK_DIR"
-export PATH=$CNB_BUILDPACK_DIR/bin:$PATH
+download_yj "$CNB_BUILDPACK_DIR"
+export PATH=$CNB_BUILDPACK_DIR/downloads/bin:$PATH
 
 if detect_function_app "${app_dir}"; then
 	write_to_build_plan "${build_plan}"

--- a/buildpacks/nodejs-function-invoker/lib/utils/download.sh
+++ b/buildpacks/nodejs-function-invoker/lib/utils/download.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+install_yj() {
+	build_dir=$1
+
+	mkdir -p "${build_dir}/bin"
+
+	if [[ ! -f "${build_dir}/bin/yj" ]]; then
+		curl -Ls https://github.com/sclevine/yj/releases/download/v2.0/yj-linux >"${build_dir}/bin/yj" &&
+			chmod +x "${build_dir}/bin/yj"
+	fi
+}
+
 download_file() {
 	local -r url="${1:?}"
 	local -r target_path="${2:?}"

--- a/buildpacks/nodejs-function-invoker/lib/utils/download.sh
+++ b/buildpacks/nodejs-function-invoker/lib/utils/download.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-install_yj() {
-	build_dir=$1
+download_yj() {
+	bp_dir=$1
 
-	mkdir -p "${build_dir}/bin"
+	mkdir -p "${bp_dir}/downloads/bin"
 
-	if [[ ! -f "${build_dir}/bin/yj" ]]; then
-		curl -Ls https://github.com/sclevine/yj/releases/download/v2.0/yj-linux >"${build_dir}/bin/yj" &&
-			chmod +x "${build_dir}/bin/yj"
+	if [[ ! -f "${bp_dir}/downloads/bin/yj" ]]; then
+		curl -Ls https://github.com/sclevine/yj/releases/download/v2.0/yj-linux >"${bp_dir}/downloads/bin/yj" &&
+			chmod +x "${bp_dir}/downloads/bin/yj"
 	fi
 }
 


### PR DESCRIPTION
Installs yj before the detect script runs, so that the correct files can be parsed in the function invoker buildpack.