### PR TITLE
Update heroku/procfile to 1.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - pack/install-pack:
-          version: 0.24.0
+          version: 0.24.1
       - heroku-buildpacks/install-build-dependencies
       - heroku-buildpacks/install-rust
       - heroku-buildpacks/install-libcnb-cargo
@@ -75,7 +75,7 @@ jobs:
     steps:
       - checkout
       - pack/install-pack:
-          version: 0.24.0
+          version: 0.24.1
       - ruby/install-deps
       - heroku-buildpacks/install-build-dependencies
       - heroku-buildpacks/install-rust
@@ -133,7 +133,7 @@ jobs:
     steps:
       - checkout
       - pack/install-pack:
-          version: 0.24.0
+          version: 0.24.1
       - heroku-buildpacks/install-build-dependencies
       - heroku-buildpacks/install-rust
       - run:

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Upgraded `heroku/procfile` to `1.0.0`
 
 ## [0.5.2] 2022/04/04
 * Upgraded `heroku/nodejs-yarn` to `0.2.2`

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -21,7 +21,7 @@ version = "0.2.2"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6.2"
+version = "1.0.0"
 optional = true
 
 [[order]]
@@ -36,7 +36,7 @@ version = "0.5.1"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6.2"
+version = "1.0.0"
 optional = true
 
 [metadata]

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -11,4 +11,4 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:e84bf06be3dc141db26b46efaaa640f2c40bc49545e005b13e486cd81db2dbe3"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
+uri = "docker://docker.io/heroku/procfile-cnb:1.0.0"

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -18,7 +18,7 @@ version = "0.2.3"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6.2"
+version = "1.0.0"
 optional = true
 
 [[order]]
@@ -33,5 +33,5 @@ version = "0.5.2"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6.2"
+version = "1.0.0"
 optional = true

--- a/test/meta-buildpacks/nodejs/package.toml
+++ b/test/meta-buildpacks/nodejs/package.toml
@@ -11,4 +11,4 @@ uri = "../../../buildpacks/npm"
 uri = "../../../buildpacks/yarn"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
+uri = "docker://docker.io/heroku/procfile-cnb:1.0.0"


### PR DESCRIPTION
The new libcnb.rs `heroku/procfile` is ready to go. Let's use it!

[W-10475648](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000hwHhMYAU)