### PR TITLE
Add cutlass tests for TypeScript support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: "Run rspec tests against a given directory"
           command: |
-            PARALLEL_SPLIT_TEST_PROCESSES=4 bundle exec parallel_split_test << parameters.test-dir >>
+            bundle exec rspec << parameters.test-dir >>
 
   shell-linting:
     docker:

--- a/test/fixtures/simple-typescript-function/.eslintrc
+++ b/test/fixtures/simple-typescript-function/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "es6": true
+  },
+  "rules": {
+  }
+}

--- a/test/fixtures/simple-typescript-function/.mocharc.json
+++ b/test/fixtures/simple-typescript-function/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "test": "./**/*.test.js",
+  "recursive": true
+}

--- a/test/fixtures/simple-typescript-function/index.ts
+++ b/test/fixtures/simple-typescript-function/index.ts
@@ -1,0 +1,11 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+async function execute(event, context, logger) {
+  logger.info(
+    `Invoking Myfnts with payload ${JSON.stringify(event.data || {})}`
+  );
+
+  return "Hello World from typescript".toLowerCase();
+}
+exports.default = execute;

--- a/test/fixtures/simple-typescript-function/package.json
+++ b/test/fixtures/simple-typescript-function/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "myfn-function",
+  "version": "0.0.1",
+  "author": "TODO",
+  "description": "TODO",
+  "license": "UNLICENSED",
+  "main": "index.ts",
+  "repository": {
+    "type": "git"
+  },
+  "engines": {
+    "node": "^14.0"
+  },
+  "scripts": {
+    "lint": "eslint . --ext .js --config .eslintrc",
+    "test": "mocha"
+  },
+  "devDependencies": {
+    "chai": "^4.3.4",
+    "eslint": "^6.8.0",
+    "mocha": "^8.4.0",
+    "sinon": "^10.0.0"
+  }
+}

--- a/test/fixtures/simple-typescript-function/project.toml
+++ b/test/fixtures/simple-typescript-function/project.toml
@@ -1,0 +1,8 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.1"
+id = "myfn"
+description = "A Function"
+type = "function"

--- a/test/fixtures/simple-typescript-function/tsconfig.json
+++ b/test/fixtures/simple-typescript-function/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "strict": true,
+    "target": "ES2019",
+
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "removeComments": true,
+  },
+  "include": [
+    "./index.ts"
+  ]
+}

--- a/test/specs/node-function/cutlass/function_spec.rb
+++ b/test/specs/node-function/cutlass/function_spec.rb
@@ -21,4 +21,23 @@ describe "Heroku's Nodejs CNB" do
       end
     end
   end
+
+  it "generates a callable salesforce function from typescript" do
+    Cutlass::App.new("simple-typescript-function").transaction do |app|
+      app.pack_build do |pack_result|
+        expect(pack_result.stdout).to include("Installing Node.js function runtime")
+      end
+
+      app.start_container(expose_ports: 8080) do |container|
+        body = { }
+        query = Cutlass::FunctionQuery.new(
+          port: container.get_host_port(8080),
+          body: body
+        ).call
+
+        expect(query.as_json).to eq("hello world from typescript")
+        expect(query.success?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION

Work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000OAyJYAW/view

This PR introduces a test app `simple-typescript-function` that contains necessary files to activate the typescript support of this project https://github.com/heroku/buildpacks-nodejs/blob/53ac19086d0959c50e3d97128d62760816e753f4/buildpacks/typescript/lib/detect.sh. 

The ultimate purpose of exercising this code is to verify that types are correctly imported (https://github.com/forcedotcom/sf-fx-sdk-nodejs/pull/79) and can be used by a customer's function.

I'm also updating the tests to not run in parallel due to a race condition in tearing down the "local buildpack". More info: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000Roc2YAC/view