### PR TITLE
Increment counter when failing to package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
               fi
 
               pack buildpack package test --config "${package_toml}" && break
+              ((n++))
             done
 
   cutlass-integration-test:


### PR DESCRIPTION
Packaging the buildpack repeats endlessly in CI if it fails. There is a counter, but it never gets incremented. Let's fix that.