### PR TITLE
Bump invoker to 0.9.2

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update sf-fx-runtime-nodejs to 0.9.2
+
 ## [0.2.7] 2021/10/18
 
 - Decrease sf-fx-runtime-nodejs workers to 2

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -23,7 +23,7 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-package = "@heroku/sf-fx-runtime-nodejs@0.9.1"
+package = "@heroku/sf-fx-runtime-nodejs@0.9.2"
 
 [metadata.release]
 


### PR DESCRIPTION
This updates the nodejs invoker/runtime to 0.9.2. There are only minor changes described here: https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/266.

GUS-W-10379120