### PR TITLE
Fix yarn install and upgrade to Buildpack API 0.6

### DIFF
--- a/buildpacks/yarn/CHANGELOG.md
+++ b/buildpacks/yarn/CHANGELOG.md
@@ -4,6 +4,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- install yarn
+- upgrade to buildpack api 0.6
+- support '*' stack
+
 ## [0.1.6] 2021/08/04
 ### Fixed
 - yarn buildpack consumes dependency on node during plan resolution

--- a/buildpacks/yarn/bin/build
+++ b/buildpacks/yarn/bin/build
@@ -22,6 +22,9 @@ export_env "$platform_dir/env" "" ""
 run_prebuild "$build_dir"
 clear_cache_on_node_version_change "$layers_dir"
 write_to_store_toml "$layers_dir"
+
+npm install --global yarn
+
 install_or_reuse_node_modules "$build_dir" "$layers_dir/node_modules"
 run_build "$build_dir"
 write_launch_toml "$build_dir/package.json" "$layers_dir/launch.toml"

--- a/buildpacks/yarn/buildpack.toml
+++ b/buildpacks/yarn/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.2"
+api = "0.6"
 
 [buildpack]
 id = "heroku/nodejs-yarn"
@@ -17,6 +17,9 @@ id = "heroku-20"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+id = "*"
 
 [metadata]
 

--- a/buildpacks/yarn/lib/build.sh
+++ b/buildpacks/yarn/lib/build.sh
@@ -109,7 +109,7 @@ install_or_reuse_node_modules() {
 	if [[ "$local_lock_checksum" == "$cached_lock_checksum" ]]; then
 		echo "---> Reusing node modules"
 	else
-	  echo "[types]" >"${layer_dir}.toml"
+		echo "[types]" >"${layer_dir}.toml"
 		echo "cache = true" >>"${layer_dir}.toml"
 
 		{

--- a/buildpacks/yarn/lib/build.sh
+++ b/buildpacks/yarn/lib/build.sh
@@ -109,7 +109,8 @@ install_or_reuse_node_modules() {
 	if [[ "$local_lock_checksum" == "$cached_lock_checksum" ]]; then
 		echo "---> Reusing node modules"
 	else
-		echo "cache = true" >"${layer_dir}.toml"
+	  echo "[types]" >"${layer_dir}.toml"
+		echo "cache = true" >>"${layer_dir}.toml"
 
 		{
 			echo "build = false"


### PR DESCRIPTION
Buildpack API 0.6 requires the `launch`, `cache`, and `build` keys to be under the `[types]` table.