### PR TITLE
Enable Dependabot for GitHub Actions and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,18 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    labels:
+      - "skip changelog"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "skip changelog"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
     labels:
       - "skip changelog"


### PR DESCRIPTION
See:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates#supported-repositories-and-ecosystems

Whilst this repository isn't using Rust right now, it will be shortly, so I've enabled Cargo updates now to save churn.

I've also changed the frequency to daily, so we don't have to wait as long.

Refs GUS-W-9678950.