### PR TITLE
Install musl tools, rust, and libcnb-cargo prior to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,20 @@ jobs:
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         env:
           AWS_REGION: us-east-1
+      - id: install-musl-tools
+        run: sudo apt-get install musl-tools
+      - id: install-rust-toolchain
+        name: "Install Rust toolchain"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: "x86_64-unknown-linux-musl"
+      - id: install-libcnb-cargo
+        name: "Install libcnb-cargo"
+        uses: actions-rs/install@v0.1
+        with:
+          crate: libcnb-cargo
+          version: latest
       - id: package
         name: "Package buildpack and publish to container registry"
         run: ./.github/scripts/release-workflow-package-push.sh


### PR DESCRIPTION
The release buildpack script is failing for rust based buildpacks: https://github.com/heroku/buildpacks-nodejs/actions/runs/1959345733.

We need to install musl-tools, rust, and libcnb-cargo so that we can build/release the libcnb-based buildpacks like `heroku/nodejs-engine` that was introduced in #184.

This code was lifted from https://github.com/heroku/buildpacks-jvm/blob/main/.github/workflows/release.yml#L31-L44

GUS-W-10729118