### PR TITLE
Update sf-fx-runtime-nodejs to 0.7.0

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update sf-fx-runtime-nodejs to 0.7.0
+
 ## [0.2.2] 2021/09/23
 
 - Update sf-fx-runtime-nodejs to 0.6.0 and install from npmjs.org

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -23,7 +23,7 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-package = "@heroku/sf-fx-runtime-nodejs@0.6.0"
+package = "@heroku/sf-fx-runtime-nodejs@0.7.0"
 
 [metadata.release]
 


### PR DESCRIPTION
- Updates SFDC API version to 0.5.3 https://github.com/forcedotcom/sf-fx-runtime-nodejs/blob/main/CHANGELOG.md#070---2021-09-29