### PR TITLE
Test node function interface via Cutlass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   pack: buildpacks/pack@0.2.2
+  ruby: circleci/ruby@1.1.2
   heroku-buildpacks:
     commands:
       install-yq:
@@ -49,6 +50,23 @@ jobs:
 
               pack buildpack package test --config "${package_toml}" && break
             done
+
+  cutlass-integration-test:
+    parameters:
+      test-dir:
+        type: string
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - checkout
+      - pack/install-pack:
+          version: 0.16.0
+      - ruby/install-deps
+      - heroku-buildpacks/install-build-dependencies
+      - run:
+          name: "Run rspec tests against a given directory"
+          command: |
+            PARALLEL_SPLIT_TEST_PROCESSES=4 bundle exec parallel_split_test << parameters.test-dir >>
 
   shell-linting:
     docker:
@@ -114,3 +132,9 @@ workflows:
                 - "meta-buildpacks/nodejs-function"
                 - "test/meta-buildpacks/nodejs"
                 - "test/meta-buildpacks/nodejs-function"
+
+      - cutlass-integration-test:
+          matrix:
+            parameters:
+              test-dir:
+                - "test/specs/node-function"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 **/target/
+
+.DS_Store

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require dead_end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem 'rspec-retry'
+gem 'rspec-expectations'
+gem 'java-properties'
+gem 'dead_end'
+gem 'cutlass'
+gem 'parallel_split_test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,41 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cutlass (0.2.1)
+      docker-api (>= 2.0)
+    dead_end (1.1.7)
+    diff-lcs (1.4.4)
+    docker-api (2.1.0)
+      excon (>= 0.47.0)
+      multi_json
+    excon (0.81.0)
+    java-properties (0.3.0)
+    multi_json (1.15.0)
+    parallel (1.20.1)
+    parallel_split_test (0.9.1)
+      parallel (>= 0.5.13)
+      rspec-core (>= 3.9.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+    rspec-support (3.10.2)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-19
+  x86_64-linux
+
+DEPENDENCIES
+  cutlass
+  dead_end
+  java-properties
+  parallel_split_test
+  rspec-expectations
+  rspec-retry
+
+BUNDLED WITH
+   2.2.16

--- a/test/fixtures/simple-function/.eslintrc
+++ b/test/fixtures/simple-function/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "es6": true
+  },
+  "rules": {
+  }
+}

--- a/test/fixtures/simple-function/.mocharc.json
+++ b/test/fixtures/simple-function/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "test": "./**/*.test.js",
+  "recursive": true
+}

--- a/test/fixtures/simple-function/index.js
+++ b/test/fixtures/simple-function/index.js
@@ -1,0 +1,3 @@
+ module.exports = async function (event, context, logger) {
+    return "Hello World".toLowerCase();
+}

--- a/test/fixtures/simple-function/package.json
+++ b/test/fixtures/simple-function/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "myfn-function",
+  "version": "0.0.1",
+  "author": "TODO",
+  "description": "TODO",
+  "license": "UNLICENSED",
+  "main": "index.js",
+  "repository": {
+    "type": "git"
+  },
+  "engines": {
+    "node": "^14.0"
+  },
+  "scripts": {
+    "lint": "eslint . --ext .js --config .eslintrc",
+    "test": "mocha"
+  },
+  "devDependencies": {
+    "chai": "^4.3.4",
+    "eslint": "^6.8.0",
+    "mocha": "^8.4.0",
+    "sinon": "^10.0.0"
+  }
+}

--- a/test/fixtures/simple-function/project.toml
+++ b/test/fixtures/simple-function/project.toml
@@ -1,0 +1,8 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.1"
+id = "myfn"
+description = "A Function"
+type = "function"

--- a/test/specs/node-function/cutlass/function_spec.rb
+++ b/test/specs/node-function/cutlass/function_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+describe "Heroku's Nodejs CNB" do
+  it "generates a callable salesforce function" do
+    Cutlass::App.new("simple-function").transaction do |app|
+      app.pack_build do |pack_result|
+        expect(pack_result.stdout).to include("Installing Node.js function runtime")
+      end
+
+      app.start_container(expose_ports: 8080) do |container|
+        body = { }
+        query = Cutlass::FunctionQuery.new(
+          port: container.get_host_port(8080),
+          body: body
+        ).call
+
+        expect(query.as_json).to eq("hello world")
+        expect(query.success?).to be_truthy
+      end
+    end
+  end
+end

--- a/test/specs/node-function/spec_helper.rb
+++ b/test/specs/node-function/spec_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rspec/core"
+require "rspec/retry"
+
+require "cutlass"
+
+def test_dir
+  Pathname(__dir__).join("../..")
+end
+
+NODEJS_FUNCTION_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("meta-buildpacks/nodejs-function"))
+Cutlass.config do |config|
+  config.default_buildpack_paths = [NODEJS_FUNCTION_BUILDPACK]
+  config.default_builder = "heroku/buildpacks:18"
+  config.default_repo_dirs = [test_dir.join("fixtures")]
+end
+
+RSpec.configure do |config|
+  # config.filter_run :focus => true
+
+  config.before(:suite) do
+    Cutlass::CleanTestEnv.record
+  end
+
+  config.after(:suite) do
+    NODEJS_FUNCTION_BUILDPACK.teardown
+    Cutlass::CleanTestEnv.check
+  end
+end
+


### PR DESCRIPTION
- Adds the cutlass library github.com/heroku/cutlass for automating scripting of building buildpacks via pack in tests. 
- Sets up rspec and related helper libraries to  allow writing tests in Ruby
- Adds a "simple" node app that contains a function, it returns a string of "hello world"
- Adds a test in rspec that uses cutlass to first build the node function buildpack, then it builds the "simple" node app using the node function buildpack and makes assertions on the output. Once the build is complete, the app is booted via docker and a function request completes successfully.
