### PR TITLE
update runtime to new version

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update sf-fx-runtime-nodejs to 0.5.2
+
 ## [0.2.0] 2021/08/24
 
 - Bump sf-fx-runtime-nodejs to 0.4.0, adding support for JavaScript Modules

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -23,7 +23,7 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://sf-fx-nodejs-internal-early-access.s3.us-east-2.amazonaws.com/sf-fx-runtime-nodejs-0.4.0.tgz"
+url = "https://sf-fx-nodejs-internal-early-access.s3.us-east-2.amazonaws.com/heroku-sf-fx-runtime-nodejs-0.5.2.tgz"
 
 [metadata.release]
 


### PR DESCRIPTION
Update [runtime](https://github.com/forcedotcom/sf-fx-runtime-nodejs) to [0.5.2](https://github.com/forcedotcom/sf-fx-runtime-nodejs/releases/tag/v0.5.2).

Changes:
- Handle malformed/missing cloud event salesforce extension ([#141](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/141))
- Update package name to @heroku/sf-fx-runtime-nodejs ([#139](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/139))
- Automatically expand ReferenceIDs with `.toApiString()` ([#133](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/133))
- Add unit testing for src/index.ts ([#118](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/118))
- Utilize @salesforce/core for logging with logfmt ([#119](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/119))