### PR TITLE
Fix buildpackage filename (drop the slash)

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -38,7 +38,7 @@ buildpack_version="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.version)
 buildpack_docker_repository="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"
 buildpack_path=$(dirname "${buildpack_toml_path}")
 buildpack_build_path="${buildpack_path}"
-buildpackage_file="$(echo -n "${buildpack_id}" | tr '/' '-'}).cnb"
+buildpackage_file="$(echo -n "${buildpack_id}" | tr '/' '-').cnb"
 
 echo "Found buildpack ${buildpack_id} at ${buildpack_path}"
 

--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -38,7 +38,7 @@ buildpack_version="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.version)
 buildpack_docker_repository="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"
 buildpack_path=$(dirname "${buildpack_toml_path}")
 buildpack_build_path="${buildpack_path}"
-buildpackage_file="${buildpack_id}.cnb"
+buildpackage_file="$(echo -n "${buildpack_id}" | tr '/' '-'}).cnb"
 
 echo "Found buildpack ${buildpack_id} at ${buildpack_path}"
 


### PR DESCRIPTION
We're failing to build the buildpackage during release: https://github.com/heroku/buildpacks-nodejs/runs/4168800227?check_suite_focus=true. The filename of `heroku/nodejs-yarn` is problematic, since it has a slash.

This error started with the release of #160.