### PR TITLE
yarn buildpack dependency fix

### DIFF
--- a/buildpacks/yarn/bin/detect
+++ b/buildpacks/yarn/bin/detect
@@ -7,10 +7,13 @@ bp_dir=$(
 	pwd
 )
 build_dir=$(pwd)
+build_plan="$2"
 
 # shellcheck source=/dev/null
 source "$bp_dir/lib/detect.sh"
 
 if ! detect_yarn_lock "$build_dir"; then
 	exit 100
+else
+	write_to_build_plan "$build_plan"
 fi

--- a/buildpacks/yarn/lib/detect.sh
+++ b/buildpacks/yarn/lib/detect.sh
@@ -4,3 +4,17 @@ detect_yarn_lock() {
 	local build_dir=$1
 	[[ -f "$build_dir/yarn.lock" ]]
 }
+
+write_to_build_plan() {
+	local build_plan=$1
+	cat <<EOF >"$build_plan"
+	[[provides]]
+	name = "node_modules"
+
+	[[requires]]
+	name = "node_modules"
+
+	[[requires]]
+	name = "node"
+EOF
+}


### PR DESCRIPTION
There is an apparent dependency issue with yarn buildpack

On a simple repo with yarn.lock, it fails and yarn.lock is ignored. This leads to another buildpack group (with npm) to take over the build.
Result is that whether or not yarn.lock is present, application is always built using npm.

Some pack output demonstrating the issue:

```
✦ ❯❯❯ pack build -v small-yarn -b heroku/nodejs-engine -b heroku/nodejs-yarn
Builder cr.nrtn.dev/heroku/buildpacks:b8c5d04e is trusted
Pulling image cr.nrtn.dev/heroku/buildpacks:b8c5d04e
b8c5d04e: Pulling from heroku/buildpacks
Digest: sha256:79b3131b2f67bce8030fe1824574e4d37d24a7da365233681b65fbc904f2baf4
Status: Image is up to date for cr.nrtn.dev/heroku/buildpacks:b8c5d04e
Selected run image cr.nrtn.dev/infra/pack:20
Pulling image cr.nrtn.dev/infra/pack:20
20: Pulling from infra/pack
Digest: sha256:f774b9e6c779c6e7e168ae5b01eb8f78f393dcc8d02ba88eb22e2e5697f31a5e
Status: Image is up to date for cr.nrtn.dev/infra/pack:20
Setting custom order
Creating builder with the following buildpacks:
-> heroku/procfile@0.6.2
-> heroku/go@0.3.1
-> heroku/nodejs@0.3.5
-> heroku/nodejs-engine@0.7.4
-> heroku/nodejs-npm@0.4.4
-> heroku/nodejs-typescript@0.2.3
-> heroku/nodejs-yarn@0.1.4
-> heroku/procfile@0.6.2
-> heroku/nodejs-function@0.5.7
-> heroku/nodejs-npm@0.4.4
-> heroku/nodejs-typescript@0.2.3
-> heroku/nodejs-engine@0.7.4
-> heroku/nodejs-function-invoker@0.1.6
-> noroutine/static@0.0.3
Using build cache volume pack-cache-library_small-yarn_latest-7623b5239096.build
Running the creator on OS linux with:
Container Settings:
  Args: /cnb/lifecycle/creator -daemon -launch-cache /launch-cache -log-level debug -cache-dir /cache -run-image cr.nrtn.dev/infra/pack:20 -process-type web small-yarn
  System Envs: CNB_PLATFORM_API=0.4
  Image: pack.local/builder/6e617364706f77646c74:latest
  User: root
  Labels: map[author:pack]
Host Settings:
  Binds: pack-cache-library_small-yarn_latest-7623b5239096.build:/cache /var/run/docker.sock:/var/run/docker.sock pack-cache-library_small-yarn_latest-7623b5239096.launch:/launch-cache pack-layers-fmxwuijyaj:/layers pack-app-qbkxereudo:/workspace
  Network Mode:
===> DETECTING
======== Results ========
pass: heroku/nodejs-engine@0.7.4
pass: heroku/nodejs-yarn@0.1.4
Resolving plan... (try #1)
fail: heroku/nodejs-engine@0.7.4 provides unused node
ERROR: No buildpack groups passed detection.
ERROR: Please check that you are running against the correct path.
ERROR: failed to detect: no buildpacks participating
ERROR: failed to build: executing lifecycle: failed with status code: 100
```

Without specific buildpacks and using full set, the group with npm takes over after this issue.

This pull request adds plan dependency on node similar to npm buildpack, that allows yarn to succeed in detection

