### PR TITLE
make etag optional part of the inventory

### DIFF
--- a/common/nodejs-utils/src/inv.rs
+++ b/common/nodejs-utils/src/inv.rs
@@ -85,7 +85,7 @@ pub struct Release {
     pub channel: String,
     pub arch: Option<String>,
     pub url: String,
-    pub etag: String,
+    pub etag: Option<String>,
 }
 
 #[cfg(test)]
@@ -105,7 +105,7 @@ mod tests {
             channel: channel.to_string(),
             arch: Some(arch.to_string()),
             url: url(&ver.to_string(), arch, channel),
-            etag: "a586044d93acb053d28dd6c0ddf95362".to_string(),
+            etag: Some("a586044d93acb053d28dd6c0ddf95362".to_string()),
         }
     }
 

--- a/common/nodejs-utils/src/nodebin_s3.rs
+++ b/common/nodejs-utils/src/nodebin_s3.rs
@@ -79,7 +79,7 @@ impl TryFrom<BucketContent> for Inventory {
                     version: Version::parse(version_number.as_str())?,
                     channel: channel.as_str().to_string(),
                     // Amazon S3 returns a quoted string for ETags
-                    etag: content.etag.replace('\"', ""),
+                    etag: Some(content.etag.replace('\"', "")),
                     url: format!("https://s3.amazonaws.com/{}/{}", BUCKET, &content.key),
                 })
             })
@@ -158,7 +158,7 @@ mod tests {
         let result = Inventory::try_from(bucket_content);
         assert!(result.is_ok());
         if let Ok(inv) = result {
-            assert_eq!(etag, inv.releases[0].etag);
+            assert_eq!(Some(String::from(etag)), inv.releases[0].etag);
         }
     }
 


### PR DESCRIPTION
To let others create an inventory.toml, I'd like to make `etag` optional. From what I can tell this is just an artifact of nodebin using S3. It's not being used anywhere in the buildpack. I wonder if we should even remove this.