### PR TITLE
yarn: Make Cutlass test use the test metabuildpack

### DIFF
--- a/test/specs/node/cutlass/basic_spec.rb
+++ b/test/specs/node/cutlass/basic_spec.rb
@@ -26,7 +26,7 @@ describe "Heroku's Nodejs CNB" do
     # The Yarn buildpack currently doesn't write to the build plan, so has to be used alongside
     # the NPM buildpack rather than instead of it, which means we have to specify a custom
     # buildpacks list. See W-9482533.
-    buildpacks = [test_dir.join("../meta-buildpacks/nodejs"), test_dir.join("../buildpacks/yarn")]
+    buildpacks = [test_dir.join("meta-buildpacks/nodejs"), test_dir.join("../buildpacks/yarn")]
     Cutlass::App.new("yarn-project", buildpacks: buildpacks).transaction do |app|
       app.pack_build do |pack_result|
         expect(pack_result.stdout).to include("Installing Node")


### PR DESCRIPTION
Since currently it's using the standard (non-test) metabuildpack, which causes failures when the versions are bumped in #87.

I was not able to use the `:default` alias (to avoid specifying the default test metabuildpack again directly),  since the current `spec_helper.rb` `Cutlass::LocalBuildpack` teardown doesn't work correctly with multiple tests using the default buildpack.

Follow-up to #86.

[skip changelog]

Refs GUS-W-9481665.