### PR TITLE
Tests: Run Cutlass tests with the Heroku-20 based builder image

### DIFF
--- a/test/specs/node-function/spec_helper.rb
+++ b/test/specs/node-function/spec_helper.rb
@@ -12,7 +12,7 @@ end
 NODEJS_FUNCTION_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("meta-buildpacks/nodejs-function"))
 Cutlass.config do |config|
   config.default_buildpack_paths = [NODEJS_FUNCTION_BUILDPACK]
-  config.default_builder = "heroku/buildpacks:18"
+  config.default_builder = "heroku/buildpacks:20"
   config.default_repo_dirs = [test_dir.join("fixtures")]
 end
 

--- a/test/specs/node/spec_helper.rb
+++ b/test/specs/node/spec_helper.rb
@@ -9,10 +9,10 @@ def test_dir
   Pathname(__dir__).join("../..")
 end
 
-NODEJS_FUNCTION_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("meta-buildpacks/nodejs"))
+NODEJS_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("meta-buildpacks/nodejs"))
 Cutlass.config do |config|
-  config.default_buildpack_paths = [NODEJS_FUNCTION_BUILDPACK]
-  config.default_builder = "heroku/buildpacks:18"
+  config.default_buildpack_paths = [NODEJS_BUILDPACK]
+  config.default_builder = "heroku/buildpacks:20"
   config.default_repo_dirs = [test_dir.join("fixtures")]
 end
 
@@ -24,7 +24,7 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
-    NODEJS_FUNCTION_BUILDPACK.teardown
+    NODEJS_BUILDPACK.teardown
     Cutlass::CleanTestEnv.check
   end
 end


### PR DESCRIPTION
Previously the Node Cutlass tests were using the Heroku-18 based builder image instead, which is not the default on the platform.

In addition, I've fixed a variable name in `spec_helper.rb` for the non-functions test. This was presumably a copy-paste error when creating the tests.

Closes GUS-W-9483311.