### PR TITLE
Reference correct path with importing download.sh

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use correct path for referencing `lib/utils/download.sh` ([#70](https://github.com/heroku/buildpacks-nodejs/pull/70))
 
 ## [0.1.4] 2021/05/18
 ### Changed

--- a/buildpacks/nodejs-function-invoker/bin/detect
+++ b/buildpacks/nodejs-function-invoker/bin/detect
@@ -7,14 +7,15 @@ app_dir=$(pwd)
 build_plan="${2:?}"
 
 # shellcheck source=/dev/null
-source "${CNB_BUILDPACK_DIR}/utils/download.sh"
+source "${CNB_BUILDPACK_DIR}/lib/utils/download.sh"
 source "${CNB_BUILDPACK_DIR}/lib/detect.sh"
 
-download_yj "$CNB_BUILDPACK_DIR"
-export PATH=$CNB_BUILDPACK_DIR/downloads/bin:$PATH
+download_yj "$app_dir"
+export PATH=$app_dir/.salesforce_functions/downloads/bin:$PATH
 
 if detect_function_app "${app_dir}"; then
 	write_to_build_plan "${build_plan}"
+	rm -rf "$app_dir/.salesforce_functions"
 	exit 0
 fi
 

--- a/buildpacks/nodejs-function-invoker/lib/utils/download.sh
+++ b/buildpacks/nodejs-function-invoker/lib/utils/download.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 download_yj() {
-	bp_dir=$1
+	app_dir="$1"
 
-	mkdir -p "${bp_dir}/downloads/bin"
+	mkdir -p "${app_dir}/.salesforce_functions/downloads/bin"
 
-	if [[ ! -f "${bp_dir}/downloads/bin/yj" ]]; then
-		curl -Ls https://github.com/sclevine/yj/releases/download/v2.0/yj-linux >"${bp_dir}/downloads/bin/yj" &&
-			chmod +x "${bp_dir}/downloads/bin/yj"
+	if [[ ! -f "${app_dir}/.salesforce_functions/downloads/bin/yj" ]]; then
+		curl -Ls https://github.com/sclevine/yj/releases/download/v2.0/yj-linux >"${app_dir}/.salesforce_functions/downloads/bin/yj" &&
+			chmod +x "${app_dir}/.salesforce_functions/downloads/bin/yj"
 	fi
 }
 


### PR DESCRIPTION
The path name was incorrect, so adding this to update and we should add a ticket for testing bin scripts in CI!

Testing this build locally to make sure the functions build passes.