### PR TITLE
Bump sf-fx-runtime-nodejs to 0.1.2-ea and Typescript function integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: "Run rspec tests against a given directory"
           command: |
-            PARALLEL_SPLIT_TEST_PROCESSES=4 bundle exec parallel_split_test << parameters.test-dir >>
+            bundle exec rspec << parameters.test-dir >>
 
   shell-linting:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .idea
+dist/
+node_modules/
+package-lock.json
+
 **/target/
 
 .DS_Store

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump sf-fx-runtime-nodejs to 0.1.2-ea
+
 ## [0.1.6] 2021/06/21
 ### Changed
 - Bump sf-fx-runtime-nodejs to 0.1.1.-ea

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -23,7 +23,7 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://sf-fx-nodejs-internal-early-access.s3.us-east-2.amazonaws.com/sf-fx-runtime-nodejs-0.1.1-ea.tgz"
+url = "https://sf-fx-nodejs-internal-early-access.s3.us-east-2.amazonaws.com/sf-fx-runtime-nodejs-0.1.2-ea.tgz"
 
 [metadata.release]
 

--- a/test/fixtures/simple-typescript-function/.eslintrc
+++ b/test/fixtures/simple-typescript-function/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "es6": true
+  },
+  "rules": {
+  }
+}

--- a/test/fixtures/simple-typescript-function/.mocharc.json
+++ b/test/fixtures/simple-typescript-function/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "test": "./**/*.test.js",
+  "recursive": true
+}

--- a/test/fixtures/simple-typescript-function/index.ts
+++ b/test/fixtures/simple-typescript-function/index.ts
@@ -1,0 +1,19 @@
+import { InvocationEvent, Context, Logger, RecordQueryResult } from "sf-fx-sdk-nodejs";
+
+/**
+ * Describe {{fnNameCased}} here.
+ *
+ * The exported method is the entry point for your code when the function is invoked.
+ *
+ * Following parameters are pre-configured and provided to your function on execution:
+ * @param event: representative of the data associated with the occurrence of an event,
+ * and supporting metadata about the source of that occurrence.
+ * @param context: represents the connection to the the execution environment and the Customer 360 instance that
+ * the function is associated with.
+ * @param logger: represents the logging functionality to log given messages at various levels
+ */
+
+ export default async function execute(event: InvocationEvent<any>, context: Context, logger: Logger): Promise<string> {
+  return "Hello World from typescript".toLowerCase();
+}
+

--- a/test/fixtures/simple-typescript-function/package.json
+++ b/test/fixtures/simple-typescript-function/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "myfn-function",
+  "version": "0.0.1",
+  "author": "TODO",
+  "description": "TODO",
+  "license": "UNLICENSED",
+  "main": "dist/index.js",
+  "repository": {
+    "type": "git"
+  },
+  "engines": {
+    "node": "^14.0"
+  },
+  "scripts": {
+    "build": "npx tsc",
+    "lint": "eslint . --ext .js --config .eslintrc",
+    "test": "mocha"
+  },
+  "devDependencies": {
+    "chai": "^4.3.4",
+    "eslint": "^6.8.0",
+    "mocha": "^8.4.0",
+    "sf-fx-sdk-nodejs": "^2.1.1",
+    "sinon": "^10.0.0"
+  },
+  "dependencies": {
+    "typescript": "^4.3.5"
+  }
+}

--- a/test/fixtures/simple-typescript-function/project.toml
+++ b/test/fixtures/simple-typescript-function/project.toml
@@ -1,0 +1,8 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.1"
+id = "myfn"
+description = "A Function"
+type = "function"

--- a/test/fixtures/simple-typescript-function/tsconfig.json
+++ b/test/fixtures/simple-typescript-function/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "target": "ES2019",
+
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "removeComments": true,
+  },
+  "include": [
+    "./index.ts"
+  ]
+}

--- a/test/specs/node-function/cutlass/function_spec.rb
+++ b/test/specs/node-function/cutlass/function_spec.rb
@@ -21,4 +21,23 @@ describe "Heroku's Nodejs CNB" do
       end
     end
   end
+
+  it "generates a callable salesforce function from typescript" do
+    Cutlass::App.new("simple-typescript-function").transaction do |app|
+      app.pack_build do |pack_result|
+        expect(pack_result.stdout).to include("Installing Node.js function runtime")
+      end
+
+      app.start_container(expose_ports: 8080) do |container|
+        body = { }
+        query = Cutlass::FunctionQuery.new(
+          port: container.get_host_port(8080),
+          body: body
+        ).call
+
+        expect(query.as_json).to eq("hello world from typescript")
+        expect(query.success?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
Version 0.1.2-ea of sf-fx-runtime-nodejs fom: https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/61 is needed to fix a problem where types were not properly exported for typescript support. This enables cutlass integration tests to run:

- Release sf-fx-runtime-nodejs work item W-9590917 https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000Qz69YAC/view
- Cutlass test for typescript work item W-9424162: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000OAyJYAW/view

This PR introduces a test app `simple-typescript-function` that contains necessary files to activate the typescript support of this project https://github.com/heroku/buildpacks-nodejs/blob/53ac19086d0959c50e3d97128d62760816e753f4/buildpacks/typescript/lib/detect.sh.

The ultimate purpose of exercising this code is to verify that types are correctly imported (https://github.com/forcedotcom/sf-fx-sdk-nodejs/pull/79) and can be used by a customer's function.

I'm also updating the tests to not run in parallel due to a race condition in tearing down the "local buildpack".