### PR TITLE
Bump heroku/procfile to 1.0.1

### DIFF
--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Upgraded `heroku/procfile` to `1.0.0`
+* Upgraded `heroku/procfile` to `1.0.1`
 
 ## [0.5.2] 2022/04/04
 * Upgraded `heroku/nodejs-yarn` to `0.2.2`

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -21,7 +21,7 @@ version = "0.2.2"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "1.0.0"
+version = "1.0.1"
 optional = true
 
 [[order]]
@@ -36,7 +36,7 @@ version = "0.5.1"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "1.0.0"
+version = "1.0.1"
 optional = true
 
 [metadata]

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -11,4 +11,4 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:e84bf06be3dc141db26b46efaaa640f2c40bc49545e005b13e486cd81db2dbe3"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:1.0.0"
+uri = "docker://docker.io/heroku/procfile-cnb:1.0.1"

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -18,7 +18,7 @@ version = "0.2.3"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "1.0.0"
+version = "1.0.1"
 optional = true
 
 [[order]]
@@ -33,5 +33,5 @@ version = "0.5.2"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "1.0.0"
+version = "1.0.1"
 optional = true

--- a/test/meta-buildpacks/nodejs/package.toml
+++ b/test/meta-buildpacks/nodejs/package.toml
@@ -11,4 +11,4 @@ uri = "../../../buildpacks/npm"
 uri = "../../../buildpacks/yarn"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:1.0.0"
+uri = "docker://docker.io/heroku/procfile-cnb:1.0.1"


### PR DESCRIPTION
Version 1.0.0 of `heroku/procfile` can cause build failures on older versions of `pack`. More details here: https://github.com/heroku/procfile-cnb/pull/55

[W-10475648](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000hwHhMYAU)