### PR TITLE
Allow app to change Node Versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,3 +140,4 @@ workflows:
             parameters:
               test-dir:
                 - "test/specs/node-function"
+                - "test/specs/node"

--- a/buildpacks/nodejs/CHANGELOG.md
+++ b/buildpacks/nodejs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clear cache when node version changes ([#40](https://github.com/heroku/buildpacks-node/pull/40))
 - Check for nodejs.toml before read ([#53](https://github.com/heroku/buildpacks-nodejs/pull/53))
 - Change default Node.js version to 16 ([#53](https://github.com/heroku/buildpacks-nodejs/pull/53))
+- Fix bug that causes an error on Node version change ([#77](https://github.com/heroku/buildpacks-nodejs/pull/77))
 
 ## [0.7.3] 2021/03/04
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -121,7 +121,7 @@ install_or_reuse_node() {
 			echo "build = true"
 			echo "launch = true"
 			echo -e "[metadata]\nversion = \"$node_version\""
-		} >>"${layer_dir}.toml"
+		} >"${layer_dir}.toml"
 
 		curl -sL "$node_url" | tar xz --strip-components=1 -C "$layer_dir"
 	fi

--- a/test/specs/node/cutlass/basic_spec.rb
+++ b/test/specs/node/cutlass/basic_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+
+describe "Heroku's Nodejs CNB" do
+  it "handles a downgrade of node engine" do
+    Cutlass::App.new("simple-function").transaction do |app|
+      set_node_version_in_dir(app.tmpdir, version: "^14.0")
+
+      app.pack_build do |pack_result|
+        expect(pack_result.stdout).to include("Installing Node")
+        expect(pack_result.stdout).to include("Downloading and extracting Node v14.")
+      end
+
+      set_node_version_in_dir(app.tmpdir, version: "^16.0")
+
+      app.pack_build do |pack_result|
+        expect(pack_result.stdout).to include("Installing Node")
+        expect(pack_result.stdout).to include("Downloading and extracting Node v16.")
+      end
+    end
+  end
+end

--- a/test/specs/node/spec_helper.rb
+++ b/test/specs/node/spec_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rspec/core"
+require "rspec/retry"
+
+require "cutlass"
+
+def test_dir
+  Pathname(__dir__).join("../..")
+end
+
+NODEJS_FUNCTION_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("meta-buildpacks/nodejs"))
+Cutlass.config do |config|
+  config.default_buildpack_paths = [NODEJS_FUNCTION_BUILDPACK]
+  config.default_builder = "heroku/buildpacks:18"
+  config.default_repo_dirs = [test_dir.join("fixtures")]
+end
+
+RSpec.configure do |config|
+  # config.filter_run :focus => true
+
+  config.before(:suite) do
+    Cutlass::CleanTestEnv.record
+  end
+
+  config.after(:suite) do
+    NODEJS_FUNCTION_BUILDPACK.teardown
+    Cutlass::CleanTestEnv.check
+  end
+end
+
+def set_node_version_in_dir(dir, version: )
+  package_json = Pathname(dir).join("package.json")
+  package_json_hash = JSON.parse(package_json.read)
+  package_json_hash["engines"]["node"] = version
+  package_json.write(package_json_hash.to_json)
+end


### PR DESCRIPTION
It was noted that if an app tries to deploy using Node 16 and then tries to deploy the same app using Node 14 it fails. It turns out it will fail for any node version change and not just a downgrade in version.

```
ERROR: failed to build: Near line 10 (last key parsed ''): Key 'metadata' has already been defined.
```

The reason for this error is that the nodejs.toml file contains metadata key twice which makes it invalid tool and pack cannot process it. Here's what the contents:

```
build = true
launch = true
cache = true

[metadata]
 version = "16.3.0"
cache = true
build = true
launch = true
[metadata]
version = "14.17.0"
```

The fix is to write over the toml file instead of appending to it. I'm worried though there may be other places with a similar bug such as installing yarn. 

There are Shpec tests and we would in theory be able to unit test this specific function to make sure this bug doesn't happen. The existing shpec tests take awhile to run though and it doesn't look like there a way to "focus" them. 

I think it's a good idea to have at least some basic integration tests with cutlass on the node function buildpack, so I think this is still worthwhile, but we might want to consider adding a unit test for this, and using unit tests for similar issues. Also it might be worth while to split up unit tests for more focused  (faster) executions.