### PR TITLE
Update to sf-fx-runtime-nodejs 0.11.0

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update sf-fx-runtime-nodejs to 0.11.0
+
 ## [0.2.9] 2022/02/10
 
 - Update sf-fx-runtime-nodejs to 0.10.0

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -23,7 +23,7 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-package = "@heroku/sf-fx-runtime-nodejs@0.10.0"
+package = "@heroku/sf-fx-runtime-nodejs@0.11.0"
 
 [metadata.release]
 


### PR DESCRIPTION
Updates sf-fx-runtime-nodejs to 0.11.0. The primary change included in this release is https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/294.

[GUS-W-10728741](https://gus.my.salesforce.com/a07EE00000qUu23YAC)