### PR TITLE
Fix `tsc: not found` for typescript rebuilds

### DIFF
--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Ensure NODE_ENV is set consistently during build, no matter the cache state ([186](https://github.com/heroku/buildpacks-nodejs/pull/186)
 
 ## [0.7.4] 2021/06/15
 - Change node engine version from 12 to 14 ([#40](https://github.com/heroku/buildpacks-node/pull/40))

--- a/buildpacks/nodejs-engine/bin/build
+++ b/buildpacks/nodejs-engine/bin/build
@@ -24,8 +24,6 @@ clear_cache_on_stack_change "$layers_dir"
 
 write_to_store_toml "$layers_dir"
 
-set_up_environment "$layers_dir/nodejs"
-
 bootstrap_buildpack "$layers_dir/bootstrap"
 
 install_or_reuse_toolbox "$layers_dir/toolbox"
@@ -38,14 +36,14 @@ export PATH=$layers_dir/nodejs/bin:$PATH
 
 clear_cache_on_node_version_change "$layers_dir" "$layers_dir/nodejs"
 
+set_node_env "$layers_dir/nodejs"
+
 parse_package_json_engines "$layers_dir/package_manager_metadata" "$build_dir"
 
 if [[ -f "yarn.lock" ]]; then
 	install_or_reuse_yarn "$layers_dir/yarn" "$build_dir"
 	export PATH=$layers_dir/yarn/bin:$PATH
 fi
-
-set_node_env "$layers_dir/nodejs"
 
 set_node_modules_path "$layers_dir/node_modules"
 

--- a/buildpacks/nodejs-engine/lib/build.sh
+++ b/buildpacks/nodejs-engine/lib/build.sh
@@ -43,18 +43,6 @@ clear_cache_on_stack_change() {
 	fi
 }
 
-set_up_environment() {
-	local layer_dir=$1
-	local node_env=${NODE_ENV:-production}
-
-	mkdir -p "${layer_dir}/env.build"
-
-	if [[ ! -s "${layer_dir}/env.build/NODE_ENV.override" ]]; then
-		echo -e "$node_env\c" >>"${layer_dir}/env.build/NODE_ENV.override"
-	fi
-	info "Setting NODE_ENV to ${node_env}"
-}
-
 install_or_reuse_toolbox() {
 	local layer_dir=$1
 
@@ -218,10 +206,11 @@ set_node_env() {
 	local layer_dir=$1
 	local node_env=${NODE_ENV:-production}
 
-	mkdir -p "${layer_dir}/env.launch"
-	if [[ ! -s "${layer_dir}/env.launch/NODE_ENV.override" ]]; then
-		echo -e "$node_env\c" >>"${layer_dir}/env.launch/NODE_ENV.override"
+	mkdir -p "${layer_dir}/env"
+	if [[ ! -s "${layer_dir}/env/NODE_ENV.override" ]]; then
+		echo -e "$node_env\c" >>"${layer_dir}/env/NODE_ENV.override"
 	fi
+	info "Setting NODE_ENV to ${node_env}"
 }
 
 set_node_modules_path() {

--- a/buildpacks/nodejs-engine/shpec/build_shpec.sh
+++ b/buildpacks/nodejs-engine/shpec/build_shpec.sh
@@ -136,33 +136,6 @@ describe "lib/build.sh"
 		end
 	end
 
-	describe "set_up_environment"
-		layers_dir=$(create_temp_layer_dir)
-		it "sets env.build/NODE_ENV.override to production when NODE_ENV is blank"
-			assert file_absent "$layers_dir/nodejs/env.build/NODE_ENV.override"
-
-			set_up_environment "$layers_dir/nodejs"
-
-			assert file_present "$layers_dir/nodejs/env.build/NODE_ENV.override"
-			assert equal "$(cat "$layers_dir/nodejs/env.build/NODE_ENV.override")" production
-
-			rm "$layers_dir/nodejs/env.build/NODE_ENV.override"
-		end
-
-		it "sets env.build/NODE_ENV.override to NODE_ENV"
-			export NODE_ENV="test"
-
-			set_up_environment "$layers_dir/nodejs"
-
-			assert file_present "$layers_dir/nodejs/env.build/NODE_ENV.override"
-			assert equal "$(cat "$layers_dir/nodejs/env.build/NODE_ENV.override")" test
-
-			unset NODE_ENV
-		end
-
-		rm_temp_dirs "$layers_dir"
-	end
-
 	describe "set_node_modules_path"
 		layers_dir=$(create_temp_layer_dir)
 		it "sets NODE_MODULES_PATH to node modules directory path"
@@ -272,24 +245,24 @@ describe "lib/build.sh"
 
 	describe "set_node_env"
 		layers_dir=$(create_temp_layer_dir)
-		it "sets env.launch/NODE_ENV.override to production when NODE_ENV is blank"
-			assert file_absent "$layers_dir/nodejs/env.launch/NODE_ENV.override"
+		it "sets env/NODE_ENV.override to production when NODE_ENV is blank"
+			assert file_absent "$layers_dir/nodejs/env/NODE_ENV.override"
 
 			set_node_env "$layers_dir/nodejs"
 
-			assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV.override"
-			assert equal "$(cat "$layers_dir/nodejs/env.launch/NODE_ENV.override")" production
+			assert file_present "$layers_dir/nodejs/env/NODE_ENV.override"
+			assert equal "$(cat "$layers_dir/nodejs/env/NODE_ENV.override")" production
 
-			rm "$layers_dir/nodejs/env.launch/NODE_ENV.override"
+			rm "$layers_dir/nodejs/env/NODE_ENV.override"
 		end
 
-		it "sets env.launch/NODE_ENV.override to NODE_ENV"
+		it "sets env/NODE_ENV.override to NODE_ENV"
 			export NODE_ENV="test"
 
 			set_node_env "$layers_dir/nodejs"
 
-			assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV.override"
-			assert equal "$(cat "$layers_dir/nodejs/env.launch/NODE_ENV.override")" test
+			assert file_present "$layers_dir/nodejs/env/NODE_ENV.override"
+			assert equal "$(cat "$layers_dir/nodejs/env/NODE_ENV.override")" test
 
 			unset NODE_ENV
 		end

--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- `npm ci` and `npm install` now run with `--production=false` to ensure `devDependencies` are installed ([186](https://github.com/heroku/buildpacks-nodejs/pull/186))
 
 ## [0.4.4] 2021/06/15
 ### Fixed

--- a/buildpacks/npm/lib/build.sh
+++ b/buildpacks/npm/lib/build.sh
@@ -131,7 +131,7 @@ install_modules() {
 		fi
 	else
 		info "Installing node modules"
-		npm install --no-package-lock
+		npm install --production=false --no-package-lock
 	fi
 }
 

--- a/buildpacks/npm/lib/build.sh
+++ b/buildpacks/npm/lib/build.sh
@@ -125,9 +125,9 @@ install_modules() {
 	if detect_package_lock "$build_dir"; then
 		info "Installing node modules from ./package-lock.json"
 		if use_npm_ci; then
-			npm ci
+			npm ci --production=false
 		else
-			npm install
+		  npm install --production=false
 		fi
 	else
 		info "Installing node modules"
@@ -182,6 +182,7 @@ install_or_reuse_node_modules() {
 		info "Reusing node modules"
 		cp -r "$layer_dir" "$build_dir/node_modules"
 	else
+    rm -rf "$layer_dir"/*
 		echo "cache = true" >"${layer_dir}.toml"
 
 		{
@@ -195,6 +196,7 @@ install_or_reuse_node_modules() {
 		if [[ -d "$build_dir/node_modules" && -n "$(ls -A "$build_dir/node_modules")" ]]; then
 			cp -r "$build_dir/node_modules/." "$layer_dir"
 		fi
+
 	fi
 }
 

--- a/buildpacks/npm/lib/build.sh
+++ b/buildpacks/npm/lib/build.sh
@@ -127,7 +127,7 @@ install_modules() {
 		if use_npm_ci; then
 			npm ci --production=false
 		else
-		  npm install --production=false
+			npm install --production=false
 		fi
 	else
 		info "Installing node modules"

--- a/buildpacks/npm/lib/build.sh
+++ b/buildpacks/npm/lib/build.sh
@@ -182,7 +182,6 @@ install_or_reuse_node_modules() {
 		info "Reusing node modules"
 		cp -r "$layer_dir" "$build_dir/node_modules"
 	else
-		rm -rf "${layer_dir:?}"/*
 		echo "cache = true" >"${layer_dir}.toml"
 
 		{
@@ -196,7 +195,6 @@ install_or_reuse_node_modules() {
 		if [[ -d "$build_dir/node_modules" && -n "$(ls -A "$build_dir/node_modules")" ]]; then
 			cp -r "$build_dir/node_modules/." "$layer_dir"
 		fi
-
 	fi
 }
 

--- a/buildpacks/npm/lib/build.sh
+++ b/buildpacks/npm/lib/build.sh
@@ -182,7 +182,7 @@ install_or_reuse_node_modules() {
 		info "Reusing node modules"
 		cp -r "$layer_dir" "$build_dir/node_modules"
 	else
-    rm -rf "$layer_dir"/*
+		rm -rf "${layer_dir:?}"/*
 		echo "cache = true" >"${layer_dir}.toml"
 
 		{


### PR DESCRIPTION
## Issue

In the scenario where a TypeScript app build has the correct Node.js version cached, but something in the `package.json` or `package-lock.json` has changed causing the `node_modules` cache to be invalid, that build would fail with `tsc: not found`. 

## Why it was happening

On a build without any cache, TypeScript builds would pass. But this may have been accidental. We were creating a `env.build/NODE_ENV.override` file, but we'd unintentionally delete it a short time later with a `rm -rf` during `install_or_reuse_node()`. Since `NODE_ENV` was unset, that meant that `npm ci` and/or `npm install` would install all `devDependencies`, including `typescript`.

On a build with a valid `nodejs` cache, the `rm -rf` mentioned never happens. So, for these builds `NODE_ENV` is set to `production` during `npm ci` or `npm install`, and `devDependencies` are NOT installed, so any `tsc` calls fail.

On a build with a valid `nodejs` and `node_modules` cache, the `rm -rf` still doesn't happen, but it doesn't matter because we don't run `npm install`, we instead restore the module cache, which includes `tsc` from the previous build. 

## How it's getting fixed

- We make sure that the `NODE_ENV` file is created AFTER the `nodejs` layer is cleaned out. 
- since we were also setting `env.launch/NODE_ENV.override`, consolidated these functions/files to create just one `env/NODE_ENV.override`that should serve both purposes.
- Now that `NODE_ENV` is always `production` during builds, `npm install` and `npm ci` will both skip `devDependencies`. Adding `--production=false` to these calls ensure we still install `devDependencies` like `typescript`.

GUS-W-10034673