### PR TITLE
Trim whitespace on release build pack

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -6,6 +6,7 @@ shopt -s globstar
 # It requires the following environment variables to function correctly:
 #
 # REQUESTED_BUILDPACK_ID - The ID of the buildpack to package and push to the container registry.
+# for example `heroku/nodejs-function` or `heroku/nodejs-engine`.
 
 function find_buildpack_toml_path() {
 	local requested_buildpack_id="${1}"
@@ -21,17 +22,17 @@ function find_buildpack_toml_path() {
 
 	num_paths=${#matching_buildpack_toml_paths[@]}
 	if [[ num_paths -eq 0 ]]; then
-		echo "Could not find requested buildpack with ID ${requested_buildpack_id}!" >&2
+		echo "Could not find requested buildpack with ID '${requested_buildpack_id}'" >&2
 		exit 1
 	elif [[ num_paths -gt 1 ]]; then
-		echo "Found multiple buildpacks matching ID ${requested_buildpack_id}!" >&2
+		echo "Found multiple buildpacks matching ID '${requested_buildpack_id}'" >&2
 		echo "${matching_buildpack_toml_paths[@]}" >&2
 		exit 1
 	fi
 	echo "${matching_buildpack_toml_paths[0]}"
 }
 
-buildpack_id="${REQUESTED_BUILDPACK_ID:?Must be set to a valid buildpack ID!}"
+buildpack_id=$(echo "${REQUESTED_BUILDPACK_ID:?Must be set to a valid buildpack ID!}" | tr -d '[:space:]')
 buildpack_toml_path="$(find_buildpack_toml_path "${buildpack_id}")"
 buildpack_version="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.version)"
 buildpack_docker_repository="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"

--- a/.github/scripts/release-workflow-prepare-pr.sh
+++ b/.github/scripts/release-workflow-prepare-pr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-released_buildpack_id="${1:?}"
+released_buildpack_id=$(echo "${1:?}" | tr -d '[:space:]')
 released_buildpack_version="${2:?}"
 released_buildpack_image_address="${3:?}"
 


### PR DESCRIPTION
Currently if you attempt to release a buildpack with id `heroku/nodejs   ` (with whitespace before or after) it will fail. It also takes a few minutes to fail and isn't 100% obvious in the message that the failure is due to whitespace.

This trims whitespace from the input on both release scripts. I also modified the error message to quote the variable so if it's used in the future without being trimmed first, the error would be easier to detect.

Other considerations:

- Could we trim the input earlier? Ideally not having to do this in every script would be ideal.
- It takes a long time running on actions before this will execute, we should check the input build pack id early and fail early to give fast feedback in the future.
- These scripts are not tested and should be modified with extreme caution. We should extract as much functionality into bash functions as possible and write some tests against them.
- Similar to above: Ideally we would lint these changes.