### PR TITLE
Set package.json scripts.start as a default process

### DIFF
--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The `web` process affiliated with `package.json`'s `scripts.start` is now a `default` process ([#214](https://github.com/heroku/buildpacks-nodejs/pull/214))
+
 ## [0.5.0] 2022/03/09
 
 - Upgraded to buildpack api 0.6 ([#184](https://github.com/heroku/buildpacks-nodejs/pull/184))

--- a/buildpacks/npm/lib/build.sh
+++ b/buildpacks/npm/lib/build.sh
@@ -243,6 +243,7 @@ write_launch_toml() {
 [[processes]]
 type = "web"
 command = "npm start"
+default = true
 TOML
 	fi
 

--- a/buildpacks/yarn/CHANGELOG.md
+++ b/buildpacks/yarn/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The `web` process affiliated with `package.json`'s `scripts.start` is now a `default` process ([#214](https://github.com/heroku/buildpacks-nodejs/pull/214))
+
 ## [0.2.0] 2022/03/09
 
 - Installs `yq` in the build toolbox layer ([#184](https://github.com/heroku/buildpacks-nodejs/pull/184))

--- a/buildpacks/yarn/lib/build.sh
+++ b/buildpacks/yarn/lib/build.sh
@@ -171,6 +171,7 @@ write_launch_toml() {
 [[processes]]
 type = "web"
 command = "yarn start"
+default = true
 TOML
 	fi
 


### PR DESCRIPTION
In #184, we updated the buildpack api version for `heroku/npm` to `0.6`. This had the unintended side effect of the `web` process no longer being flagged as a default process. In earlier buildpack API versions, overwriting a default process with an undefined default would result in a process flagged as default. Newer buildpack API versions will prefer the default setting of the overwriting process.

This PR ensures the `web` process affiliated with `package.json`'s `scripts.start` is flagged as a default process, for both `yarn` and `npm`. 

Fixes #211 

[W-10888625](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000tVabFYAS)