### PR TITLE
Bump sf-fx-runtime-nodejs to 0.4.0 in nodejs-function-invoker

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump sf-fx-runtime-nodejs to 0.3.1, adding support for JavaScript Modules
+
 ## [0.1.7] 2021/07/28
 
 - Bump sf-fx-runtime-nodejs to 0.1.2-ea

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,7 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Bump sf-fx-runtime-nodejs to 0.3.1, adding support for JavaScript Modules
+- Bump sf-fx-runtime-nodejs to 0.4.0, adding support for JavaScript Modules
 
 ## [0.1.7] 2021/07/28
 

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -23,7 +23,7 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://sf-fx-nodejs-internal-early-access.s3.us-east-2.amazonaws.com/sf-fx-runtime-nodejs-0.1.2-ea.tgz"
+url = "https://sf-fx-nodejs-internal-early-access.s3.us-east-2.amazonaws.com/sf-fx-runtime-nodejs-0.3.1.tgz"
 
 [metadata.release]
 

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.6"
 
 [buildpack]
 id = "heroku/nodejs-function-invoker"
-version = "0.1.8"
+version = "0.2.0"
 name = "Node.js Function Invoker"
 clear-env = true
 homepage = "https://github.com/heroku/buildpacks-nodejs"
@@ -23,7 +23,7 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://sf-fx-nodejs-internal-early-access.s3.us-east-2.amazonaws.com/sf-fx-runtime-nodejs-0.3.1.tgz"
+url = "https://sf-fx-nodejs-internal-early-access.s3.us-east-2.amazonaws.com/sf-fx-runtime-nodejs-0.4.0.tgz"
 
 [metadata.release]
 

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -25,7 +25,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-function-invoker"
-version = "0.1.7"
+version = "0.2.0"
 
 [metadata]
 

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -25,7 +25,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-function-invoker"
-version = "0.2.0"
+version = "0.1.7"
 
 [metadata]
 

--- a/test/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/test/meta-buildpacks/nodejs-function/buildpack.toml
@@ -25,7 +25,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-function-invoker"
-version = "0.1.8"
+version = "0.2.0"
 
 [metadata]
 


### PR DESCRIPTION
This upgrades the sf-fx-runtime-nodejs to 0.4.0. It also bumps the minor version of the nodejs-function-invoker buildpack since we're adding new functionality.

This brings in https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/99, adding support for ESM / JavaScript Modules.