### PR TITLE
Make publishing script fail if duplicate buildpack IDs found

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -1,45 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
+shopt -s globstar
 
 # This script is an integral part of the release workflow: .github/workflows/release.yml
 # It requires the following environment variables to function correctly:
 #
 # REQUESTED_BUILDPACK_ID - The ID of the buildpack to package and push to the container registry.
 
-while IFS="" read -r -d "" buildpack_toml_path; do
-	buildpack_id="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.id)"
-	buildpack_version="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.version)"
-	buildpack_docker_repository="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"
-	buildpack_path=$(dirname "${buildpack_toml_path}")
-	buildpack_build_path="${buildpack_path}"
+function find_buildpack_toml_path() {
+	local requested_buildpack_id="${1}"
+	local buildpack_id
+	local matching_buildpack_toml_paths=()
 
-	if [[ $buildpack_id == "${REQUESTED_BUILDPACK_ID}" ]]; then
-		# Some buildpacks require a build step before packaging. If we detect a build.sh script, we execute it and
-		# modify some variables to point to the directory with the built buildpack instead.
-		if [[ -f "${buildpack_path}/build.sh" ]]; then
-			echo "Buildpack has build script, executing..."
-			"${buildpack_path}/build.sh"
-			echo "Build finished!"
-
-			buildpack_path="${buildpack_path}/target"
-			buildpack_toml_path="${buildpack_path}/buildpack.toml"
+	for buildpack_toml_path in **/buildpack.toml; do
+		buildpack_id="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.id)"
+		if [[ "${buildpack_id}" == "${requested_buildpack_id}" ]]; then
+			matching_buildpack_toml_paths+=("${buildpack_toml_path}")
 		fi
+	done
 
-		image_name="${buildpack_docker_repository}:${buildpack_version}"
-		pack buildpack package --config "${buildpack_build_path}/package.toml" --publish "${image_name}"
-
-		# We might have local changes after building and/or shimming the buildpack. To ensure scripts down the pipeline
-		# work with a clean state, we reset all local changes here.
-		git reset --hard
-		git clean -fdx
-
-		echo "::set-output name=id::${buildpack_id}"
-		echo "::set-output name=version::${buildpack_version}"
-		echo "::set-output name=path::${buildpack_path}"
-		echo "::set-output name=address::${buildpack_docker_repository}@$(crane digest "${image_name}")"
-		exit 0
+	num_paths=${#matching_buildpack_toml_paths[@]}
+	if [[ num_paths -eq 0 ]]; then
+		echo "Could not find requested buildpack with ID ${requested_buildpack_id}!" >&2
+		exit 1
+	elif [[ num_paths -gt 1 ]]; then
+		echo "Found multiple buildpacks matching ID ${requested_buildpack_id}!" >&2
+		echo "${matching_buildpack_toml_paths[@]}" >&2
+		exit 1
 	fi
-done < <(find . -name buildpack.toml -print0)
+	echo "${matching_buildpack_toml_paths[0]}"
+}
 
-echo "Could not find requested buildpack with id ${REQUESTED_BUILDPACK_ID}!"
-exit 1
+buildpack_id="${REQUESTED_BUILDPACK_ID:?Must be set to a valid buildpack ID!}"
+buildpack_toml_path="$(find_buildpack_toml_path "${buildpack_id}")"
+buildpack_version="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.version)"
+buildpack_docker_repository="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"
+buildpack_path=$(dirname "${buildpack_toml_path}")
+buildpack_build_path="${buildpack_path}"
+
+echo "Found buildpack ${buildpack_id} at ${buildpack_path}"
+
+# Some buildpacks require a build step before packaging. If we detect a build.sh script, we execute it and
+# modify the buildpack_build_path variable to point to the directory with the built buildpack instead.
+if [[ -f "${buildpack_path}/build.sh" ]]; then
+	echo "Buildpack has build script, executing..."
+	"${buildpack_path}/build.sh"
+	echo "Build finished!"
+
+	buildpack_build_path="${buildpack_path}/target"
+fi
+
+image_name="${buildpack_docker_repository}:${buildpack_version}"
+
+echo "Publishing ${buildpack_id} v${buildpack_version} to ${image_name}"
+pack buildpack package --config "${buildpack_build_path}/package.toml" --publish "${image_name}"
+
+# We might have local changes after building and/or shimming the buildpack. To ensure scripts down the pipeline
+# work with a clean state, we reset all local changes here.
+git reset --hard
+git clean -fdx
+
+echo "::set-output name=id::${buildpack_id}"
+echo "::set-output name=version::${buildpack_version}"
+echo "::set-output name=path::${buildpack_path}"
+echo "::set-output name=address::${buildpack_docker_repository}@$(crane digest "${image_name}")"


### PR DESCRIPTION
Previously if duplicate buildpack IDs existed in the repository, the publish script would publish the first buildpack found, and exit 0.

The Node.js test buildpacks have the same IDs as the real buildpacks, leading to the test buildpacks being published instead of the intended buildpack.

With this change, the publish script now traverses the repository and errors if more than one buildpack with the same ID was found.

In addition, I've added a bit more logging around the name/path/version of the found buildpack, which would have aided debugging this issue.

This PR is the Node.js equivalent of:
https://github.com/heroku/buildpacks-jvm/pull/129

Refs GUS-W-9672962.