### PR TITLE
Update Pack to v0.23.0 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  pack: buildpacks/pack@0.2.2
+  pack: buildpacks/pack@0.2.4
   ruby: circleci/ruby@1.1.2
   heroku-buildpacks:
     commands:
@@ -33,7 +33,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - pack/install-pack:
-          version: 0.16.0
+          version: 0.23.0
       - heroku-buildpacks/install-build-dependencies
       - run:
           name: "Build and package buildpack with retries"
@@ -60,7 +60,7 @@ jobs:
     steps:
       - checkout
       - pack/install-pack:
-          version: 0.16.0
+          version: 0.23.0
       - ruby/install-deps
       - heroku-buildpacks/install-build-dependencies
       - run:


### PR DESCRIPTION
Changes:
https://github.com/buildpacks/pack/releases/tag/v0.17.0
https://github.com/buildpacks/pack/releases/tag/v0.18.0
https://github.com/buildpacks/pack/releases/tag/v0.18.1
https://github.com/buildpacks/pack/releases/tag/v0.19.0
https://github.com/buildpacks/pack/releases/tag/v0.20.0
https://github.com/buildpacks/pack/releases/tag/v0.21.0
https://github.com/buildpacks/pack/releases/tag/v0.21.1
https://github.com/buildpacks/pack/releases/tag/v0.22.0
https://github.com/buildpacks/pack/releases/tag/v0.23.0https://github.com/buildpacks/pack-orb/releases/tag/0.2.3
https://github.com/buildpacks/pack-orb/releases/tag/0.2.4

(The version used in the GitHub actions release workflow is updated automatically by Dependabot, so only the Circle CI versions need manual updates.)

GUS-W-10301655.