### PR TITLE
Add buildpacks:22 to the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ workflows:
               stack-version:
                 - "18"
                 - "20"
+                - "22"
 
       - package-buildpack:
           matrix:


### PR DESCRIPTION
We support heroku-22, so we should test against it.

[W-10343872](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000ZVsEZYA1)