### PR TITLE
Add missing changelog entries for npm/yarn/typescript buildpacks

### DIFF
--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Clear cache when node version changes ([#40](https://github.com/heroku/buildpacks-node/pull/40))
 
 ## [0.4.3] 2021/03/04
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))

--- a/buildpacks/typescript/CHANGELOG.md
+++ b/buildpacks/typescript/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Clear cache when node version changes ([#40](https://github.com/heroku/buildpacks-node/pull/40))
 
 ## [0.2.2] 2021/03/04
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))

--- a/buildpacks/yarn/CHANGELOG.md
+++ b/buildpacks/yarn/CHANGELOG.md
@@ -2,7 +2,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
+## [Unreleased]
+### Fixed
+- Clear cache when node version changes ([#40](https://github.com/heroku/buildpacks-node/pull/40))
 
 ## [0.1.3] 2021/03/04
 - Add license to buildpack.toml ([#17](https://github.com/heroku/buildpacks-node/pull/17))


### PR DESCRIPTION
In #40 a change was made to multiple buildpacks, however a changelog entry was only added for `heroku/nodejs-engine`.

This adds the remaining changelog entries.

It also switches back to the keepachangelog.com format (eg using "Fixed" headings etc).

Closes GUS-W-9469704.