### PR TITLE
Add test for logging output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cutlass (0.2.3)
+    cutlass (0.2.4)
       docker-api (>= 2.0)
     dead_end (1.1.7)
     diff-lcs (1.4.4)
     docker-api (2.2.0)
       excon (>= 0.47.0)
       multi_json
-    excon (0.85.0)
+    excon (0.86.0)
     java-properties (0.3.0)
     multi_json (1.15.0)
     parallel (1.20.1)

--- a/test/fixtures/simple-function/index.js
+++ b/test/fixtures/simple-function/index.js
@@ -1,3 +1,4 @@
  module.exports = async function (event, context, logger) {
+    logger.info("logging info is a fun 1")
     return "Hello World".toLowerCase();
 }

--- a/test/specs/node-function/cutlass/function_spec.rb
+++ b/test/specs/node-function/cutlass/function_spec.rb
@@ -18,6 +18,8 @@ describe "Heroku's Nodejs CNB" do
 
         expect(query.as_json).to eq("hello world")
         expect(query.success?).to be_truthy
+
+        expect(container.logs.stdout).to include("logging info is a fun 1")
       end
     end
   end


### PR DESCRIPTION
Currently, there are no integration tests that ensure the contents to the log interface show up in the output. This commit ensures basic logging functionality does not regress.

GUS-W-9933414

Java logging test: https://github.com/heroku/buildpacks-jvm/pull/175
Node logging test: https://github.com/heroku/buildpacks-nodejs/pull/135