### PR TITLE
Add support for the heroku-22 stack

### DIFF
--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for the heroku-22 stack
+
 ## [0.8.2] 2022/04/01
 
 - Update Node.js inventory ([#225](https://github.com/heroku/buildpacks-nodejs/pull/225))

--- a/buildpacks/nodejs-engine/buildpack.toml
+++ b/buildpacks/nodejs-engine/buildpack.toml
@@ -17,6 +17,9 @@ id = "heroku-18"
 id = "heroku-20"
 
 [[stacks]]
+id = "heroku-22"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
 [metadata]

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for the heroku-22 stack
+- Drop support for the bionic stack
+
 ## [0.3.0] 2022/04/01
 
 - Rewrite from bash to libcnb.rs implementation

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -17,7 +17,7 @@ id = "heroku-18"
 id = "heroku-20"
 
 [[stacks]]
-id = "io.buildpacks.stacks.bionic"
+id = "heroku-22"
 
 [metadata]
 

--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for all stacks
+- Add explicit support for the heroku-22 stack
+
 ## [0.5.1] 2022/03/23
 
 - The `web` process affiliated with `package.json`'s `scripts.start` is now a `default` process ([#214](https://github.com/heroku/buildpacks-nodejs/pull/214))

--- a/buildpacks/npm/buildpack.toml
+++ b/buildpacks/npm/buildpack.toml
@@ -10,11 +10,20 @@ keywords = ["nodejs", "node", "npm"]
 [[buildpack.licenses]]
 type = "MIT"
 
+# Wildcard stacks are not well supported prior to `pack` `0.24.1`. Explicit
+# stack identifiers can be removed after the buildpack api version is revised
+# to something greater than 0.6.
+[[stacks]]
+id = "*"
+
 [[stacks]]
 id = "heroku-18"
 
 [[stacks]]
 id = "heroku-20"
+
+[[stacks]]
+id = "heroku-22"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"

--- a/buildpacks/yarn/CHANGELOG.md
+++ b/buildpacks/yarn/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for the heroku-22 stack
+
 ## [0.2.2] 2022/04/04
 - `yarn install` now run with `--production=false` to ensure `devDependencies` are installed ([201](https://github.com/heroku/buildpacks-nodejs/pull/201))
 

--- a/buildpacks/yarn/buildpack.toml
+++ b/buildpacks/yarn/buildpack.toml
@@ -10,6 +10,12 @@ keywords = ["nodejs", "node", "yarn"]
 [[buildpack.licenses]]
 type = "MIT"
 
+# Wildcard stacks are not well supported prior to `pack` `0.24.1`. Explicit
+# stack identifiers can be removed after the buildpack api version is revised
+# to something greater than 0.6.
+[[stacks]]
+id = "*"
+
 [[stacks]]
 id = "heroku-18"
 
@@ -17,10 +23,10 @@ id = "heroku-18"
 id = "heroku-20"
 
 [[stacks]]
-id = "io.buildpacks.stacks.bionic"
+id = "heroku-22"
 
 [[stacks]]
-id = "*"
+id = "io.buildpacks.stacks.bionic"
 
 [metadata]
 


### PR DESCRIPTION
This PR revises stack support for all buildpacks. It adds explicit support for `heroku-22` on all buildpacks, and additionally:

- Drops support for `bionic` for the `heroku/nodejs-function-invoker` (this buildpack doesn't make sense on other stacks)
- Adds wildcard stack support for `heroku/nodejs-npm` to match `heroku/nodejs-yarn` (this buildpack should be useable in most places `node` and/or `npm` is available)

[W-10345122](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000ZZE8oYAH)