### PR TITLE
Fix inventory automation when there are no changes

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Rebuild Inventory
         run: "cargo run --bin list_versions node > buildpacks/nodejs-engine/inventory.toml"
       - name: Update Changelog
-        run: perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- ${{ steps.set-diff-msg.outputs.msg }}/' buildpacks/nodejs-engine/CHANGELOG.md
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' buildpacks/nodejs-engine/CHANGELOG.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
In #235, there were no new node versions, but we opened a PR anyway. The change (added `-`) to the changelog triggered a PR to be opened.

This PR uses `xargs` to avoid touching the changelog when there is no diff message.

[W-10942589](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000uDs1SYAS)