### PR TITLE
Switch away from deprecated path-based S3 URLs

### DIFF
--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -4,9 +4,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Switch away from deprecated path-based S3 URLs
+
 ## [0.8.5] 2022/06/08
 
 - Added node version 16.15.1, 18.3.0, 17.9.1.
+
 ## [0.8.4] 2022/05/23
 
 - Added node version 14.19.3, 18.2.0.
@@ -14,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added node version 18.0.0.
 - Added node version 17.9.0.
 - Added node version 12.22.12.
+
 ## [0.8.3] 2022/04/05
 
 - Add support for the heroku-22 stack

--- a/buildpacks/nodejs-engine/inventory.toml
+++ b/buildpacks/nodejs-engine/inventory.toml
@@ -4,8763 +4,8763 @@ name = "node"
 version = "0.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.0-darwin-x64.tar.gz"
 etag = "739c200ca266266ff150ad4d89b83205"
 
 [[releases]]
 version = "0.10.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.1-darwin-x64.tar.gz"
 etag = "add2c86408c51ca108e2014030dded1d"
 
 [[releases]]
 version = "0.10.10"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.10-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.10-darwin-x64.tar.gz"
 etag = "f6721ca79d7402ddc881ea8f4380b0c2"
 
 [[releases]]
 version = "0.10.11"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.11-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.11-darwin-x64.tar.gz"
 etag = "ce0674b2322d7c33664212d211aa4bb9"
 
 [[releases]]
 version = "0.10.12"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.12-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.12-darwin-x64.tar.gz"
 etag = "23804ca5de6d2a6139ead017faf1ed60"
 
 [[releases]]
 version = "0.10.13"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.13-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.13-darwin-x64.tar.gz"
 etag = "d5a63c84cdb39b470f7ad3dc45c2727a"
 
 [[releases]]
 version = "0.10.14"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.14-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.14-darwin-x64.tar.gz"
 etag = "4386f721ba4e862b946f163b62cf61db"
 
 [[releases]]
 version = "0.10.15"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.15-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.15-darwin-x64.tar.gz"
 etag = "996c64a09c2a36cddfbf3cdfce493a51"
 
 [[releases]]
 version = "0.10.16"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.16-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.16-darwin-x64.tar.gz"
 etag = "d53b6340de354eb048cc7703a44e9b33"
 
 [[releases]]
 version = "0.10.17"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.17-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.17-darwin-x64.tar.gz"
 etag = "f67479fe9e0524344a50407575f6c251"
 
 [[releases]]
 version = "0.10.18"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.18-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.18-darwin-x64.tar.gz"
 etag = "0aa4270c3c6b2907041ac0d4e1d06731"
 
 [[releases]]
 version = "0.10.19"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.19-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.19-darwin-x64.tar.gz"
 etag = "d84eaf1d2a4445ae99d55f0c3a3b5cb0"
 
 [[releases]]
 version = "0.10.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.2-darwin-x64.tar.gz"
 etag = "d7217ca7e7710e04d8f4071bf601874b"
 
 [[releases]]
 version = "0.10.20"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.20-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.20-darwin-x64.tar.gz"
 etag = "165eb79335dfa844823ed07eebd571ba"
 
 [[releases]]
 version = "0.10.21"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.21-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.21-darwin-x64.tar.gz"
 etag = "4cd170168374738bc0c1818c94592be5"
 
 [[releases]]
 version = "0.10.22"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.22-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.22-darwin-x64.tar.gz"
 etag = "3541e529c8be6ac367b388a68d32844f"
 
 [[releases]]
 version = "0.10.23"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.23-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.23-darwin-x64.tar.gz"
 etag = "8dc094d98bd38f521f84016d4a0ea6d4"
 
 [[releases]]
 version = "0.10.24"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.24-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.24-darwin-x64.tar.gz"
 etag = "6127fae6281e5e40dc353e05da190e93"
 
 [[releases]]
 version = "0.10.25"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.25-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.25-darwin-x64.tar.gz"
 etag = "9323f6b7987407b9eb8d1402c7741f1a"
 
 [[releases]]
 version = "0.10.26"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.26-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.26-darwin-x64.tar.gz"
 etag = "34520fbfd822d3899b49eeaafcdbf170"
 
 [[releases]]
 version = "0.10.27"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.27-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.27-darwin-x64.tar.gz"
 etag = "a799579a84476983eb6e387f5185ebf0"
 
 [[releases]]
 version = "0.10.28"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.28-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.28-darwin-x64.tar.gz"
 etag = "fffb965e05b2c6f0b7a7b22f33ffad34"
 
 [[releases]]
 version = "0.10.29"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.29-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.29-darwin-x64.tar.gz"
 etag = "beb1de9f25c28f417d493124f0e49e53"
 
 [[releases]]
 version = "0.10.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.3-darwin-x64.tar.gz"
 etag = "b7effabcbff4fe1dca4e8a5c6bc1fb5c"
 
 [[releases]]
 version = "0.10.30"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.30-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.30-darwin-x64.tar.gz"
 etag = "3973ca6d1367474ca02850fb5d7a9d57"
 
 [[releases]]
 version = "0.10.31"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.31-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.31-darwin-x64.tar.gz"
 etag = "7a833d417b76c305366b09102eda94d0"
 
 [[releases]]
 version = "0.10.32"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.32-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.32-darwin-x64.tar.gz"
 etag = "bd5a65196c2ebe33c0251f19c5321b52"
 
 [[releases]]
 version = "0.10.33"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.33-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.33-darwin-x64.tar.gz"
 etag = "6fba8115b885c622d06683d75c676f48"
 
 [[releases]]
 version = "0.10.34"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.34-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.34-darwin-x64.tar.gz"
 etag = "62a928fc2a73d860c460865cf123c575"
 
 [[releases]]
 version = "0.10.35"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.35-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.35-darwin-x64.tar.gz"
 etag = "7d8e8de66e727e9bc51dead89a7b14cc"
 
 [[releases]]
 version = "0.10.36"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.36-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.36-darwin-x64.tar.gz"
 etag = "215ab4fb1cf6e767650ef0d3cd606e17"
 
 [[releases]]
 version = "0.10.37"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.37-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.37-darwin-x64.tar.gz"
 etag = "0603dedf1d2026c2331b669f53dc26e1"
 
 [[releases]]
 version = "0.10.38"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.38-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.38-darwin-x64.tar.gz"
 etag = "03a18da46350772ecae75ed58908477c"
 
 [[releases]]
 version = "0.10.39"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.39-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.39-darwin-x64.tar.gz"
 etag = "e5f59d0ee5a09c81d78395c1dd993a46"
 
 [[releases]]
 version = "0.10.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.4-darwin-x64.tar.gz"
 etag = "9fbb0184a5df999712948124cf09dc05"
 
 [[releases]]
 version = "0.10.40"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.40-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.40-darwin-x64.tar.gz"
 etag = "76c54366530314da504a5007f15a5aec"
 
 [[releases]]
 version = "0.10.41"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.41-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.41-darwin-x64.tar.gz"
 etag = "c677ea00932040e381c23cbd44c0803c"
 
 [[releases]]
 version = "0.10.42"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.42-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.42-darwin-x64.tar.gz"
 etag = "a6ba39e90330d93157d57285a64ec452"
 
 [[releases]]
 version = "0.10.43"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.43-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.43-darwin-x64.tar.gz"
 etag = "9f780366c50e11d2568a8625a59daff7"
 
 [[releases]]
 version = "0.10.44"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.44-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.44-darwin-x64.tar.gz"
 etag = "d8d2ea8e88b0f2cd5ae7aed433fc311e"
 
 [[releases]]
 version = "0.10.45"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.45-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.45-darwin-x64.tar.gz"
 etag = "a17db31698018e08a476eedc5e598b6e"
 
 [[releases]]
 version = "0.10.46"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.46-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.46-darwin-x64.tar.gz"
 etag = "5f73583d287cf3914f07f787792b5d9c"
 
 [[releases]]
 version = "0.10.47"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.47-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.47-darwin-x64.tar.gz"
 etag = "d63dfd67feabdd2cbe45d4abec11d9e3"
 
 [[releases]]
 version = "0.10.48"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.48-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.48-darwin-x64.tar.gz"
 etag = "8f543018e5a064588c3bb702cadccafd"
 
 [[releases]]
 version = "0.10.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.5-darwin-x64.tar.gz"
 etag = "38fe9f773e5a5ff45c3fec18d1049985"
 
 [[releases]]
 version = "0.10.6"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.6-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.6-darwin-x64.tar.gz"
 etag = "7a5967f8f2c1ecf88e82d00e63171fb4"
 
 [[releases]]
 version = "0.10.7"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.7-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.7-darwin-x64.tar.gz"
 etag = "55bc3ff33a8f1f75a87e1833fddea26e"
 
 [[releases]]
 version = "0.10.8"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.8-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.8-darwin-x64.tar.gz"
 etag = "3a1cf754787f708b693ba306c4acf169"
 
 [[releases]]
 version = "0.10.9"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.10.9-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.9-darwin-x64.tar.gz"
 etag = "a7328931bb7bd251c7d41dbf927e0d41"
 
 [[releases]]
 version = "0.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.0-darwin-x64.tar.gz"
 etag = "38f7c4238b49e8c4073e754f7ffdb19c"
 
 [[releases]]
 version = "0.11.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.1-darwin-x64.tar.gz"
 etag = "32608390f1fe57f48c187f1c9d2b4e18"
 
 [[releases]]
 version = "0.11.10"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.10-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.10-darwin-x64.tar.gz"
 etag = "738f72c339d4071c8e61c793da2e52d1"
 
 [[releases]]
 version = "0.11.11"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.11-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.11-darwin-x64.tar.gz"
 etag = "982cc2b49d3e5babdf5bd562fe4c0926"
 
 [[releases]]
 version = "0.11.12"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.12-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.12-darwin-x64.tar.gz"
 etag = "afcf17c85420c2c73e45339ded62fa8d"
 
 [[releases]]
 version = "0.11.13"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.13-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.13-darwin-x64.tar.gz"
 etag = "21ad4ffb7818e0a417db9337259c396e"
 
 [[releases]]
 version = "0.11.14"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.14-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.14-darwin-x64.tar.gz"
 etag = "002ed72f0088c5dddbb1be01c2af0638"
 
 [[releases]]
 version = "0.11.15"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.15-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.15-darwin-x64.tar.gz"
 etag = "e3d0eb56dd809049e5702c73d4045a78"
 
 [[releases]]
 version = "0.11.16"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.16-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.16-darwin-x64.tar.gz"
 etag = "73634a80432dbbfacada263f6cec36cb"
 
 [[releases]]
 version = "0.11.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.2-darwin-x64.tar.gz"
 etag = "3feeee79ae46834e75572c625c0f0542"
 
 [[releases]]
 version = "0.11.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.3-darwin-x64.tar.gz"
 etag = "1e56e19afbd95bd795c20056eed4933a"
 
 [[releases]]
 version = "0.11.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.4-darwin-x64.tar.gz"
 etag = "ae5c57a9f852fbc9529423e65aa8b696"
 
 [[releases]]
 version = "0.11.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.5-darwin-x64.tar.gz"
 etag = "d50ee079ce3cbb49d3f41afef4fecb23"
 
 [[releases]]
 version = "0.11.6"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.6-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.6-darwin-x64.tar.gz"
 etag = "6b2ccf9eb054ee10d0673b9357c9a297"
 
 [[releases]]
 version = "0.11.7"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.7-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.7-darwin-x64.tar.gz"
 etag = "196d5b28789d1ee20e038193ef7a23de"
 
 [[releases]]
 version = "0.11.8"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.8-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.8-darwin-x64.tar.gz"
 etag = "d483c05cbb31924d3bdea30f26f49d23"
 
 [[releases]]
 version = "0.11.9"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.11.9-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.9-darwin-x64.tar.gz"
 etag = "f89e4994ab1c7277a78a0e6d4c0899c3"
 
 [[releases]]
 version = "0.12.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.0-darwin-x64.tar.gz"
 etag = "1d8d0e3c3c0ccfd45c055b42c26c1ca7"
 
 [[releases]]
 version = "0.12.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.1-darwin-x64.tar.gz"
 etag = "592ba6e0e99bd8fc58e448f5d9e500cc"
 
 [[releases]]
 version = "0.12.10"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.10-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.10-darwin-x64.tar.gz"
 etag = "d9ee01290fc87e63206fb30b5069bb11"
 
 [[releases]]
 version = "0.12.11"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.11-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.11-darwin-x64.tar.gz"
 etag = "416dac6ff5d849922bf1d3e0d724bae4"
 
 [[releases]]
 version = "0.12.12"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.12-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.12-darwin-x64.tar.gz"
 etag = "ef7e7ab15d21c2d2648293937d0ae44a"
 
 [[releases]]
 version = "0.12.13"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.13-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.13-darwin-x64.tar.gz"
 etag = "c6803787452700a9ec319ec2286ff8de"
 
 [[releases]]
 version = "0.12.14"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.14-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.14-darwin-x64.tar.gz"
 etag = "e3205a937b4540885f1063f797fce988"
 
 [[releases]]
 version = "0.12.15"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.15-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.15-darwin-x64.tar.gz"
 etag = "419ace8c46216989e12a741a44a7731a"
 
 [[releases]]
 version = "0.12.16"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.16-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.16-darwin-x64.tar.gz"
 etag = "ee30295fa1aefbfb225463a3b8456363"
 
 [[releases]]
 version = "0.12.17"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.17-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.17-darwin-x64.tar.gz"
 etag = "b0b4f1030e12d2b512bbcf90732baf0d"
 
 [[releases]]
 version = "0.12.18"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.18-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.18-darwin-x64.tar.gz"
 etag = "49c80986b9d5b1acbf6ad8a1999b6cea"
 
 [[releases]]
 version = "0.12.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.2-darwin-x64.tar.gz"
 etag = "fb2fd0e602bc4c0ee4daaff5dac200c6"
 
 [[releases]]
 version = "0.12.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.3-darwin-x64.tar.gz"
 etag = "e35219a458ddb2e9e6c24d119b02d1b3"
 
 [[releases]]
 version = "0.12.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.4-darwin-x64.tar.gz"
 etag = "b9f311cd43f3e51ac4123f7750989d95"
 
 [[releases]]
 version = "0.12.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.5-darwin-x64.tar.gz"
 etag = "0d7ed0f9aab35c791b8064f18b6e2745"
 
 [[releases]]
 version = "0.12.6"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.6-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.6-darwin-x64.tar.gz"
 etag = "f435cb7650ae7d4019b51e08c4d62d65"
 
 [[releases]]
 version = "0.12.7"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.7-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.7-darwin-x64.tar.gz"
 etag = "ca4897256e00f5b8523cb84e85ad83ea"
 
 [[releases]]
 version = "0.12.8"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.8-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.8-darwin-x64.tar.gz"
 etag = "5c25cb525ac6f97b5c0c2eec00111623"
 
 [[releases]]
 version = "0.12.9"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.12.9-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.9-darwin-x64.tar.gz"
 etag = "45b61d6b3c5cdaac0f4046db0565ecbc"
 
 [[releases]]
 version = "0.8.10"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.10-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.10-darwin-x64.tar.gz"
 etag = "56dab27cc904791dd324a29e30fe8ae7"
 
 [[releases]]
 version = "0.8.11"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.11-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.11-darwin-x64.tar.gz"
 etag = "a35e1376822d0fbad51daadde7cabad7"
 
 [[releases]]
 version = "0.8.12"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.12-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.12-darwin-x64.tar.gz"
 etag = "60547b643e4f0966a20cf42407466563"
 
 [[releases]]
 version = "0.8.13"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.13-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.13-darwin-x64.tar.gz"
 etag = "61337c8953075670391a8752bda13bda"
 
 [[releases]]
 version = "0.8.14"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.14-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.14-darwin-x64.tar.gz"
 etag = "a2c406dddc355c67a6d56fc54d8d39bd"
 
 [[releases]]
 version = "0.8.15"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.15-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.15-darwin-x64.tar.gz"
 etag = "b1bf7b088912361e46b5138b64475516"
 
 [[releases]]
 version = "0.8.16"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.16-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.16-darwin-x64.tar.gz"
 etag = "face3eaa75cd5aba019ee978813c1d17"
 
 [[releases]]
 version = "0.8.17"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.17-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.17-darwin-x64.tar.gz"
 etag = "57832104e0536cb63412197159fe77cf"
 
 [[releases]]
 version = "0.8.18"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.18-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.18-darwin-x64.tar.gz"
 etag = "02ee6073e6a87f7c9c00dd602db07163"
 
 [[releases]]
 version = "0.8.19"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.19-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.19-darwin-x64.tar.gz"
 etag = "e8b346a4f69ae83767424550af3dd4d0"
 
 [[releases]]
 version = "0.8.20"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.20-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.20-darwin-x64.tar.gz"
 etag = "cb0c253f4fcca6b91614e5e56854b311"
 
 [[releases]]
 version = "0.8.21"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.21-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.21-darwin-x64.tar.gz"
 etag = "38319ebdc4d2d85d60344f483de0283b"
 
 [[releases]]
 version = "0.8.22"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.22-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.22-darwin-x64.tar.gz"
 etag = "fbf42b4daf46c9e116ed01fff61b4c23"
 
 [[releases]]
 version = "0.8.23"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.23-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.23-darwin-x64.tar.gz"
 etag = "3f6a2cb26cdf7f350b5d2e2ccea98c77"
 
 [[releases]]
 version = "0.8.24"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.24-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.24-darwin-x64.tar.gz"
 etag = "a42122be1f420bdf57c251babf5d8070"
 
 [[releases]]
 version = "0.8.25"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.25-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.25-darwin-x64.tar.gz"
 etag = "e89e8300224a071d31ca80c507b9a1f1"
 
 [[releases]]
 version = "0.8.26"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.26-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.26-darwin-x64.tar.gz"
 etag = "d280e8b57089db7620373b7d398dc39a"
 
 [[releases]]
 version = "0.8.27"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.27-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.27-darwin-x64.tar.gz"
 etag = "3028f490e2e457d67aeb8d4f2835fd33"
 
 [[releases]]
 version = "0.8.28"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.28-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.28-darwin-x64.tar.gz"
 etag = "6ab1225ea01032b87d2a9a08adb3402e"
 
 [[releases]]
 version = "0.8.6"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.6-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.6-darwin-x64.tar.gz"
 etag = "b5ff6ae04cbf8fe84bc0cffca9fdff7b"
 
 [[releases]]
 version = "0.8.7"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.7-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.7-darwin-x64.tar.gz"
 etag = "324266fbf25ba05282209f5bbd60ff11"
 
 [[releases]]
 version = "0.8.8"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.8-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.8-darwin-x64.tar.gz"
 etag = "084e6edf8e73a97344cea02fa868e3b1"
 
 [[releases]]
 version = "0.8.9"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.8.9-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.9-darwin-x64.tar.gz"
 etag = "07fe9ebaf6b620cd6ba74370c4f35882"
 
 [[releases]]
 version = "0.9.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.1-darwin-x64.tar.gz"
 etag = "50be3aa0d3ee2cede7b4ab972e5175d5"
 
 [[releases]]
 version = "0.9.10"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.10-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.10-darwin-x64.tar.gz"
 etag = "88120d7fa1717334114e4a80d0cb0365"
 
 [[releases]]
 version = "0.9.11"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.11-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.11-darwin-x64.tar.gz"
 etag = "795a3c869bdb384b34b68e6406bf145f"
 
 [[releases]]
 version = "0.9.12"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.12-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.12-darwin-x64.tar.gz"
 etag = "8a56c23f7a5e3724e1bface4398f83ba"
 
 [[releases]]
 version = "0.9.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.2-darwin-x64.tar.gz"
 etag = "0c9a0e751ee1b069c835039cc1116f15"
 
 [[releases]]
 version = "0.9.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.3-darwin-x64.tar.gz"
 etag = "8141db63871daaaada2db8b8982a1429"
 
 [[releases]]
 version = "0.9.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.4-darwin-x64.tar.gz"
 etag = "e9062b989187f679e81070773d041ca5"
 
 [[releases]]
 version = "0.9.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.5-darwin-x64.tar.gz"
 etag = "43c36503c316aee0bd66ea360e0d26e0"
 
 [[releases]]
 version = "0.9.6"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.6-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.6-darwin-x64.tar.gz"
 etag = "f31a916da408a2c33e2902e9c393be97"
 
 [[releases]]
 version = "0.9.7"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.7-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.7-darwin-x64.tar.gz"
 etag = "acb9e55c00a49b1b5ef1226b3b66e327"
 
 [[releases]]
 version = "0.9.8"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.8-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.8-darwin-x64.tar.gz"
 etag = "077b15f7b31a1143e008f8ca3a2a747a"
 
 [[releases]]
 version = "0.9.9"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v0.9.9-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.9-darwin-x64.tar.gz"
 etag = "fda6cf91f58e44dfa9686915ba00b29f"
 
 [[releases]]
 version = "10.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.0.0-darwin-x64.tar.gz"
 etag = "489d0568ea937a3e5041fad18649b51e"
 
 [[releases]]
 version = "10.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.1.0-darwin-x64.tar.gz"
 etag = "2dd881e36eb28179b05668eb2f7ccb42"
 
 [[releases]]
 version = "10.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.10.0-darwin-x64.tar.gz"
 etag = "c442bca910c01b931661a9e91186e8ef"
 
 [[releases]]
 version = "10.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.11.0-darwin-x64.tar.gz"
 etag = "b58541d7e9eee8eda30fd5b67b4a9f11"
 
 [[releases]]
 version = "10.12.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.12.0-darwin-x64.tar.gz"
 etag = "9a153115f11dd2c076c2d72a55c5a9fc"
 
 [[releases]]
 version = "10.13.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.13.0-darwin-x64.tar.gz"
 etag = "65d2400b91b5ba7bda813572bf08442f"
 
 [[releases]]
 version = "10.14.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.14.0-darwin-x64.tar.gz"
 etag = "b0eb309e9a7e749117c42a9725d5f769"
 
 [[releases]]
 version = "10.14.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.14.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.14.1-darwin-x64.tar.gz"
 etag = "002f5683eb664e14d26a54330334b320"
 
 [[releases]]
 version = "10.14.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.14.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.14.2-darwin-x64.tar.gz"
 etag = "77d55c4112ee4b66a6b2ce3eb8ead6c3"
 
 [[releases]]
 version = "10.15.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.15.0-darwin-x64.tar.gz"
 etag = "e640e01d12d42797f80434f2475492b4"
 
 [[releases]]
 version = "10.15.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.15.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.15.1-darwin-x64.tar.gz"
 etag = "9d6698c8132924a9b98e035295959cd1"
 
 [[releases]]
 version = "10.15.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.15.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.15.2-darwin-x64.tar.gz"
 etag = "515022c63ae40f50929c11795703309d"
 
 [[releases]]
 version = "10.15.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.15.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.15.3-darwin-x64.tar.gz"
 etag = "03828afe26a0926962a4390d7d956127"
 
 [[releases]]
 version = "10.16.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.16.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.16.0-darwin-x64.tar.gz"
 etag = "a286ed1c4acfffa9124d9df0ac273fd6"
 
 [[releases]]
 version = "10.16.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.16.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.16.1-darwin-x64.tar.gz"
 etag = "ebaf420919ef4e764ca05d27139af28b"
 
 [[releases]]
 version = "10.16.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.16.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.16.2-darwin-x64.tar.gz"
 etag = "5f5af433d60067ddd955012313f1bcc6"
 
 [[releases]]
 version = "10.16.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.16.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.16.3-darwin-x64.tar.gz"
 etag = "5f419fa2f5a19bf880416f44cd147749"
 
 [[releases]]
 version = "10.17.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.17.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.17.0-darwin-x64.tar.gz"
 etag = "d829b260a537d5124b632b53cfbb7cd4"
 
 [[releases]]
 version = "10.18.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.18.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.18.0-darwin-x64.tar.gz"
 etag = "4a899925537f4e935c55e69c3ec9d47b"
 
 [[releases]]
 version = "10.18.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.18.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.18.1-darwin-x64.tar.gz"
 etag = "82848bb435183a6264b6470c27aae2d9"
 
 [[releases]]
 version = "10.19.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.19.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.19.0-darwin-x64.tar.gz"
 etag = "e0a89df131a21f5659bd05304ffdca36"
 
 [[releases]]
 version = "10.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.2.0-darwin-x64.tar.gz"
 etag = "17381719cc670ddfb4ad94bd61d892ab"
 
 [[releases]]
 version = "10.2.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.2.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.2.1-darwin-x64.tar.gz"
 etag = "6227f1a0e4016a3bb4812edf1d04a5ec"
 
 [[releases]]
 version = "10.20.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.20.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.20.0-darwin-x64.tar.gz"
 etag = "9333a777f0a74f5b7ea87550d74262c3-3"
 
 [[releases]]
 version = "10.20.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.20.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.20.1-darwin-x64.tar.gz"
 etag = "878c0c4323e31dd9106d756abb0b9002-3"
 
 [[releases]]
 version = "10.21.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.21.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.21.0-darwin-x64.tar.gz"
 etag = "3df5c0dec214c35f2d731726733b1c6a-3"
 
 [[releases]]
 version = "10.22.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.22.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.22.0-darwin-x64.tar.gz"
 etag = "0037544c07933ec1d5da9c33092f6831-3"
 
 [[releases]]
 version = "10.22.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.22.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.22.1-darwin-x64.tar.gz"
 etag = "d32be387d0f7f21abf2642e23d47b19c-3"
 
 [[releases]]
 version = "10.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.3.0-darwin-x64.tar.gz"
 etag = "b60c4138233e6dbd81136991478d3ce8"
 
 [[releases]]
 version = "10.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.4.0-darwin-x64.tar.gz"
 etag = "fdfe32890237401b1074b76f4531d7af"
 
 [[releases]]
 version = "10.4.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.4.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.4.1-darwin-x64.tar.gz"
 etag = "a2f3db9e73ef1289b98fab580efd1829"
 
 [[releases]]
 version = "10.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.5.0-darwin-x64.tar.gz"
 etag = "ab1b49dcd29791ef0183c6aa4cb00885"
 
 [[releases]]
 version = "10.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.6.0-darwin-x64.tar.gz"
 etag = "48ae42cdab07fa348621cf5525847605"
 
 [[releases]]
 version = "10.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.7.0-darwin-x64.tar.gz"
 etag = "1339db7e1ce0b9a626f49451319ea4c5"
 
 [[releases]]
 version = "10.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.8.0-darwin-x64.tar.gz"
 etag = "cceaa14bbe1408de6a2b00c4b941205b"
 
 [[releases]]
 version = "10.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.9.0-darwin-x64.tar.gz"
 etag = "589b2b59735c2756fa3ab64cdfb1f1a9"
 
 [[releases]]
 version = "11.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.0.0-darwin-x64.tar.gz"
 etag = "ecc3e19ec147553f53a1d55cd7985054"
 
 [[releases]]
 version = "11.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.1.0-darwin-x64.tar.gz"
 etag = "58249d44f40a5a5299fa83f3fd1ee36c"
 
 [[releases]]
 version = "11.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.10.0-darwin-x64.tar.gz"
 etag = "bf5fd780114c9e7981146a4909e2ffde"
 
 [[releases]]
 version = "11.10.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.10.1-darwin-x64.tar.gz"
 etag = "80ac0921ffeca782eabae1e543cf5a1d"
 
 [[releases]]
 version = "11.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.11.0-darwin-x64.tar.gz"
 etag = "736858f23fb79479af941461817424a4"
 
 [[releases]]
 version = "11.12.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.12.0-darwin-x64.tar.gz"
 etag = "77636576d7ba54c52a984e9891413b16"
 
 [[releases]]
 version = "11.13.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.13.0-darwin-x64.tar.gz"
 etag = "56d811e1709ae0ba4b591ee2489003c3"
 
 [[releases]]
 version = "11.14.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.14.0-darwin-x64.tar.gz"
 etag = "59478d7f4976d5d4248b8e6d24b19270"
 
 [[releases]]
 version = "11.15.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.15.0-darwin-x64.tar.gz"
 etag = "3cc7ff95006b05b6d8cb7b727388c19b"
 
 [[releases]]
 version = "11.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.2.0-darwin-x64.tar.gz"
 etag = "3dbded714a5cebaf5ac447c4484e32fe"
 
 [[releases]]
 version = "11.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.3.0-darwin-x64.tar.gz"
 etag = "d15a0a760aeb7fcd4c0b6a25529759c0"
 
 [[releases]]
 version = "11.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.4.0-darwin-x64.tar.gz"
 etag = "0badf49f8d6aa6d8132916052547865d"
 
 [[releases]]
 version = "11.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.5.0-darwin-x64.tar.gz"
 etag = "f1968a180739aec5a35e7778b77d4bea"
 
 [[releases]]
 version = "11.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.6.0-darwin-x64.tar.gz"
 etag = "bc6044faecbd1a216d11ab8ac05f3a41"
 
 [[releases]]
 version = "11.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.7.0-darwin-x64.tar.gz"
 etag = "ccea4d6956bf66ce6af96cefb93d1f04"
 
 [[releases]]
 version = "11.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.8.0-darwin-x64.tar.gz"
 etag = "d7d522f5bf1e1821d258cdb3ebf87e7c"
 
 [[releases]]
 version = "11.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v11.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.9.0-darwin-x64.tar.gz"
 etag = "1dce07e744fd518a9d3bf1611c0e721a"
 
 [[releases]]
 version = "12.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.0.0-darwin-x64.tar.gz"
 etag = "9bd5425992b3e8b27542dd0017140feb"
 
 [[releases]]
 version = "12.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.1.0-darwin-x64.tar.gz"
 etag = "f6464cf5569dcd84a7930dd463636418"
 
 [[releases]]
 version = "12.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.10.0-darwin-x64.tar.gz"
 etag = "ae17569da0e787b77f7811b255c528cb"
 
 [[releases]]
 version = "12.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.11.0-darwin-x64.tar.gz"
 etag = "cfb6ddede26476faa95e4e445dee6254"
 
 [[releases]]
 version = "12.11.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.11.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.11.1-darwin-x64.tar.gz"
 etag = "870f6467a4e95f1d3b29f08f8158dde1"
 
 [[releases]]
 version = "12.12.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.12.0-darwin-x64.tar.gz"
 etag = "72b892d17a1de38b40cddd7fdb39e8e7"
 
 [[releases]]
 version = "12.13.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.13.0-darwin-x64.tar.gz"
 etag = "e5cb03e25d7996ae24a230a4512c5817"
 
 [[releases]]
 version = "12.13.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.13.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.13.1-darwin-x64.tar.gz"
 etag = "1df6f5862c67e5cf377ee8661ed730f4"
 
 [[releases]]
 version = "12.14.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.14.0-darwin-x64.tar.gz"
 etag = "1ec6c21238c6af4b8c2cb20ae6630df8"
 
 [[releases]]
 version = "12.14.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.14.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.14.1-darwin-x64.tar.gz"
 etag = "d98df77c47b0b83b3d0cb04d97374e90"
 
 [[releases]]
 version = "12.15.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.15.0-darwin-x64.tar.gz"
 etag = "8bf0ff87a9cd53de20f9905a4266b445"
 
 [[releases]]
 version = "12.16.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.16.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.16.0-darwin-x64.tar.gz"
 etag = "5504043d93837eeee1fb3dbfaa52eaa6"
 
 [[releases]]
 version = "12.16.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.16.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.16.1-darwin-x64.tar.gz"
 etag = "3bcfe9b7553b9836878c87394d585fbd"
 
 [[releases]]
 version = "12.16.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.16.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.16.2-darwin-x64.tar.gz"
 etag = "51645a099c321d971733a645e37847bc"
 
 [[releases]]
 version = "12.16.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.16.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.16.3-darwin-x64.tar.gz"
 etag = "db0e17a2dffe405e6077c817131a823d-3"
 
 [[releases]]
 version = "12.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.2.0-darwin-x64.tar.gz"
 etag = "d95b66b6c81e4bbddd94b7ddfa4a4a2f"
 
 [[releases]]
 version = "12.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.3.0-darwin-x64.tar.gz"
 etag = "3b55e52fc17ba959ce339c7fdcee0f56"
 
 [[releases]]
 version = "12.3.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.3.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.3.1-darwin-x64.tar.gz"
 etag = "67a1cf0fd7d2b623ff3503f5026b21d4"
 
 [[releases]]
 version = "12.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.4.0-darwin-x64.tar.gz"
 etag = "1327d9429ca77b14ce14b52b622031f2"
 
 [[releases]]
 version = "12.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.5.0-darwin-x64.tar.gz"
 etag = "ace7c880c8178bbdbdc2efae749a9ac7"
 
 [[releases]]
 version = "12.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.6.0-darwin-x64.tar.gz"
 etag = "cf1326bb477c17e4b2cd660a9b450143"
 
 [[releases]]
 version = "12.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.7.0-darwin-x64.tar.gz"
 etag = "336ee36ab6bcfd2c40f4a1a943f03b84"
 
 [[releases]]
 version = "12.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.8.0-darwin-x64.tar.gz"
 etag = "a6bf0fad73dd99a3eb92c8dffdf73a9e"
 
 [[releases]]
 version = "12.8.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.8.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.8.1-darwin-x64.tar.gz"
 etag = "288f89d653725c41cb148d9724ff09ab"
 
 [[releases]]
 version = "12.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.9.0-darwin-x64.tar.gz"
 etag = "db54bea21ff05b1faf4515b62df166cc"
 
 [[releases]]
 version = "12.9.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v12.9.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.9.1-darwin-x64.tar.gz"
 etag = "5095b55f99b9d740343ef7f2bd6af0b5"
 
 [[releases]]
 version = "13.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.0.0-darwin-x64.tar.gz"
 etag = "c29a2d0512dad49563013dcb8d2388a3"
 
 [[releases]]
 version = "13.0.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.0.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.0.1-darwin-x64.tar.gz"
 etag = "38d4e72e84dd08cfdf155e165df8c30d"
 
 [[releases]]
 version = "13.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.1.0-darwin-x64.tar.gz"
 etag = "5b3a440dc47f3a8be6c0bae473dbb529"
 
 [[releases]]
 version = "13.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.10.0-darwin-x64.tar.gz"
 etag = "ace887b3fabcb29c467748b45cceac48"
 
 [[releases]]
 version = "13.10.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.10.1-darwin-x64.tar.gz"
 etag = "6d5164fbe7b24fc12c238ee28722582c"
 
 [[releases]]
 version = "13.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.11.0-darwin-x64.tar.gz"
 etag = "3267c943b8539cb57aafb368c44f683d"
 
 [[releases]]
 version = "13.12.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.12.0-darwin-x64.tar.gz"
 etag = "aa056d40fcfe7f63caa212a8a6da0e69"
 
 [[releases]]
 version = "13.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.2.0-darwin-x64.tar.gz"
 etag = "5357dc8b60f0467c37f5408667fc1915"
 
 [[releases]]
 version = "13.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.3.0-darwin-x64.tar.gz"
 etag = "a2090fb5b2388c6e3a970d66a982b267"
 
 [[releases]]
 version = "13.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.4.0-darwin-x64.tar.gz"
 etag = "253f2ddb1e1507e16793df039d5c9282"
 
 [[releases]]
 version = "13.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.5.0-darwin-x64.tar.gz"
 etag = "a3660b576ee4e0afd9d631819748d7eb"
 
 [[releases]]
 version = "13.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.6.0-darwin-x64.tar.gz"
 etag = "4b02b6953ad7f299be3047e9337abbd9"
 
 [[releases]]
 version = "13.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.7.0-darwin-x64.tar.gz"
 etag = "e109ac3d1a92a3cc147b4be24c8d96e8"
 
 [[releases]]
 version = "13.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.8.0-darwin-x64.tar.gz"
 etag = "d314a378a6622eacdd7bd1cd138fc22f"
 
 [[releases]]
 version = "13.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v13.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.9.0-darwin-x64.tar.gz"
 etag = "25433a0b64a3b71b981656b01b3b0031"
 
 [[releases]]
 version = "4.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.0.0-darwin-x64.tar.gz"
 etag = "fd64ae33e7757293e6fe1acf660fd8fa"
 
 [[releases]]
 version = "4.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.1.0-darwin-x64.tar.gz"
 etag = "8ca7483120975d1510ab651d56630941"
 
 [[releases]]
 version = "4.1.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.1.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.1.1-darwin-x64.tar.gz"
 etag = "8a51c6314c0e43a911cd214bb34ca383"
 
 [[releases]]
 version = "4.1.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.1.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.1.2-darwin-x64.tar.gz"
 etag = "31a3ee2f51bb2018501048f543ea31c7"
 
 [[releases]]
 version = "4.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.0-darwin-x64.tar.gz"
 etag = "7372a81b1c6b8340c99421d55a0eda71"
 
 [[releases]]
 version = "4.2.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.2.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.1-darwin-x64.tar.gz"
 etag = "1570be16287504d7bd5410c6b047cf0c"
 
 [[releases]]
 version = "4.2.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.2.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.2-darwin-x64.tar.gz"
 etag = "7fa842ce2a6070b09e0dc774d5d9f81c"
 
 [[releases]]
 version = "4.2.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.2.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.3-darwin-x64.tar.gz"
 etag = "ba6c1db01e0fc29c94106d294959f63e"
 
 [[releases]]
 version = "4.2.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.2.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.4-darwin-x64.tar.gz"
 etag = "3a68493cd518e34f9cc913ea351b0d76"
 
 [[releases]]
 version = "4.2.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.2.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.5-darwin-x64.tar.gz"
 etag = "14934b5f60737cd3e2ee01fa5fad16e7"
 
 [[releases]]
 version = "4.2.6"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.2.6-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.6-darwin-x64.tar.gz"
 etag = "cab166afc09599e5b6946c2246aff0bf"
 
 [[releases]]
 version = "4.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.3.0-darwin-x64.tar.gz"
 etag = "e83bc0721bbd693d87e6d4a5739eff16"
 
 [[releases]]
 version = "4.3.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.3.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.3.1-darwin-x64.tar.gz"
 etag = "9a55c96b5c23e9d317cb7f5db2a8d9fc"
 
 [[releases]]
 version = "4.3.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.3.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.3.2-darwin-x64.tar.gz"
 etag = "1a621360147e89d351dd7262652d6f84"
 
 [[releases]]
 version = "4.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.0-darwin-x64.tar.gz"
 etag = "5392ac884a1e0acdf0011eb7fe6d10c3"
 
 [[releases]]
 version = "4.4.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.4.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.1-darwin-x64.tar.gz"
 etag = "b9ea0c459baa3ebea63cf59ae60373c0"
 
 [[releases]]
 version = "4.4.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.4.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.2-darwin-x64.tar.gz"
 etag = "b9acc9f1ff3bf474bc33e92b78a06fd3"
 
 [[releases]]
 version = "4.4.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.4.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.3-darwin-x64.tar.gz"
 etag = "32e4ce24aefbdd19e9b2306a8a0d6d3b"
 
 [[releases]]
 version = "4.4.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.4.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.4-darwin-x64.tar.gz"
 etag = "1f4c9fd5f68f7b626eb0d48c562d3250"
 
 [[releases]]
 version = "4.4.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.4.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.5-darwin-x64.tar.gz"
 etag = "553d2f47ade9312a3cb23192df927603"
 
 [[releases]]
 version = "4.4.6"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.4.6-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.6-darwin-x64.tar.gz"
 etag = "9db907435908ae769f0188605b4ce385"
 
 [[releases]]
 version = "4.4.7"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.4.7-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.7-darwin-x64.tar.gz"
 etag = "b2e25ef68900d66cca801bd149ad5fb4"
 
 [[releases]]
 version = "4.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.5.0-darwin-x64.tar.gz"
 etag = "5260810ee7c15d615552257a0d38a15d"
 
 [[releases]]
 version = "4.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.6.0-darwin-x64.tar.gz"
 etag = "89e85f848a731326a993a29cfe225db8"
 
 [[releases]]
 version = "4.6.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.6.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.6.1-darwin-x64.tar.gz"
 etag = "535ebadbee21b7a725143686bc662bcc"
 
 [[releases]]
 version = "4.6.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.6.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.6.2-darwin-x64.tar.gz"
 etag = "e20736b12e738b28c40e322bce66c399"
 
 [[releases]]
 version = "4.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.7.0-darwin-x64.tar.gz"
 etag = "d6f8e02a4a60e320e5cb7c8795a5a96f"
 
 [[releases]]
 version = "4.7.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.7.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.7.1-darwin-x64.tar.gz"
 etag = "0545346f38c803f039f8f63cbe9d8327"
 
 [[releases]]
 version = "4.7.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.7.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.7.2-darwin-x64.tar.gz"
 etag = "499521a44c1b2c174c70e0a903287179"
 
 [[releases]]
 version = "4.7.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.7.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.7.3-darwin-x64.tar.gz"
 etag = "36ec677543797d5d80cafc3e76cf788c"
 
 [[releases]]
 version = "4.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.0-darwin-x64.tar.gz"
 etag = "2160ab2fc4b3d97e30923c8ce73ff6e8"
 
 [[releases]]
 version = "4.8.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.8.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.1-darwin-x64.tar.gz"
 etag = "04aedde750aa1bf01f16f9d0ae5f0c9c"
 
 [[releases]]
 version = "4.8.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.8.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.2-darwin-x64.tar.gz"
 etag = "cd776a58cf3b1ba65f295094ab958087"
 
 [[releases]]
 version = "4.8.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.8.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.3-darwin-x64.tar.gz"
 etag = "d98c95d3735f911a836c6dca72416f00"
 
 [[releases]]
 version = "4.8.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.8.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.4-darwin-x64.tar.gz"
 etag = "591d6e6146d29ae62a1b9f885b72f652"
 
 [[releases]]
 version = "4.8.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.8.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.5-darwin-x64.tar.gz"
 etag = "9a8a87347201348b756baf733d88c3a1"
 
 [[releases]]
 version = "4.8.6"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.8.6-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.6-darwin-x64.tar.gz"
 etag = "9a270f3accb5c13ee9a7d238c6b630ec"
 
 [[releases]]
 version = "4.8.7"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.8.7-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.7-darwin-x64.tar.gz"
 etag = "3ec65a0ca5617bafad196f22487b4e92"
 
 [[releases]]
 version = "4.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.9.0-darwin-x64.tar.gz"
 etag = "ab0e0f28d3899e69bc8695ded2f78cda"
 
 [[releases]]
 version = "4.9.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v4.9.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.9.1-darwin-x64.tar.gz"
 etag = "45e1a8ac9e641a82acf976516f435842"
 
 [[releases]]
 version = "5.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.0.0-darwin-x64.tar.gz"
 etag = "b30997758fa2e89cca5434b06cbed440"
 
 [[releases]]
 version = "5.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.1.0-darwin-x64.tar.gz"
 etag = "d531d26ebec53b1ae00e99af25ae2a18"
 
 [[releases]]
 version = "5.1.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.1.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.1.1-darwin-x64.tar.gz"
 etag = "c52f962aeb14444c44c12280056f4cc3"
 
 [[releases]]
 version = "5.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.10.0-darwin-x64.tar.gz"
 etag = "9a8d8014841ffff463810b4d1c665f70"
 
 [[releases]]
 version = "5.10.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.10.1-darwin-x64.tar.gz"
 etag = "1dcc9d712dd2df5df88623c72309bf81"
 
 [[releases]]
 version = "5.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.11.0-darwin-x64.tar.gz"
 etag = "c4d12d0bd233b1674de585e2c50896d2"
 
 [[releases]]
 version = "5.11.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.11.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.11.1-darwin-x64.tar.gz"
 etag = "7106c928dabe9fde7159bc209e0115cc"
 
 [[releases]]
 version = "5.12.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.12.0-darwin-x64.tar.gz"
 etag = "46f848fd273ad87f5b9250d8312b7387"
 
 [[releases]]
 version = "5.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.2.0-darwin-x64.tar.gz"
 etag = "db1ae727932b933053862880fa6e5611"
 
 [[releases]]
 version = "5.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.3.0-darwin-x64.tar.gz"
 etag = "cd724378cf7f2c38934ef9361fdd3e9c"
 
 [[releases]]
 version = "5.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.4.0-darwin-x64.tar.gz"
 etag = "8e797a6e476e071fa09f59275f04cca3"
 
 [[releases]]
 version = "5.4.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.4.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.4.1-darwin-x64.tar.gz"
 etag = "4a8f9ebb26b5c6858799a32caf90a8ad"
 
 [[releases]]
 version = "5.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.5.0-darwin-x64.tar.gz"
 etag = "7f5c3e0cfc6866d99633c238139f1957"
 
 [[releases]]
 version = "5.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.6.0-darwin-x64.tar.gz"
 etag = "6644c279d0c9e178e87fe5c9b4ac3887"
 
 [[releases]]
 version = "5.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.7.0-darwin-x64.tar.gz"
 etag = "cbfa878e61eeedc29090e96e74783954"
 
 [[releases]]
 version = "5.7.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.7.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.7.1-darwin-x64.tar.gz"
 etag = "0db5fb88acd4ba2d65ba68459297c595"
 
 [[releases]]
 version = "5.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.8.0-darwin-x64.tar.gz"
 etag = "c939f95036066bd7f2629a2804c88e39"
 
 [[releases]]
 version = "5.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.9.0-darwin-x64.tar.gz"
 etag = "387926afe9499ffbe8c8417ed452936a"
 
 [[releases]]
 version = "5.9.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v5.9.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.9.1-darwin-x64.tar.gz"
 etag = "25ea4f9c9f6752e9464ebb876f588915"
 
 [[releases]]
 version = "6.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.0.0-darwin-x64.tar.gz"
 etag = "484a3058a2f75664f0c74cae4198ef99"
 
 [[releases]]
 version = "6.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.1.0-darwin-x64.tar.gz"
 etag = "97c09ca684eb6c3e8bf1a7dbbdf4394d"
 
 [[releases]]
 version = "6.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.10.0-darwin-x64.tar.gz"
 etag = "cdcd0f8f7bd8ba7665a3a645a32f9140"
 
 [[releases]]
 version = "6.10.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.10.1-darwin-x64.tar.gz"
 etag = "72d70fe5e6fe2c4123c9d313c8f852a1"
 
 [[releases]]
 version = "6.10.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.10.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.10.2-darwin-x64.tar.gz"
 etag = "df91310e47f2442b23e146cc02a6f825"
 
 [[releases]]
 version = "6.10.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.10.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.10.3-darwin-x64.tar.gz"
 etag = "c4cc8c509739f40960828aa9c87ef84a"
 
 [[releases]]
 version = "6.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.0-darwin-x64.tar.gz"
 etag = "af9fcf8ac3c2bd248c04f953488bce39"
 
 [[releases]]
 version = "6.11.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.11.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.1-darwin-x64.tar.gz"
 etag = "5250d8876d1d36fb31f08a149de6975b"
 
 [[releases]]
 version = "6.11.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.11.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.2-darwin-x64.tar.gz"
 etag = "1dc8b1cada5c2f0c651a5aa964dd8352"
 
 [[releases]]
 version = "6.11.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.11.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.3-darwin-x64.tar.gz"
 etag = "4ac55d1366cd86c93c25fdcd7cbf8e77"
 
 [[releases]]
 version = "6.11.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.11.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.4-darwin-x64.tar.gz"
 etag = "5ae64364557a952c05077c47bad7c0e4"
 
 [[releases]]
 version = "6.11.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.11.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.5-darwin-x64.tar.gz"
 etag = "2f2759d8b7a5d7827ec81ad38559f436"
 
 [[releases]]
 version = "6.12.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.12.0-darwin-x64.tar.gz"
 etag = "1ac3996e047fecba6a795720d910f254"
 
 [[releases]]
 version = "6.12.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.12.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.12.1-darwin-x64.tar.gz"
 etag = "01c3d1dcd37be7a64f89739300f75e6f"
 
 [[releases]]
 version = "6.12.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.12.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.12.2-darwin-x64.tar.gz"
 etag = "2647861a42f2052d31601b651cfd722b"
 
 [[releases]]
 version = "6.12.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.12.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.12.3-darwin-x64.tar.gz"
 etag = "1c5c373a464ed3b6d7de76b13f5dbc8a"
 
 [[releases]]
 version = "6.13.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.13.0-darwin-x64.tar.gz"
 etag = "8739711a000b22819add0f4a5c9ce90f"
 
 [[releases]]
 version = "6.13.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.13.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.13.1-darwin-x64.tar.gz"
 etag = "9a17508fc8573c92095fa7dfa9c20015"
 
 [[releases]]
 version = "6.14.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.0-darwin-x64.tar.gz"
 etag = "91b1b235028d51939f983d8682d2160a"
 
 [[releases]]
 version = "6.14.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.14.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.1-darwin-x64.tar.gz"
 etag = "8e28708fd099ccd09aee2c7bd4132b12"
 
 [[releases]]
 version = "6.14.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.14.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.2-darwin-x64.tar.gz"
 etag = "32708275cb56de819a9e8422b553e0ca"
 
 [[releases]]
 version = "6.14.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.14.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.3-darwin-x64.tar.gz"
 etag = "7351e1f2ae8bcc326c0898e25b71407f"
 
 [[releases]]
 version = "6.14.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.14.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.4-darwin-x64.tar.gz"
 etag = "0bb04f12c5041367429175a765e0f948"
 
 [[releases]]
 version = "6.15.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.15.0-darwin-x64.tar.gz"
 etag = "d8db6fa9ab2757996604a0b6e5af31d4"
 
 [[releases]]
 version = "6.15.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.15.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.15.1-darwin-x64.tar.gz"
 etag = "f4c860c829f4749ee9196f94239cd2ad"
 
 [[releases]]
 version = "6.16.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.16.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.16.0-darwin-x64.tar.gz"
 etag = "ece449be5f8b9a7a5acc6d7c75d2a97e"
 
 [[releases]]
 version = "6.17.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.17.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.17.0-darwin-x64.tar.gz"
 etag = "0a3afceae5144b47d497c01d40e57fed"
 
 [[releases]]
 version = "6.17.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.17.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.17.1-darwin-x64.tar.gz"
 etag = "55394ba4babf46ec8eeded045c1c8c56"
 
 [[releases]]
 version = "6.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.2.0-darwin-x64.tar.gz"
 etag = "26c088c39aa083ce07422ccc7af6d825"
 
 [[releases]]
 version = "6.2.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.2.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.2.1-darwin-x64.tar.gz"
 etag = "1bdc85854a27b84c5f9ed0132217b62f"
 
 [[releases]]
 version = "6.2.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.2.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.2.2-darwin-x64.tar.gz"
 etag = "6d2ea41938c4ccee53bde9423b1991fc"
 
 [[releases]]
 version = "6.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.3.0-darwin-x64.tar.gz"
 etag = "11ad99b9cf675ace0da8ca880369a338"
 
 [[releases]]
 version = "6.3.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.3.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.3.1-darwin-x64.tar.gz"
 etag = "7ad393945bf4b90e2e4c8737035a8167"
 
 [[releases]]
 version = "6.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.4.0-darwin-x64.tar.gz"
 etag = "a39aea666fef161df8e515189d318bbd"
 
 [[releases]]
 version = "6.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.5.0-darwin-x64.tar.gz"
 etag = "44080b266b0312ed1ebe054538be520a"
 
 [[releases]]
 version = "6.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.6.0-darwin-x64.tar.gz"
 etag = "aaf636350e51238f9ebba403741df2ea"
 
 [[releases]]
 version = "6.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.7.0-darwin-x64.tar.gz"
 etag = "cdb82558b770dd763cb7d2f3c9364287"
 
 [[releases]]
 version = "6.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.8.0-darwin-x64.tar.gz"
 etag = "3a0f016ee726588d0e01131b4f779bae"
 
 [[releases]]
 version = "6.8.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.8.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.8.1-darwin-x64.tar.gz"
 etag = "f2789ba98dd571b18c652b9cfb3dde0c"
 
 [[releases]]
 version = "6.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.0-darwin-x64.tar.gz"
 etag = "c1fab809f9d2e6e4593e726f4977327b"
 
 [[releases]]
 version = "6.9.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.9.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.1-darwin-x64.tar.gz"
 etag = "3e48d814a8bf69b2f42cea40daa3d252"
 
 [[releases]]
 version = "6.9.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.9.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.2-darwin-x64.tar.gz"
 etag = "8cdf2b717e404a37872bd3d4f0aee6f6"
 
 [[releases]]
 version = "6.9.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.9.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.3-darwin-x64.tar.gz"
 etag = "681d8aeff603aec817d3aa17ef88e34f"
 
 [[releases]]
 version = "6.9.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.9.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.4-darwin-x64.tar.gz"
 etag = "cfc3eff29e952b7f5c15ec0bf10ff877"
 
 [[releases]]
 version = "6.9.5"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v6.9.5-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.5-darwin-x64.tar.gz"
 etag = "1c4e82ed6c23c454bec36533581b48bd"
 
 [[releases]]
 version = "7.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.0.0-darwin-x64.tar.gz"
 etag = "e54f28c735c95991f3988c6ac0b8962f"
 
 [[releases]]
 version = "7.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.1.0-darwin-x64.tar.gz"
 etag = "46423bbe029458f5d495fa89b0e3ac8e"
 
 [[releases]]
 version = "7.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.10.0-darwin-x64.tar.gz"
 etag = "8d9bca96db9aa8b3c55dda544bb16ea8"
 
 [[releases]]
 version = "7.10.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.10.1-darwin-x64.tar.gz"
 etag = "17cc75617a63682f5c6cf51db5d08c23"
 
 [[releases]]
 version = "7.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.2.0-darwin-x64.tar.gz"
 etag = "9adf88beaad7bb1822ba65ad57e47df4"
 
 [[releases]]
 version = "7.2.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.2.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.2.1-darwin-x64.tar.gz"
 etag = "65c680fef9e82f03d720df5b4774af88"
 
 [[releases]]
 version = "7.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.3.0-darwin-x64.tar.gz"
 etag = "6ae4dd30d0470e2ac2ee181e78548d99"
 
 [[releases]]
 version = "7.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.4.0-darwin-x64.tar.gz"
 etag = "7daf628c7d2e8ac005dad53b35982930"
 
 [[releases]]
 version = "7.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.5.0-darwin-x64.tar.gz"
 etag = "0d885817d79da925d7da51f2144a1347"
 
 [[releases]]
 version = "7.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.6.0-darwin-x64.tar.gz"
 etag = "4f907c748933a9e6cce841239d708098"
 
 [[releases]]
 version = "7.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.0-darwin-x64.tar.gz"
 etag = "1040d8bcfca44e0fe80d8d6b76036b4b"
 
 [[releases]]
 version = "7.7.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.7.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.1-darwin-x64.tar.gz"
 etag = "8faf4f7704f956143a7b527f12dc656d"
 
 [[releases]]
 version = "7.7.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.7.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.2-darwin-x64.tar.gz"
 etag = "e8638adc89c219708629e0fdba15cfb4"
 
 [[releases]]
 version = "7.7.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.7.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.3-darwin-x64.tar.gz"
 etag = "0b62b1c7c4e0d7c4c1de458c6cbd2cec"
 
 [[releases]]
 version = "7.7.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.7.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.4-darwin-x64.tar.gz"
 etag = "7149579b4722d2026fc56e3df1dd2f84"
 
 [[releases]]
 version = "7.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.8.0-darwin-x64.tar.gz"
 etag = "95726bc5cb0207f65f47dffe0d6a320a"
 
 [[releases]]
 version = "7.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v7.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.9.0-darwin-x64.tar.gz"
 etag = "c4b1f398626b760f3e0ceb1c04d178f1"
 
 [[releases]]
 version = "8.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.0.0-darwin-x64.tar.gz"
 etag = "d1014f2aa625d100861367f7f93be1d6"
 
 [[releases]]
 version = "8.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.0-darwin-x64.tar.gz"
 etag = "e70963faa98945377a197c5f663c3cd8"
 
 [[releases]]
 version = "8.1.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.1.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.1-darwin-x64.tar.gz"
 etag = "f6fefeacd699294845fa4b255f9ad19a"
 
 [[releases]]
 version = "8.1.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.1.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.2-darwin-x64.tar.gz"
 etag = "0e218035c649612f1d1af2a9472b8e1b"
 
 [[releases]]
 version = "8.1.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.1.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.3-darwin-x64.tar.gz"
 etag = "7b66582e833f35e18de5914a35c5254c"
 
 [[releases]]
 version = "8.1.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.1.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.4-darwin-x64.tar.gz"
 etag = "0455fa02b87a530d86bcd2e790d4cf49"
 
 [[releases]]
 version = "8.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.10.0-darwin-x64.tar.gz"
 etag = "2f8c39ba3d09bbf9af648dce29608e2a"
 
 [[releases]]
 version = "8.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.0-darwin-x64.tar.gz"
 etag = "ed495410c5288975b251739954a65038"
 
 [[releases]]
 version = "8.11.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.11.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.1-darwin-x64.tar.gz"
 etag = "346c568c2f2ab7e0b804f2122a313d86"
 
 [[releases]]
 version = "8.11.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.11.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.2-darwin-x64.tar.gz"
 etag = "a7a4c8391bf5543c64658d7e5776c936"
 
 [[releases]]
 version = "8.11.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.11.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.3-darwin-x64.tar.gz"
 etag = "6211a102bd368c4f83a869c8b9b4b184"
 
 [[releases]]
 version = "8.11.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.11.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.4-darwin-x64.tar.gz"
 etag = "c30ef72d947f05a2a803f7bfd32d511b"
 
 [[releases]]
 version = "8.12.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.12.0-darwin-x64.tar.gz"
 etag = "f1489227237471edcbe1f02505b49ce4"
 
 [[releases]]
 version = "8.13.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.13.0-darwin-x64.tar.gz"
 etag = "77934dd4a77be45aab6069a2e2cc327c"
 
 [[releases]]
 version = "8.14.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.14.0-darwin-x64.tar.gz"
 etag = "cd6cfa062d4f62e7126ad653f8ed42aa"
 
 [[releases]]
 version = "8.14.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.14.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.14.1-darwin-x64.tar.gz"
 etag = "bf1e2d414c9b8b4ced0fb921536396fd"
 
 [[releases]]
 version = "8.15.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.15.0-darwin-x64.tar.gz"
 etag = "2b8d16fd1b804feb2534e5dc9d513e4f"
 
 [[releases]]
 version = "8.15.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.15.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.15.1-darwin-x64.tar.gz"
 etag = "bf05532c0ef3262c5a40a4af4ee8273a"
 
 [[releases]]
 version = "8.16.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.16.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.16.0-darwin-x64.tar.gz"
 etag = "765e9fb02e197f83d80f8afddf97438d"
 
 [[releases]]
 version = "8.16.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.16.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.16.1-darwin-x64.tar.gz"
 etag = "0d5148d32e59dafe82c772ede431290c"
 
 [[releases]]
 version = "8.16.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.16.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.16.2-darwin-x64.tar.gz"
 etag = "f5e20750bcc2d5b8642c1d0221f5ae71"
 
 [[releases]]
 version = "8.17.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.17.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.17.0-darwin-x64.tar.gz"
 etag = "794cf5d11fa08aab90c69e879f82a117"
 
 [[releases]]
 version = "8.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.2.0-darwin-x64.tar.gz"
 etag = "765fff5503c98f32d56c6a6554a3bae1"
 
 [[releases]]
 version = "8.2.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.2.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.2.1-darwin-x64.tar.gz"
 etag = "8dab18d4f2443c267367571c1cfb1e5f"
 
 [[releases]]
 version = "8.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.3.0-darwin-x64.tar.gz"
 etag = "6264f0d513f85377f95c96a0c6f6ab63"
 
 [[releases]]
 version = "8.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.4.0-darwin-x64.tar.gz"
 etag = "1be19a34c6159d40d96d603c14065752"
 
 [[releases]]
 version = "8.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.5.0-darwin-x64.tar.gz"
 etag = "e57d9b45d1deece35bf55c00b8c5ee92"
 
 [[releases]]
 version = "8.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.6.0-darwin-x64.tar.gz"
 etag = "628fe6b9683cf36ca808a998f5b6088b"
 
 [[releases]]
 version = "8.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.7.0-darwin-x64.tar.gz"
 etag = "87aa0c918a883f1a452a738dfb32a1de"
 
 [[releases]]
 version = "8.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.8.0-darwin-x64.tar.gz"
 etag = "5253bd34ddafc932d97d159492c810b6"
 
 [[releases]]
 version = "8.8.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.8.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.8.1-darwin-x64.tar.gz"
 etag = "0ebbd83692c7cde9c5de3cb3b188387f"
 
 [[releases]]
 version = "8.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.0-darwin-x64.tar.gz"
 etag = "8fc9f439dd896a56d546ceadb948c5b2"
 
 [[releases]]
 version = "8.9.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.9.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.1-darwin-x64.tar.gz"
 etag = "e7bfe8c32ce33f3a740538b12d4caa4e"
 
 [[releases]]
 version = "8.9.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.9.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.2-darwin-x64.tar.gz"
 etag = "db46704db0fd7d3f2cb40668c6dad63c"
 
 [[releases]]
 version = "8.9.3"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.9.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.3-darwin-x64.tar.gz"
 etag = "5827bb2a09c8979471030dae5c9f2943"
 
 [[releases]]
 version = "8.9.4"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v8.9.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.4-darwin-x64.tar.gz"
 etag = "bdbd711d842acb83238471181aed5687"
 
 [[releases]]
 version = "9.0.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.0.0-darwin-x64.tar.gz"
 etag = "71d7195b015f66c96a2d4e2094071730"
 
 [[releases]]
 version = "9.1.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.1.0-darwin-x64.tar.gz"
 etag = "81331b134680cf948c94baad99ffc69a"
 
 [[releases]]
 version = "9.10.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.10.0-darwin-x64.tar.gz"
 etag = "6983f25374dfcac22057a7f5b200a2e2"
 
 [[releases]]
 version = "9.10.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.10.1-darwin-x64.tar.gz"
 etag = "ebee6028fd9640179794d7c464931739"
 
 [[releases]]
 version = "9.11.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.11.0-darwin-x64.tar.gz"
 etag = "e1ebd4c9d3b14b4d689b18bc7a480d7c"
 
 [[releases]]
 version = "9.11.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.11.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.11.1-darwin-x64.tar.gz"
 etag = "6818f9754f3aff86ee0b4c5ee0a339aa"
 
 [[releases]]
 version = "9.11.2"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.11.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.11.2-darwin-x64.tar.gz"
 etag = "fc9c918d1ce899d2a48e0062ca4eeae0"
 
 [[releases]]
 version = "9.2.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.2.0-darwin-x64.tar.gz"
 etag = "4fe4f9d2d17e7a961bb354bfe05fc449"
 
 [[releases]]
 version = "9.2.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.2.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.2.1-darwin-x64.tar.gz"
 etag = "24fa4bb6425e89df981b699fd7dfd720"
 
 [[releases]]
 version = "9.3.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.3.0-darwin-x64.tar.gz"
 etag = "e78be9b5b17670b2f415c608b685e0a2"
 
 [[releases]]
 version = "9.4.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.4.0-darwin-x64.tar.gz"
 etag = "00af859a02eab98f9dd0c6071695e0a0"
 
 [[releases]]
 version = "9.5.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.5.0-darwin-x64.tar.gz"
 etag = "1dd0ae5e8fd0ec2f65fc49a7970f2210"
 
 [[releases]]
 version = "9.6.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.6.0-darwin-x64.tar.gz"
 etag = "31e5b9ab8daa7da8cc9abb33a176bf13"
 
 [[releases]]
 version = "9.6.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.6.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.6.1-darwin-x64.tar.gz"
 etag = "495aacaf16d6d26bb00349721ed709c6"
 
 [[releases]]
 version = "9.7.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.7.0-darwin-x64.tar.gz"
 etag = "a3f595934fe6f421e4db49538baccf7c"
 
 [[releases]]
 version = "9.7.1"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.7.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.7.1-darwin-x64.tar.gz"
 etag = "b56bf1c43373b2aed7341032fad4d76f"
 
 [[releases]]
 version = "9.8.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.8.0-darwin-x64.tar.gz"
 etag = "03bad9803dbec17794938f54452cb261"
 
 [[releases]]
 version = "9.9.0"
 channel = "release"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v9.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.9.0-darwin-x64.tar.gz"
 etag = "a4c0ab67127c1dbd875dd5967cf9cde8"
 
 [[releases]]
 version = "0.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.0-linux-x64.tar.gz"
 etag = "a586044d93acb053d28dd6c0ddf95362"
 
 [[releases]]
 version = "0.10.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.1-linux-x64.tar.gz"
 etag = "f24a1fca96c717abc050f7526ee0101a"
 
 [[releases]]
 version = "0.10.10"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.10-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.10-linux-x64.tar.gz"
 etag = "561e25c025d922f99d158dac813a4526"
 
 [[releases]]
 version = "0.10.11"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.11-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.11-linux-x64.tar.gz"
 etag = "037ca782761ac9e704cc34ae9936de75"
 
 [[releases]]
 version = "0.10.12"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.12-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.12-linux-x64.tar.gz"
 etag = "e396dfb737f2c396af7e5c459aadce08"
 
 [[releases]]
 version = "0.10.13"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.13-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.13-linux-x64.tar.gz"
 etag = "1819a87f2ac617fb8281ae9efa6abe42"
 
 [[releases]]
 version = "0.10.14"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.14-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.14-linux-x64.tar.gz"
 etag = "3a5b08dc92cc54ece1645bb47a33331b"
 
 [[releases]]
 version = "0.10.15"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.15-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.15-linux-x64.tar.gz"
 etag = "1f0b836dd88c20854459a67a46aa0bef"
 
 [[releases]]
 version = "0.10.16"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.16-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.16-linux-x64.tar.gz"
 etag = "3e7980d5d2fe25323b81bf741d41487f"
 
 [[releases]]
 version = "0.10.17"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.17-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.17-linux-x64.tar.gz"
 etag = "d26df32e934b88f2db44223c0112ff7b"
 
 [[releases]]
 version = "0.10.18"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.18-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.18-linux-x64.tar.gz"
 etag = "7e01855f266474bb4063209e391d4c61"
 
 [[releases]]
 version = "0.10.19"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.19-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.19-linux-x64.tar.gz"
 etag = "8222dc2f5d62f3c0f663852aba0a2b83"
 
 [[releases]]
 version = "0.10.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.2-linux-x64.tar.gz"
 etag = "3a42e17ab298349e8236f72c4e39e97a"
 
 [[releases]]
 version = "0.10.20"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.20-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.20-linux-x64.tar.gz"
 etag = "37cfd1484fc621078b487ff7678ee2d4"
 
 [[releases]]
 version = "0.10.21"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.21-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.21-linux-x64.tar.gz"
 etag = "eab73809ba4ca2840e8dc5f21c873759"
 
 [[releases]]
 version = "0.10.22"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.22-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.22-linux-x64.tar.gz"
 etag = "942740fdeceaffe091688a04d87caf2c"
 
 [[releases]]
 version = "0.10.23"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.23-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.23-linux-x64.tar.gz"
 etag = "8d39492c18751aed2d77aae60ed8cd64"
 
 [[releases]]
 version = "0.10.24"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.24-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.24-linux-x64.tar.gz"
 etag = "e4e23b3ab9ee1d72f98baab8b6aa9aa4"
 
 [[releases]]
 version = "0.10.25"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.25-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.25-linux-x64.tar.gz"
 etag = "3738f6c24743f53f520d896ecff5e2b5"
 
 [[releases]]
 version = "0.10.26"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.26-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.26-linux-x64.tar.gz"
 etag = "5d41f981ed3bca6cebd4cfc4444537f1"
 
 [[releases]]
 version = "0.10.27"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.27-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.27-linux-x64.tar.gz"
 etag = "b2c15782d81eb11c7fed30152217b43d"
 
 [[releases]]
 version = "0.10.28"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.28-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.28-linux-x64.tar.gz"
 etag = "693afa81416da3632077bb5c24c168fd"
 
 [[releases]]
 version = "0.10.29"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.29-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.29-linux-x64.tar.gz"
 etag = "ea96bef3eda6ebfef38a76ada5ecd24a"
 
 [[releases]]
 version = "0.10.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.3-linux-x64.tar.gz"
 etag = "c9746a7e5ff82bd25fd719b8f36203c1"
 
 [[releases]]
 version = "0.10.30"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.30-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.30-linux-x64.tar.gz"
 etag = "e96aebef3cc0feaca0e9a7b73740ed01"
 
 [[releases]]
 version = "0.10.31"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.31-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.31-linux-x64.tar.gz"
 etag = "566ce38b1b0b46560ac8edd2f50ab087"
 
 [[releases]]
 version = "0.10.32"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.32-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.32-linux-x64.tar.gz"
 etag = "126ed002d88315b8d37cec1ee4915454"
 
 [[releases]]
 version = "0.10.33"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.33-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.33-linux-x64.tar.gz"
 etag = "1efad7c248b453ee6c62a706f6f86dbe"
 
 [[releases]]
 version = "0.10.34"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.34-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.34-linux-x64.tar.gz"
 etag = "03bc7cfbd7be3a093daaa23b76bafd46"
 
 [[releases]]
 version = "0.10.35"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.35-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.35-linux-x64.tar.gz"
 etag = "f3b33eed97772ce3a9341bbeb67511d7"
 
 [[releases]]
 version = "0.10.36"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.36-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.36-linux-x64.tar.gz"
 etag = "d40acc6f134bc2ab207e04011f452564"
 
 [[releases]]
 version = "0.10.37"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.37-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.37-linux-x64.tar.gz"
 etag = "ad487cb3d4d0fe2c710cffbd25e4f238"
 
 [[releases]]
 version = "0.10.38"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.38-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.38-linux-x64.tar.gz"
 etag = "8893f1f5ce16c612ba2805432edc0138"
 
 [[releases]]
 version = "0.10.39"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.39-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.39-linux-x64.tar.gz"
 etag = "3994985df38a5b7d74ad8918282f411c"
 
 [[releases]]
 version = "0.10.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.4-linux-x64.tar.gz"
 etag = "7352980adaa9031fa406c5ad7b9617d9"
 
 [[releases]]
 version = "0.10.40"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.40-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.40-linux-x64.tar.gz"
 etag = "efacca570a6ed176a9a3ba18957301b6"
 
 [[releases]]
 version = "0.10.41"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.41-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.41-linux-x64.tar.gz"
 etag = "ec75dbc572e66d8d4f9ddbf5cde4dacc"
 
 [[releases]]
 version = "0.10.42"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.42-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.42-linux-x64.tar.gz"
 etag = "86a2b747beb3e051417f809a97891dc2"
 
 [[releases]]
 version = "0.10.43"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.43-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.43-linux-x64.tar.gz"
 etag = "2ce1317a985b6b359b8dfe22ae4d7c1e"
 
 [[releases]]
 version = "0.10.44"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.44-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.44-linux-x64.tar.gz"
 etag = "d06b675830ece4b9ebe21eb556ed4a5f"
 
 [[releases]]
 version = "0.10.45"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.45-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.45-linux-x64.tar.gz"
 etag = "1b8a131d469b357acdf219bd6536242a"
 
 [[releases]]
 version = "0.10.46"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.46-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.46-linux-x64.tar.gz"
 etag = "cd36e700215520e02eda9f2ae4d3fba5"
 
 [[releases]]
 version = "0.10.47"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.47-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.47-linux-x64.tar.gz"
 etag = "97cefdf9c1cec1f1737b53cfa64dfed3"
 
 [[releases]]
 version = "0.10.48"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.48-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.48-linux-x64.tar.gz"
 etag = "4eed9a2de77191a3c499c6550ce37f5d"
 
 [[releases]]
 version = "0.10.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.5-linux-x64.tar.gz"
 etag = "983f1d6d598038fc0b91da86afaa13a7"
 
 [[releases]]
 version = "0.10.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.6-linux-x64.tar.gz"
 etag = "ef7cca05167075f217981f58ed697a6d"
 
 [[releases]]
 version = "0.10.7"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.7-linux-x64.tar.gz"
 etag = "bd90c722623ba236e8869bb838e7801d"
 
 [[releases]]
 version = "0.10.8"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.8-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.8-linux-x64.tar.gz"
 etag = "9f723ebc985687fcaaa7636819d562cb"
 
 [[releases]]
 version = "0.10.9"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.10.9-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.9-linux-x64.tar.gz"
 etag = "8b723cf963ad01ddce7ab2d272ab34d6"
 
 [[releases]]
 version = "0.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.0-linux-x64.tar.gz"
 etag = "fda656d4a8691fd5103c91c7e22b7860"
 
 [[releases]]
 version = "0.11.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.1-linux-x64.tar.gz"
 etag = "bc18d6fe82cff1a6c4ed7cae1f90fa7d"
 
 [[releases]]
 version = "0.11.10"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.10-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.10-linux-x64.tar.gz"
 etag = "f9723689606eebaf0e05775ff038fb42"
 
 [[releases]]
 version = "0.11.11"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.11-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.11-linux-x64.tar.gz"
 etag = "d78cce4da7582d5ba35be115930522ed"
 
 [[releases]]
 version = "0.11.12"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.12-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.12-linux-x64.tar.gz"
 etag = "1c3fe24727955b517ff1b4e97a4cc903"
 
 [[releases]]
 version = "0.11.13"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.13-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.13-linux-x64.tar.gz"
 etag = "d8cc3a9d98629590b7d5d75e06fa2c61"
 
 [[releases]]
 version = "0.11.14"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.14-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.14-linux-x64.tar.gz"
 etag = "a1651a04eabd1097da63f011e13fea91"
 
 [[releases]]
 version = "0.11.15"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.15-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.15-linux-x64.tar.gz"
 etag = "eaec6219f25aff616675159c9717dcb9"
 
 [[releases]]
 version = "0.11.16"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.16-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.16-linux-x64.tar.gz"
 etag = "c667ab595837821f61306c9d2d3dd3b3"
 
 [[releases]]
 version = "0.11.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.2-linux-x64.tar.gz"
 etag = "2a19da4ca4897e7174960771964dbf8d"
 
 [[releases]]
 version = "0.11.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.3-linux-x64.tar.gz"
 etag = "a026a8e4ad3a28a04ba977a0fba4e930"
 
 [[releases]]
 version = "0.11.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.4-linux-x64.tar.gz"
 etag = "24f4412ef76de3cd44e993d79c9ee59a"
 
 [[releases]]
 version = "0.11.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.5-linux-x64.tar.gz"
 etag = "efd6067e57ea69d5f2474c3e765257a2"
 
 [[releases]]
 version = "0.11.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.6-linux-x64.tar.gz"
 etag = "3da96a942b381da8b8bba9dc5e09db55"
 
 [[releases]]
 version = "0.11.7"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.7-linux-x64.tar.gz"
 etag = "0f03042ca08e6d8e8412de5c5ccd9628"
 
 [[releases]]
 version = "0.11.8"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.8-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.8-linux-x64.tar.gz"
 etag = "53e3e7e39b686ac1b42de24d4cafbfdb"
 
 [[releases]]
 version = "0.11.9"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.11.9-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.9-linux-x64.tar.gz"
 etag = "3159350bcfc311dca5d414d63e0e3a52"
 
 [[releases]]
 version = "0.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.0-linux-x64.tar.gz"
 etag = "ce648d80c0167b0cfe6ec141466822b9"
 
 [[releases]]
 version = "0.12.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.1-linux-x64.tar.gz"
 etag = "b7546bd69ce043a9470f119a36944afd"
 
 [[releases]]
 version = "0.12.10"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.10-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.10-linux-x64.tar.gz"
 etag = "a5a377ac54183786875545974136cb47"
 
 [[releases]]
 version = "0.12.11"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.11-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.11-linux-x64.tar.gz"
 etag = "d886f1e126eae1474819d2b349d7130e"
 
 [[releases]]
 version = "0.12.12"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.12-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.12-linux-x64.tar.gz"
 etag = "67dabce97df771ba44bcd359bf91cae3"
 
 [[releases]]
 version = "0.12.13"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.13-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.13-linux-x64.tar.gz"
 etag = "ecb38dfea79405ce56d706a9ea69bcb7"
 
 [[releases]]
 version = "0.12.14"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.14-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.14-linux-x64.tar.gz"
 etag = "a15d1c3eb4fe38084b3042b686fe3a48"
 
 [[releases]]
 version = "0.12.15"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.15-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.15-linux-x64.tar.gz"
 etag = "e4c6b41e2e8699b14a17ded28bc8e556"
 
 [[releases]]
 version = "0.12.16"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.16-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.16-linux-x64.tar.gz"
 etag = "f2169d4ea96ee2e652308151adc2a308"
 
 [[releases]]
 version = "0.12.17"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.17-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.17-linux-x64.tar.gz"
 etag = "77947c84c8f360e84c2d84b78e6534cb"
 
 [[releases]]
 version = "0.12.18"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.18-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.18-linux-x64.tar.gz"
 etag = "9ef269e8581f18729001c09cc7bc8e57"
 
 [[releases]]
 version = "0.12.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.2-linux-x64.tar.gz"
 etag = "2cfce07dc35ee1ffe875e166b541df35"
 
 [[releases]]
 version = "0.12.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.3-linux-x64.tar.gz"
 etag = "0bc67ed79e01bcc0c673fa5c21f96c1c"
 
 [[releases]]
 version = "0.12.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.4-linux-x64.tar.gz"
 etag = "a4fd80871c4362d98a52b54ecb45d915"
 
 [[releases]]
 version = "0.12.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.5-linux-x64.tar.gz"
 etag = "d27a934de4763550e0f9fd180428b0be"
 
 [[releases]]
 version = "0.12.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.6-linux-x64.tar.gz"
 etag = "28c0750cd4cef5fc9785d9bfbfb5a72d"
 
 [[releases]]
 version = "0.12.7"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.7-linux-x64.tar.gz"
 etag = "182175d82395171f299e3a05a2ce70a1"
 
 [[releases]]
 version = "0.12.8"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.8-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.8-linux-x64.tar.gz"
 etag = "b0a9fe02aa0db91fc27611864da062b9"
 
 [[releases]]
 version = "0.12.9"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.12.9-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.9-linux-x64.tar.gz"
 etag = "0282a5cedf4580a6cc515096bd00cc6c"
 
 [[releases]]
 version = "0.8.10"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.10-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.10-linux-x64.tar.gz"
 etag = "e7746c57b7e5386d61cb76374b8e9f9d"
 
 [[releases]]
 version = "0.8.11"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.11-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.11-linux-x64.tar.gz"
 etag = "0198ab3e509420162819649c569334dd"
 
 [[releases]]
 version = "0.8.12"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.12-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.12-linux-x64.tar.gz"
 etag = "05811a262a34cba71aab2b0db099d2c6"
 
 [[releases]]
 version = "0.8.13"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.13-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.13-linux-x64.tar.gz"
 etag = "2508f05d2ff7d54a01f3a2df2b22ed00"
 
 [[releases]]
 version = "0.8.14"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.14-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.14-linux-x64.tar.gz"
 etag = "6f6c90b4f2a7b21ed5b9ad305201e6f7"
 
 [[releases]]
 version = "0.8.15"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.15-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.15-linux-x64.tar.gz"
 etag = "f0194431d70c47c0af6314842712ea8a"
 
 [[releases]]
 version = "0.8.16"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.16-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.16-linux-x64.tar.gz"
 etag = "b2d1f86053952db562a1be3351cf1a74"
 
 [[releases]]
 version = "0.8.17"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.17-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.17-linux-x64.tar.gz"
 etag = "5fbaf4c6311529486ed9d4e18c3ca8d3"
 
 [[releases]]
 version = "0.8.18"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.18-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.18-linux-x64.tar.gz"
 etag = "e60b276e013c5e0cf7fdee5bfc83b04d"
 
 [[releases]]
 version = "0.8.19"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.19-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.19-linux-x64.tar.gz"
 etag = "65cdb33fa88321188b9584f7bd2e19f0"
 
 [[releases]]
 version = "0.8.20"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.20-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.20-linux-x64.tar.gz"
 etag = "03a051d0d5c1f108f3303bdfc89988ce"
 
 [[releases]]
 version = "0.8.21"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.21-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.21-linux-x64.tar.gz"
 etag = "586d562fefa463cbbb362057e3718945"
 
 [[releases]]
 version = "0.8.22"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.22-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.22-linux-x64.tar.gz"
 etag = "1a45ed485153bdfacfbaee2a918c1c25"
 
 [[releases]]
 version = "0.8.23"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.23-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.23-linux-x64.tar.gz"
 etag = "df5d9ac473f06b75e684a368d3bfdf49"
 
 [[releases]]
 version = "0.8.24"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.24-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.24-linux-x64.tar.gz"
 etag = "1716b18cbf1af696a5312a65312d0cc0"
 
 [[releases]]
 version = "0.8.25"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.25-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.25-linux-x64.tar.gz"
 etag = "eb9585400192622bfa596d816d786385"
 
 [[releases]]
 version = "0.8.26"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.26-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.26-linux-x64.tar.gz"
 etag = "8b32ce92320f974d836239e477e687a6"
 
 [[releases]]
 version = "0.8.27"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.27-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.27-linux-x64.tar.gz"
 etag = "35e2b21a7879a2dd97ff198f19519850"
 
 [[releases]]
 version = "0.8.28"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.28-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.28-linux-x64.tar.gz"
 etag = "623d6b50f550034074b5928e05ab1a45"
 
 [[releases]]
 version = "0.8.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.6-linux-x64.tar.gz"
 etag = "e8d92d46201ba6e61ee748fc85ad2afa"
 
 [[releases]]
 version = "0.8.7"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.7-linux-x64.tar.gz"
 etag = "7a3bb324b1ad1864162a5ff6e9e5e012"
 
 [[releases]]
 version = "0.8.8"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.8-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.8-linux-x64.tar.gz"
 etag = "8a9272ee8d6dd25a09e641c85dd638e7"
 
 [[releases]]
 version = "0.8.9"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.8.9-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.9-linux-x64.tar.gz"
 etag = "1b2bc68dfe8c61a63063afeba89f24f3"
 
 [[releases]]
 version = "0.9.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.1-linux-x64.tar.gz"
 etag = "c2fbb42f94062ea6bdfefc722700604f"
 
 [[releases]]
 version = "0.9.10"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.10-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.10-linux-x64.tar.gz"
 etag = "6ee43eee7545622df8ffb44cf187a6f8"
 
 [[releases]]
 version = "0.9.11"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.11-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.11-linux-x64.tar.gz"
 etag = "df07d58f3e8f49fd7203c8920eed9850"
 
 [[releases]]
 version = "0.9.12"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.12-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.12-linux-x64.tar.gz"
 etag = "a228712b02ef2e8ae4f08378869104ba"
 
 [[releases]]
 version = "0.9.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.2-linux-x64.tar.gz"
 etag = "19133fc15485905898907e322699dff2"
 
 [[releases]]
 version = "0.9.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.3-linux-x64.tar.gz"
 etag = "172eb07f8e840dcbea67a6903411aa3d"
 
 [[releases]]
 version = "0.9.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.4-linux-x64.tar.gz"
 etag = "4b7289787c68baa3194245410ea15204"
 
 [[releases]]
 version = "0.9.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.5-linux-x64.tar.gz"
 etag = "8e312d20333be7ca5ac18545ca81d192"
 
 [[releases]]
 version = "0.9.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.6-linux-x64.tar.gz"
 etag = "a1895c5697faeffa9758e1038a75c333"
 
 [[releases]]
 version = "0.9.7"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.7-linux-x64.tar.gz"
 etag = "d5e013ef6ce93d65b307fdaf7f33bebb"
 
 [[releases]]
 version = "0.9.8"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.8-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.8-linux-x64.tar.gz"
 etag = "37c0909b31bc82e30430cc2bea1b2e45"
 
 [[releases]]
 version = "0.9.9"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v0.9.9-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.9-linux-x64.tar.gz"
 etag = "b22df68fb53151778c2ebeacb7a204b1"
 
 [[releases]]
 version = "10.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.0.0-linux-x64.tar.gz"
 etag = "815774181214108aa165de58314c6bfb"
 
 [[releases]]
 version = "10.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.1.0-linux-x64.tar.gz"
 etag = "3eac965208c9882924783aa927446509"
 
 [[releases]]
 version = "10.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.10.0-linux-x64.tar.gz"
 etag = "32f0212328dd2ece196a5f24fc64166a"
 
 [[releases]]
 version = "10.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.11.0-linux-x64.tar.gz"
 etag = "03cd8caf351086d45bd3482dc6d0a4fc"
 
 [[releases]]
 version = "10.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.12.0-linux-x64.tar.gz"
 etag = "1756916da001a529fac147f7e1b0eb20"
 
 [[releases]]
 version = "10.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.13.0-linux-x64.tar.gz"
 etag = "8f483498e00b376bcce2c310361cd356"
 
 [[releases]]
 version = "10.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.14.0-linux-x64.tar.gz"
 etag = "7bcec1016ab379018158e0bdfb228c6a"
 
 [[releases]]
 version = "10.14.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.14.1-linux-x64.tar.gz"
 etag = "0c5d5d45ddb467f3de47811a3a342dee"
 
 [[releases]]
 version = "10.14.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.14.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.14.2-linux-x64.tar.gz"
 etag = "e8465364a3a1d970f28e2d8dc166e9bb"
 
 [[releases]]
 version = "10.15.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.15.0-linux-x64.tar.gz"
 etag = "145eadc24238a890e2cf3abf96029065"
 
 [[releases]]
 version = "10.15.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.15.1-linux-x64.tar.gz"
 etag = "0aa5f7e95724d9c8b9c07576454c9893"
 
 [[releases]]
 version = "10.15.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.15.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.15.2-linux-x64.tar.gz"
 etag = "c923ec2f672a8f4dd33d3239c9c9eb04"
 
 [[releases]]
 version = "10.15.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.15.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.15.3-linux-x64.tar.gz"
 etag = "7068b1553f2b87ef33a3f296c94236c2"
 
 [[releases]]
 version = "10.16.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.16.0-linux-x64.tar.gz"
 etag = "88a233b41b26c1603d38f8b18c793a87"
 
 [[releases]]
 version = "10.16.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.16.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.16.1-linux-x64.tar.gz"
 etag = "559a1bd566c17d5e709374700f0e0db2"
 
 [[releases]]
 version = "10.16.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.16.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.16.2-linux-x64.tar.gz"
 etag = "6ffb45f911f4fc6888d092c4ce4ecbdd"
 
 [[releases]]
 version = "10.16.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.16.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.16.3-linux-x64.tar.gz"
 etag = "e6d2eb2af1aa2bce9b8309cefbb5e15f"
 
 [[releases]]
 version = "10.17.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.17.0-linux-x64.tar.gz"
 etag = "6fc78926853e1a4746578fed7cb7d699"
 
 [[releases]]
 version = "10.18.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.18.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.18.0-linux-x64.tar.gz"
 etag = "089b445b64c0879f6827061b6f976d9d"
 
 [[releases]]
 version = "10.18.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.18.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.18.1-linux-x64.tar.gz"
 etag = "bc4bc398faba57963fd48cc2343a47dd"
 
 [[releases]]
 version = "10.19.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.19.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.19.0-linux-x64.tar.gz"
 etag = "441a8e19ab9cd9884cbd24f85840c7a6"
 
 [[releases]]
 version = "10.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.2.0-linux-x64.tar.gz"
 etag = "1a32beeb745ee4df076783caf9c54ee5"
 
 [[releases]]
 version = "10.2.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.2.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.2.1-linux-x64.tar.gz"
 etag = "8262dc9e2f24e076d7b49212d3fb9389"
 
 [[releases]]
 version = "10.20.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.20.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.20.0-linux-x64.tar.gz"
 etag = "ea22f766c5eb9d64ac658fd4467a5ae2"
 
 [[releases]]
 version = "10.20.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.20.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.20.1-linux-x64.tar.gz"
 etag = "3072a026105bb078f99fdf94b51d996e"
 
 [[releases]]
 version = "10.21.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.21.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.21.0-linux-x64.tar.gz"
 etag = "73f6c861e6453e75c2e7f4ad31ac5ad9"
 
 [[releases]]
 version = "10.22.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.22.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.22.0-linux-x64.tar.gz"
 etag = "7cf59442c716572239cb14fdabb0ead5-3"
 
 [[releases]]
 version = "10.22.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.22.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.22.1-linux-x64.tar.gz"
 etag = "92b244406470e9a4f49cc233675fdf96-3"
 
 [[releases]]
 version = "10.23.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.23.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.23.0-linux-x64.tar.gz"
 etag = "3cc926fb4db5ad0d0ef161916760c25e-3"
 
 [[releases]]
 version = "10.23.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.23.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.23.1-linux-x64.tar.gz"
 etag = "5387220383fd6512e7cab92ef287426f-3"
 
 [[releases]]
 version = "10.23.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.23.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.23.2-linux-x64.tar.gz"
 etag = "f511a3763a63e7616fb608416e00a253-3"
 
 [[releases]]
 version = "10.23.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.23.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.23.3-linux-x64.tar.gz"
 etag = "6a05b6db3a7e812691eb2992c8287670-3"
 
 [[releases]]
 version = "10.24.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.24.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.24.0-linux-x64.tar.gz"
 etag = "b179fd013f51c02a3c77281fe744dd41-3"
 
 [[releases]]
 version = "10.24.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.24.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.24.1-linux-x64.tar.gz"
 etag = "957994ef8bf3610b7f0b67365691ebaf-3"
 
 [[releases]]
 version = "10.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.3.0-linux-x64.tar.gz"
 etag = "320a13fa365023bc52d75bb19eff3d7a"
 
 [[releases]]
 version = "10.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.4.0-linux-x64.tar.gz"
 etag = "4ad5730cffe5e745c32b2822cd5e30f1"
 
 [[releases]]
 version = "10.4.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.4.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.4.1-linux-x64.tar.gz"
 etag = "72f1a2dda2e73aaa8576d15f7a48ffe4"
 
 [[releases]]
 version = "10.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.5.0-linux-x64.tar.gz"
 etag = "2b54d378a1a0339a649b6a1acb0f7e0c"
 
 [[releases]]
 version = "10.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.6.0-linux-x64.tar.gz"
 etag = "3b6c99e7af8bd950a07353d2992c84b6"
 
 [[releases]]
 version = "10.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.7.0-linux-x64.tar.gz"
 etag = "ecfc64f7b5df211352b0527c09311531"
 
 [[releases]]
 version = "10.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.8.0-linux-x64.tar.gz"
 etag = "b5a4cb8c017c719deceaf5f89936c3d6"
 
 [[releases]]
 version = "10.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.9.0-linux-x64.tar.gz"
 etag = "70c617771708c7c4f36d5823fb413600"
 
 [[releases]]
 version = "11.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.0.0-linux-x64.tar.gz"
 etag = "6cc8a0761f4266183190c56b72363e98"
 
 [[releases]]
 version = "11.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.1.0-linux-x64.tar.gz"
 etag = "6f471bc29d30640097c743927c113f02"
 
 [[releases]]
 version = "11.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.10.0-linux-x64.tar.gz"
 etag = "a1239a07fbd8b9dc460e1e44246e5f29"
 
 [[releases]]
 version = "11.10.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.10.1-linux-x64.tar.gz"
 etag = "1e462fb3a741ce0abf3fe2b0d81574e2"
 
 [[releases]]
 version = "11.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.11.0-linux-x64.tar.gz"
 etag = "009c70629178fb47044333aa4a031c77"
 
 [[releases]]
 version = "11.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.12.0-linux-x64.tar.gz"
 etag = "da2736962216075cb9ad09e87a7f300e"
 
 [[releases]]
 version = "11.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.13.0-linux-x64.tar.gz"
 etag = "95d07b2b544793962b0214bd7e33441c"
 
 [[releases]]
 version = "11.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.14.0-linux-x64.tar.gz"
 etag = "d1ec8cc7a5a102c92d5486cfa9e03b00"
 
 [[releases]]
 version = "11.15.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.15.0-linux-x64.tar.gz"
 etag = "ab251fc5b77761064204d00be022fda3"
 
 [[releases]]
 version = "11.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.2.0-linux-x64.tar.gz"
 etag = "6f1e2002e2af3f660ec0d84dda5e8a6a"
 
 [[releases]]
 version = "11.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.3.0-linux-x64.tar.gz"
 etag = "dc1a836d178e97e06107e1673d3caf96"
 
 [[releases]]
 version = "11.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.4.0-linux-x64.tar.gz"
 etag = "2718dafe1f89dd3794a0da222ee365ae"
 
 [[releases]]
 version = "11.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.5.0-linux-x64.tar.gz"
 etag = "7a32d6b4c300f6a7b78f3a28ed4587e3"
 
 [[releases]]
 version = "11.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.6.0-linux-x64.tar.gz"
 etag = "9ab9d9540290c15caad5fdf0a32b40fa"
 
 [[releases]]
 version = "11.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.7.0-linux-x64.tar.gz"
 etag = "35c41456320eb8a712dde2aac4145166"
 
 [[releases]]
 version = "11.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.8.0-linux-x64.tar.gz"
 etag = "7a6bdb9ffd31bc5ae4c6d866b5462826"
 
 [[releases]]
 version = "11.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v11.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.9.0-linux-x64.tar.gz"
 etag = "8805aeb4cfb798106c6a99ed34536682"
 
 [[releases]]
 version = "12.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.0.0-linux-x64.tar.gz"
 etag = "246f00fcffbd01974f260b4383f91c58"
 
 [[releases]]
 version = "12.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.1.0-linux-x64.tar.gz"
 etag = "d4df5a60e1b73c062131985de2ada621"
 
 [[releases]]
 version = "12.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.10.0-linux-x64.tar.gz"
 etag = "74dc625cf656bd501f0cd08f28e92131"
 
 [[releases]]
 version = "12.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.11.0-linux-x64.tar.gz"
 etag = "3ad3502adff89d3a037cd910ef17f725"
 
 [[releases]]
 version = "12.11.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.11.1-linux-x64.tar.gz"
 etag = "fb56b6d4439d3ccca91a8ff419391c3e"
 
 [[releases]]
 version = "12.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.12.0-linux-x64.tar.gz"
 etag = "41e3b3ccc2e2254869234f1f4c50dffc"
 
 [[releases]]
 version = "12.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.13.0-linux-x64.tar.gz"
 etag = "5f1bc3459c59f8b80cf6ea3d38944da7"
 
 [[releases]]
 version = "12.13.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.13.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.13.1-linux-x64.tar.gz"
 etag = "169ca5c7407b7532ed947a2014a48b1e"
 
 [[releases]]
 version = "12.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.14.0-linux-x64.tar.gz"
 etag = "919f124e16acb7464459c58dd2cfd36e"
 
 [[releases]]
 version = "12.14.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.14.1-linux-x64.tar.gz"
 etag = "cf97b81a436bdd484e642660eb769e16"
 
 [[releases]]
 version = "12.15.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.15.0-linux-x64.tar.gz"
 etag = "6c5ee256556aec2f1ca11f02b58d81b4"
 
 [[releases]]
 version = "12.16.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.16.0-linux-x64.tar.gz"
 etag = "7f8d2520e715d7df82f368b0fab9d2b6"
 
 [[releases]]
 version = "12.16.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.16.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.16.1-linux-x64.tar.gz"
 etag = "656435219a1655586fe02ac5f8bfa694"
 
 [[releases]]
 version = "12.16.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.16.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.16.2-linux-x64.tar.gz"
 etag = "6bd0588c3db32a734d3d0c34ddb05e60"
 
 [[releases]]
 version = "12.16.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.16.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.16.3-linux-x64.tar.gz"
 etag = "20963d6e105a6f29c272734f64de5f67"
 
 [[releases]]
 version = "12.17.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.17.0-linux-x64.tar.gz"
 etag = "ae367608adc068358e0f805fbb548cc2"
 
 [[releases]]
 version = "12.18.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.18.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.0-linux-x64.tar.gz"
 etag = "f723197769cd3adc449ffa5835193c1f"
 
 [[releases]]
 version = "12.18.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.18.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.1-linux-x64.tar.gz"
 etag = "0c26eac16e4b5f0f8d0d4944d38258ef"
 
 [[releases]]
 version = "12.18.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.18.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.2-linux-x64.tar.gz"
 etag = "612d831288b3e3d896cde1596e5fe704"
 
 [[releases]]
 version = "12.18.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.18.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.3-linux-x64.tar.gz"
 etag = "9e7444e9d66072035f73e9ac0ee51322-3"
 
 [[releases]]
 version = "12.18.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.18.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.4-linux-x64.tar.gz"
 etag = "fdecf94ced8dcdeb972e14b333c72e47-3"
 
 [[releases]]
 version = "12.19.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.19.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.19.0-linux-x64.tar.gz"
 etag = "1962f4127fb09f2942b82f48f4ae2cf8-3"
 
 [[releases]]
 version = "12.19.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.19.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.19.1-linux-x64.tar.gz"
 etag = "7851352d2c9d60d4c5779910af828755-3"
 
 [[releases]]
 version = "12.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.2.0-linux-x64.tar.gz"
 etag = "87dc21fee7f484defd9010a6c606aa92"
 
 [[releases]]
 version = "12.20.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.20.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.20.0-linux-x64.tar.gz"
 etag = "3383e1624171a83a04740f24831c5c92-3"
 
 [[releases]]
 version = "12.20.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.20.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.20.1-linux-x64.tar.gz"
 etag = "51c80c3820855d8e77f37c9a67b9d89b-3"
 
 [[releases]]
 version = "12.20.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.20.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.20.2-linux-x64.tar.gz"
 etag = "d296cca07540a62c9c583ce4f23afee7-3"
 
 [[releases]]
 version = "12.21.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.21.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.21.0-linux-x64.tar.gz"
 etag = "a0fe4d871fc223d21fbac24689c598fd-3"
 
 [[releases]]
 version = "12.22.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.0-linux-x64.tar.gz"
 etag = "b0eb62d33d028e6cd3f1b7220b962a55-3"
 
 [[releases]]
 version = "12.22.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.1-linux-x64.tar.gz"
 etag = "4648915ed3eb1be12cf7cbe1c5b3e867-3"
 
 [[releases]]
 version = "12.22.10"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.10-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.10-linux-x64.tar.gz"
 etag = "58fe1bdc055914f433ee3f07bb380f36-3"
 
 [[releases]]
 version = "12.22.11"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.11-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.11-linux-x64.tar.gz"
 etag = "98a9f79ab4d7840b31c95968e82e9569-3"
 
 [[releases]]
 version = "12.22.12"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.12-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.12-linux-x64.tar.gz"
 etag = "84488d656cf19837e8dbc27b1a9993c9-3"
 
 [[releases]]
 version = "12.22.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.2-linux-x64.tar.gz"
 etag = "a014e16e46f6c158facd9d48c6a450f7-3"
 
 [[releases]]
 version = "12.22.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.3-linux-x64.tar.gz"
 etag = "41956f3f2a7cbbfc012e0d52facee55d-3"
 
 [[releases]]
 version = "12.22.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.4-linux-x64.tar.gz"
 etag = "461546c7894049caaa06041520e4172e-3"
 
 [[releases]]
 version = "12.22.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.5-linux-x64.tar.gz"
 etag = "2e8f7e52697114e493a312d7c4493fb0-3"
 
 [[releases]]
 version = "12.22.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.6-linux-x64.tar.gz"
 etag = "d61482b86203da8b3542f25723ca8f6a-3"
 
 [[releases]]
 version = "12.22.7"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.7-linux-x64.tar.gz"
 etag = "28b7bdac5d0a1a5361cf4504898d985e-3"
 
 [[releases]]
 version = "12.22.8"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.8-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.8-linux-x64.tar.gz"
 etag = "e7ca67cb90ca08afe64d87f9cdfbe2f9-3"
 
 [[releases]]
 version = "12.22.9"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.9-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.9-linux-x64.tar.gz"
 etag = "827ab91c2a29f14e1ad39e0fbd2ede10-3"
 
 [[releases]]
 version = "12.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.3.0-linux-x64.tar.gz"
 etag = "123a93553a06e8a7615c444c1ea42882"
 
 [[releases]]
 version = "12.3.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.3.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.3.1-linux-x64.tar.gz"
 etag = "82721dca1c9757af1e50fda8f23a0175"
 
 [[releases]]
 version = "12.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.4.0-linux-x64.tar.gz"
 etag = "75341c471626e3155079041fc8737bab"
 
 [[releases]]
 version = "12.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.5.0-linux-x64.tar.gz"
 etag = "7377ca5f3d429dba8069808c57509f24"
 
 [[releases]]
 version = "12.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.6.0-linux-x64.tar.gz"
 etag = "259326813ae277cf8a2cd764c610df8c"
 
 [[releases]]
 version = "12.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.7.0-linux-x64.tar.gz"
 etag = "b013a541a950c7ac8547622e4588542e"
 
 [[releases]]
 version = "12.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.8.0-linux-x64.tar.gz"
 etag = "2bc1f6bf496bfb6447c3fa129cf8a3d6"
 
 [[releases]]
 version = "12.8.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.8.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.8.1-linux-x64.tar.gz"
 etag = "f0ad395a6b921fa1121cd60aa3f47fef"
 
 [[releases]]
 version = "12.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.9.0-linux-x64.tar.gz"
 etag = "406857cde2b0012cb860653de74777ea"
 
 [[releases]]
 version = "12.9.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.9.1-linux-x64.tar.gz"
 etag = "74001acf6e4f1980045a985a86b198d1"
 
 [[releases]]
 version = "13.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.0.0-linux-x64.tar.gz"
 etag = "80ec0dee495ddf5ac1f52658fc7004d8"
 
 [[releases]]
 version = "13.0.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.0.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.0.1-linux-x64.tar.gz"
 etag = "248b1a416a4c2af6b888ce1897df12cd"
 
 [[releases]]
 version = "13.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.1.0-linux-x64.tar.gz"
 etag = "ef41097c9220782c8cac61161fe9eb60"
 
 [[releases]]
 version = "13.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.10.0-linux-x64.tar.gz"
 etag = "fc533a5c86419ad4976f7e15b5333100"
 
 [[releases]]
 version = "13.10.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.10.1-linux-x64.tar.gz"
 etag = "e5e28ed8047859e8be1cee3b7155df4e"
 
 [[releases]]
 version = "13.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.11.0-linux-x64.tar.gz"
 etag = "7544d1ae0b70dc3ad7b2505c3f10ae3e"
 
 [[releases]]
 version = "13.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.12.0-linux-x64.tar.gz"
 etag = "50ac82a9792bf99d0b4c24960ecd7da2"
 
 [[releases]]
 version = "13.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.13.0-linux-x64.tar.gz"
 etag = "cf039ea0c590d5e2e055305ff80020ef"
 
 [[releases]]
 version = "13.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.14.0-linux-x64.tar.gz"
 etag = "45c315bd788c3505a636fd925445a240"
 
 [[releases]]
 version = "13.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.2.0-linux-x64.tar.gz"
 etag = "021173844878f2a62d6644da631b384e"
 
 [[releases]]
 version = "13.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.3.0-linux-x64.tar.gz"
 etag = "0984273970fbe1b55d46a74132c79768"
 
 [[releases]]
 version = "13.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.4.0-linux-x64.tar.gz"
 etag = "822b0185650e14a8e614caa4db36e1b2"
 
 [[releases]]
 version = "13.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.5.0-linux-x64.tar.gz"
 etag = "28e68b5893a353dae4525655d3230d19"
 
 [[releases]]
 version = "13.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.6.0-linux-x64.tar.gz"
 etag = "5758d37594fa78cabb0b4578771a01fd"
 
 [[releases]]
 version = "13.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.7.0-linux-x64.tar.gz"
 etag = "66087b902dac00d18558ec6b892de497"
 
 [[releases]]
 version = "13.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.8.0-linux-x64.tar.gz"
 etag = "308ec153bc621d3ef32a3d9731083e44"
 
 [[releases]]
 version = "13.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v13.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.9.0-linux-x64.tar.gz"
 etag = "ba1fcf56182c7afb8863b3bff9469fb2"
 
 [[releases]]
 version = "14.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.0.0-linux-x64.tar.gz"
 etag = "6d385ef3fffc1c5e5d870c590627552f"
 
 [[releases]]
 version = "14.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.1.0-linux-x64.tar.gz"
 etag = "42fffcd3e0ec9789ec127684a1d30539"
 
 [[releases]]
 version = "14.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.10.0-linux-x64.tar.gz"
 etag = "0692912fe38915d832ac97d9c8e75b6f-5"
 
 [[releases]]
 version = "14.10.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.10.1-linux-x64.tar.gz"
 etag = "4cc3f36a5a752141310ce9462b83b9e1-5"
 
 [[releases]]
 version = "14.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.11.0-linux-x64.tar.gz"
 etag = "5f0b0d752a988c5846e2850251d0de6e-5"
 
 [[releases]]
 version = "14.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.12.0-linux-x64.tar.gz"
 etag = "d543750360e322f6172ebbac5180f794-5"
 
 [[releases]]
 version = "14.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.13.0-linux-x64.tar.gz"
 etag = "d8db874594a71ef0a537e563f69403d5-5"
 
 [[releases]]
 version = "14.13.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.13.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.13.1-linux-x64.tar.gz"
 etag = "5fd8b1ffb4fe1f889bd39be6911ef12a-5"
 
 [[releases]]
 version = "14.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.14.0-linux-x64.tar.gz"
 etag = "8048c3ed071d05c927c4fbf21b7ce1d8-5"
 
 [[releases]]
 version = "14.15.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.0-linux-x64.tar.gz"
 etag = "53ded239e3e7b19ff58c63a13fc7295a-5"
 
 [[releases]]
 version = "14.15.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.1-linux-x64.tar.gz"
 etag = "ee95fa0dd4b142e075f7f61d6e9fdd3c-5"
 
 [[releases]]
 version = "14.15.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.15.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.2-linux-x64.tar.gz"
 etag = "f344e8a0fb555aa7cad8df8ee227c053-4"
 
 [[releases]]
 version = "14.15.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.15.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.3-linux-x64.tar.gz"
 etag = "929b59a348873583cf0eece6e997f694-4"
 
 [[releases]]
 version = "14.15.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.15.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.4-linux-x64.tar.gz"
 etag = "ad295578e70f4838d619a289c7d7654e-4"
 
 [[releases]]
 version = "14.15.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.15.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.5-linux-x64.tar.gz"
 etag = "78ef6759634ee37a78d17be7af46ed79-4"
 
 [[releases]]
 version = "14.16.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.16.0-linux-x64.tar.gz"
 etag = "f2cbbae39184fee9c13b611437b10921-4"
 
 [[releases]]
 version = "14.16.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.16.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.16.1-linux-x64.tar.gz"
 etag = "e03bf3ea73d969d9c08c8b7ae5493613-4"
 
 [[releases]]
 version = "14.17.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.0-linux-x64.tar.gz"
 etag = "cdc57f6a3cc4ca6f12f49dadd75a554e-5"
 
 [[releases]]
 version = "14.17.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.1-linux-x64.tar.gz"
 etag = "b41c1f2d90ecda727af59f7cc7c5dcfb-5"
 
 [[releases]]
 version = "14.17.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.2-linux-x64.tar.gz"
 etag = "7021d231631d65ece0f74c95bbc43eb3-5"
 
 [[releases]]
 version = "14.17.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.3-linux-x64.tar.gz"
 etag = "0bdbb8e1b6e813dbc040da523831c684-5"
 
 [[releases]]
 version = "14.17.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.4-linux-x64.tar.gz"
 etag = "81ca69987ef377abff2ecb2ae35d7ad7-5"
 
 [[releases]]
 version = "14.17.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.5-linux-x64.tar.gz"
 etag = "4e872307dfbc942a43b0eb5e6e44765c-5"
 
 [[releases]]
 version = "14.17.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.6-linux-x64.tar.gz"
 etag = "888e9ad0d2a56802507f3f6cd27f7ebe-5"
 
 [[releases]]
 version = "14.18.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.18.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.18.0-linux-x64.tar.gz"
 etag = "a667cd6939a25a71d4773357a693e170-5"
 
 [[releases]]
 version = "14.18.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.18.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.18.1-linux-x64.tar.gz"
 etag = "4a620703f674343fe1041b2bd0dfba66-5"
 
 [[releases]]
 version = "14.18.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.18.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.18.2-linux-x64.tar.gz"
 etag = "dad4b0c2b0daed55d75fd98500e57d62-5"
 
 [[releases]]
 version = "14.18.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.18.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.18.3-linux-x64.tar.gz"
 etag = "af7ed8db30228507dad9cf71afcce543-5"
 
 [[releases]]
 version = "14.19.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.19.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.0-linux-x64.tar.gz"
 etag = "06a14f4fdc59ae064ba047d4e9736fa3-5"
 
 [[releases]]
 version = "14.19.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.19.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.1-linux-x64.tar.gz"
 etag = "fcb00a3d0c4b22c1b6e157a558949657-5"
 
 [[releases]]
 version = "14.19.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.19.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.2-linux-x64.tar.gz"
 etag = "a6dd0bfb2f656166aeefefa37cfa8122-5"
 
 [[releases]]
 version = "14.19.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.19.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.3-linux-x64.tar.gz"
 etag = "3990a70c4d0794e8646575c76bff11a7-5"
 
 [[releases]]
 version = "14.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.2.0-linux-x64.tar.gz"
 etag = "130cb565b0fac4199fbc31df53a5f767"
 
 [[releases]]
 version = "14.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.3.0-linux-x64.tar.gz"
 etag = "801b4e07a0f9686d54f21d56f982843c"
 
 [[releases]]
 version = "14.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.4.0-linux-x64.tar.gz"
 etag = "dd8f4cc53204e154b77729fa7bad99df"
 
 [[releases]]
 version = "14.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.5.0-linux-x64.tar.gz"
 etag = "cd5748870280f52ba9c1b2c35d6e0823"
 
 [[releases]]
 version = "14.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.6.0-linux-x64.tar.gz"
 etag = "e076d8f3ac1ffaf3540b6bff5fa14dd1-5"
 
 [[releases]]
 version = "14.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.7.0-linux-x64.tar.gz"
 etag = "98021eb36abb1d21ed54521a85ce5fa6-5"
 
 [[releases]]
 version = "14.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.8.0-linux-x64.tar.gz"
 etag = "00e00bc07580f6376df8f218b7196594-5"
 
 [[releases]]
 version = "14.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.9.0-linux-x64.tar.gz"
 etag = "2353027766ae1fdc82aa2fefc9cfad25-5"
 
 [[releases]]
 version = "15.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.0.0-linux-x64.tar.gz"
 etag = "39eea40a8dc5ca81ef1010088ae74ea5-5"
 
 [[releases]]
 version = "15.0.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.0.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.0.1-linux-x64.tar.gz"
 etag = "4066ea9cd7b29f9084c237a1024872c7-5"
 
 [[releases]]
 version = "15.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.1.0-linux-x64.tar.gz"
 etag = "e1d3af432eb7accbfc614a3cf48c7583-4"
 
 [[releases]]
 version = "15.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.10.0-linux-x64.tar.gz"
 etag = "485a712d740b014662a226e834bd9557-4"
 
 [[releases]]
 version = "15.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.11.0-linux-x64.tar.gz"
 etag = "ef6f1f9484a255594673ca7bcfbed280-4"
 
 [[releases]]
 version = "15.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.12.0-linux-x64.tar.gz"
 etag = "231a5764d7aafa2c8d99fcd147b0e875-4"
 
 [[releases]]
 version = "15.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.13.0-linux-x64.tar.gz"
 etag = "6a6b953c042ee7fca4a7e4482de60dc2-4"
 
 [[releases]]
 version = "15.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.14.0-linux-x64.tar.gz"
 etag = "0f2e0ef70eebc4840eab7547e59880ae-4"
 
 [[releases]]
 version = "15.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.2.0-linux-x64.tar.gz"
 etag = "784df9e5242bb304820b2c14512d9ce3-4"
 
 [[releases]]
 version = "15.2.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.2.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.2.1-linux-x64.tar.gz"
 etag = "ca1c922ba43df36fbb23fd8b3a8ea876-4"
 
 [[releases]]
 version = "15.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.3.0-linux-x64.tar.gz"
 etag = "292ba2368577fa093bedb1b7f5014402-4"
 
 [[releases]]
 version = "15.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.4.0-linux-x64.tar.gz"
 etag = "69eeff861c07a0fed33fda82b35a5ecb-4"
 
 [[releases]]
 version = "15.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.5.0-linux-x64.tar.gz"
 etag = "b5bc122b0bb815f48128c67709a76cf0-4"
 
 [[releases]]
 version = "15.5.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.5.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.5.1-linux-x64.tar.gz"
 etag = "37e51c2d28beb27f4488fbd5b4a58f59-4"
 
 [[releases]]
 version = "15.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.6.0-linux-x64.tar.gz"
 etag = "aeb1a459afa11e7fc482e0a672cf1fe2-4"
 
 [[releases]]
 version = "15.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.7.0-linux-x64.tar.gz"
 etag = "065a4833bd91372bf26a45a46820f77a-4"
 
 [[releases]]
 version = "15.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.8.0-linux-x64.tar.gz"
 etag = "e88c6266c1926b5c4348ad943e1c2ee2-4"
 
 [[releases]]
 version = "15.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.9.0-linux-x64.tar.gz"
 etag = "38308de828100c4f52adb07e8de3cc9d-4"
 
 [[releases]]
 version = "16.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.0.0-linux-x64.tar.gz"
 etag = "9ced677cf96c5ca3b4067f35c21311ac-4"
 
 [[releases]]
 version = "16.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.1.0-linux-x64.tar.gz"
 etag = "8d4e3e558429cf64b22302f210b3d7e5-4"
 
 [[releases]]
 version = "16.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.10.0-linux-x64.tar.gz"
 etag = "d91908102992fad63e2eb2c9b8082553-4"
 
 [[releases]]
 version = "16.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.11.0-linux-x64.tar.gz"
 etag = "c93e9efb20bf3f5807ec0e058bd83d5c-4"
 
 [[releases]]
 version = "16.11.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.11.1-linux-x64.tar.gz"
 etag = "ae7ebdb2d57c11865882e4dc3d6fc5e5-4"
 
 [[releases]]
 version = "16.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.12.0-linux-x64.tar.gz"
 etag = "66344ff27247c29c3a5fbe85fe5acb9d-4"
 
 [[releases]]
 version = "16.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.13.0-linux-x64.tar.gz"
 etag = "d445951da7d338a5d6d758aa24b6804d-4"
 
 [[releases]]
 version = "16.13.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.13.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.13.1-linux-x64.tar.gz"
 etag = "5ed5638fad670c7568cb216775f03cc6-4"
 
 [[releases]]
 version = "16.13.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.13.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.13.2-linux-x64.tar.gz"
 etag = "8104fa926e76b71b0c22236b24310732-4"
 
 [[releases]]
 version = "16.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.0-linux-x64.tar.gz"
 etag = "5bc4c0b1c1c94fad08c80561e259ee99-4"
 
 [[releases]]
 version = "16.14.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.1-linux-x64.tar.gz"
 etag = "64b4bbdf40af72cd2fe6accfc8054b16-4"
 
 [[releases]]
 version = "16.14.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.14.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.2-linux-x64.tar.gz"
 etag = "4db20ae2bbff10cf3c8aa2f7ea370fb0-4"
 
 [[releases]]
 version = "16.15.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.15.0-linux-x64.tar.gz"
 etag = "4df8f054993a43950ef0f2e42b9ff53d-4"
 
 [[releases]]
 version = "16.15.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.15.1-linux-x64.tar.gz"
 etag = "b863d244e4b1c0df901c8c8c8967dd68-4"
 
 [[releases]]
 version = "16.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.2.0-linux-x64.tar.gz"
 etag = "ee81bd1f587c60c54432650eba4c51bc-4"
 
 [[releases]]
 version = "16.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.3.0-linux-x64.tar.gz"
 etag = "b0a9cecd669951adac9e27a35102923d-4"
 
 [[releases]]
 version = "16.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.4.0-linux-x64.tar.gz"
 etag = "8a77e82e1ca44f4fe1922714403161e8-4"
 
 [[releases]]
 version = "16.4.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.4.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.4.1-linux-x64.tar.gz"
 etag = "558b0575a48ff39c21a1fd9402fa0b84-4"
 
 [[releases]]
 version = "16.4.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.4.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.4.2-linux-x64.tar.gz"
 etag = "722a9783a7201b020ad6a89b9703cc3b-4"
 
 [[releases]]
 version = "16.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.5.0-linux-x64.tar.gz"
 etag = "5322a660d103a2974b9e073eae890bfb-4"
 
 [[releases]]
 version = "16.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.6.0-linux-x64.tar.gz"
 etag = "dfbee0cdf68d776ad1e51ca482250b0a-4"
 
 [[releases]]
 version = "16.6.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.6.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.6.1-linux-x64.tar.gz"
 etag = "bc15b11b0fd5ff2b62c6bf83646c82df-4"
 
 [[releases]]
 version = "16.6.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.6.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.6.2-linux-x64.tar.gz"
 etag = "0f897c317d9f01058731d4d283ce1cf2-4"
 
 [[releases]]
 version = "16.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.7.0-linux-x64.tar.gz"
 etag = "5db3c31791f4f8f75a8e8737e2ad2382-4"
 
 [[releases]]
 version = "16.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.8.0-linux-x64.tar.gz"
 etag = "2cf9f82dd69a9d35ba71532459629f83-4"
 
 [[releases]]
 version = "16.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.9.0-linux-x64.tar.gz"
 etag = "f76ebd4df376e0a9a8138bfcbe3a3079-4"
 
 [[releases]]
 version = "16.9.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.9.1-linux-x64.tar.gz"
 etag = "b591f8229fa8bf2f0a387c23b8277c55-4"
 
 [[releases]]
 version = "17.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.0.0-linux-x64.tar.gz"
 etag = "86c99126a99b3a82d007caedabdb9fa1-6"
 
 [[releases]]
 version = "17.0.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.0.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.0.1-linux-x64.tar.gz"
 etag = "10dc62fa317414c345bed79c04cc71fc-6"
 
 [[releases]]
 version = "17.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.1.0-linux-x64.tar.gz"
 etag = "8bf50f0462ee3144f34c6da85ae09e32-6"
 
 [[releases]]
 version = "17.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.2.0-linux-x64.tar.gz"
 etag = "0aee67a645145fd83f1e9c333c68c655-6"
 
 [[releases]]
 version = "17.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.3.0-linux-x64.tar.gz"
 etag = "43a9c23500b6183f63c62fe1c72bbdcd-6"
 
 [[releases]]
 version = "17.3.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.3.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.3.1-linux-x64.tar.gz"
 etag = "89f0dc5714f090fb5255b2ab4b943c03-6"
 
 [[releases]]
 version = "17.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.4.0-linux-x64.tar.gz"
 etag = "72cd45ee41e736a3d15ccd255bc42ea5-6"
 
 [[releases]]
 version = "17.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.5.0-linux-x64.tar.gz"
 etag = "85ca8cdd9038440dbad047487fe5caad-6"
 
 [[releases]]
 version = "17.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.6.0-linux-x64.tar.gz"
 etag = "acb898de485f6fd431c5bba29737cdd6-6"
 
 [[releases]]
 version = "17.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.0-linux-x64.tar.gz"
 etag = "3ae4ee1f090945e80ad2209beb2c019e-6"
 
 [[releases]]
 version = "17.7.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.7.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.1-linux-x64.tar.gz"
 etag = "45444848e3db9df8e1906f30303f0b73-6"
 
 [[releases]]
 version = "17.7.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.7.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.2-linux-x64.tar.gz"
 etag = "5bfd0dc5e7e878dd4561fd0e41035051-6"
 
 [[releases]]
 version = "17.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.8.0-linux-x64.tar.gz"
 etag = "062cf4cae4ec3b032c41909a49df706e-6"
 
 [[releases]]
 version = "17.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.9.0-linux-x64.tar.gz"
 etag = "d82856ef7d8fd6ee756e0c4054e686aa-6"
 
 [[releases]]
 version = "17.9.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v17.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.9.1-linux-x64.tar.gz"
 etag = "5abb91fe234c1cb3709811ca8c62ee88-6"
 
 [[releases]]
 version = "18.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v18.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.0.0-linux-x64.tar.gz"
 etag = "48ae6c63e24f5ce074e86188287198e0-6"
 
 [[releases]]
 version = "18.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v18.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.1.0-linux-x64.tar.gz"
 etag = "37faa7d1b87accc2b5f8c5c8af3d4a85-6"
 
 [[releases]]
 version = "18.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v18.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.2.0-linux-x64.tar.gz"
 etag = "3e7b3258d258a95ba0e1ad06ed7f482d-6"
 
 [[releases]]
 version = "18.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v18.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.3.0-linux-x64.tar.gz"
 etag = "0882fd16bcfeabd57379441604051ca4-6"
 
 [[releases]]
 version = "4.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.0.0-linux-x64.tar.gz"
 etag = "ad9aa8802fe1ef5b9c96913fd2d08816"
 
 [[releases]]
 version = "4.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.1.0-linux-x64.tar.gz"
 etag = "5110ec82838293fbbfb67df9cd72b029"
 
 [[releases]]
 version = "4.1.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.1.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.1.1-linux-x64.tar.gz"
 etag = "e5d370e666f2305787a1fce3661fd89e"
 
 [[releases]]
 version = "4.1.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.1.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.1.2-linux-x64.tar.gz"
 etag = "0fdf4986da53ea7828ed3aa651a23834"
 
 [[releases]]
 version = "4.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.0-linux-x64.tar.gz"
 etag = "157502f1f71c36a7331e2515b27a4e55"
 
 [[releases]]
 version = "4.2.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.2.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.1-linux-x64.tar.gz"
 etag = "6c89bd44bc01e3806958192913cd2df1"
 
 [[releases]]
 version = "4.2.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.2.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.2-linux-x64.tar.gz"
 etag = "d15578f9497cfc470876035be6817b44"
 
 [[releases]]
 version = "4.2.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.2.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.3-linux-x64.tar.gz"
 etag = "d147b47f159a450ca2ddb21efa15494b"
 
 [[releases]]
 version = "4.2.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.2.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.4-linux-x64.tar.gz"
 etag = "3a5a62cf70ccd3da8f236fe8970c56f3"
 
 [[releases]]
 version = "4.2.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.2.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.5-linux-x64.tar.gz"
 etag = "ac75a1f161cc038d7864e31f836544cc"
 
 [[releases]]
 version = "4.2.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.2.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.6-linux-x64.tar.gz"
 etag = "99e171e31ada52506ea19921c8f12655"
 
 [[releases]]
 version = "4.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.3.0-linux-x64.tar.gz"
 etag = "971d69c8630e86d310a1e9358dd9d784"
 
 [[releases]]
 version = "4.3.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.3.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.3.1-linux-x64.tar.gz"
 etag = "4ffab69c4a38b4239b902575cb2e3c8e"
 
 [[releases]]
 version = "4.3.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.3.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.3.2-linux-x64.tar.gz"
 etag = "c97908f365d55ac8112a85504498d9d4"
 
 [[releases]]
 version = "4.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.0-linux-x64.tar.gz"
 etag = "f53766c3065beaf5df816cbbcabbbaa8"
 
 [[releases]]
 version = "4.4.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.4.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.1-linux-x64.tar.gz"
 etag = "e63bc99f24096ce83a310342bc33185d"
 
 [[releases]]
 version = "4.4.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.4.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.2-linux-x64.tar.gz"
 etag = "b298f15e97e2bf65a51074a6274989c3"
 
 [[releases]]
 version = "4.4.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.4.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.3-linux-x64.tar.gz"
 etag = "57b39b7e98d7267118536db1ce9c61c2"
 
 [[releases]]
 version = "4.4.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.4.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.4-linux-x64.tar.gz"
 etag = "7c120af0281a7e7195e99f61e6d7ba31"
 
 [[releases]]
 version = "4.4.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.4.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.5-linux-x64.tar.gz"
 etag = "f182997bd203528c5a358c8fb1082a5e"
 
 [[releases]]
 version = "4.4.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.4.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.6-linux-x64.tar.gz"
 etag = "4c72d988c91bf95e4dde32cb2adfb4f0"
 
 [[releases]]
 version = "4.4.7"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.4.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.7-linux-x64.tar.gz"
 etag = "9a5e9d9eeaa9a48f5eacf619fd8c11d8"
 
 [[releases]]
 version = "4.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.5.0-linux-x64.tar.gz"
 etag = "05a630d65295c2fb854fb76277681233"
 
 [[releases]]
 version = "4.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.6.0-linux-x64.tar.gz"
 etag = "9ea38915970403e2f39ffb7ddeab037f"
 
 [[releases]]
 version = "4.6.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.6.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.6.1-linux-x64.tar.gz"
 etag = "2a0f179566efbc1018c0f5b8e79dd37f"
 
 [[releases]]
 version = "4.6.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.6.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.6.2-linux-x64.tar.gz"
 etag = "076573f2f809e5050098c8969a32327e"
 
 [[releases]]
 version = "4.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.7.0-linux-x64.tar.gz"
 etag = "7f6f2e8172bb61666b75de84f430703d"
 
 [[releases]]
 version = "4.7.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.7.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.7.1-linux-x64.tar.gz"
 etag = "e130bd5a3cc159aa32c54d082e7963dd"
 
 [[releases]]
 version = "4.7.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.7.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.7.2-linux-x64.tar.gz"
 etag = "d438c6cf3d2b63aedae84f7770dba2bf"
 
 [[releases]]
 version = "4.7.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.7.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.7.3-linux-x64.tar.gz"
 etag = "15508f8fea6b2c3f15a7094b85a400ac"
 
 [[releases]]
 version = "4.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.0-linux-x64.tar.gz"
 etag = "9b0f9368f140ce6095d0338196ef3d0e"
 
 [[releases]]
 version = "4.8.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.8.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.1-linux-x64.tar.gz"
 etag = "c061c265953467cbaecb528936a4350d"
 
 [[releases]]
 version = "4.8.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.8.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.2-linux-x64.tar.gz"
 etag = "3838bed594a34909e3e960db823fe5cb"
 
 [[releases]]
 version = "4.8.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.8.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.3-linux-x64.tar.gz"
 etag = "f7a7392704f74ae1c35ac43e57147518"
 
 [[releases]]
 version = "4.8.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.8.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.4-linux-x64.tar.gz"
 etag = "d4cbf24ebcfe3208eda22474917159ba"
 
 [[releases]]
 version = "4.8.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.8.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.5-linux-x64.tar.gz"
 etag = "96af0054769096d569981f2d22131a96"
 
 [[releases]]
 version = "4.8.6"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.8.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.6-linux-x64.tar.gz"
 etag = "b0b95ceab3ac27aba8a56033f94658b9"
 
 [[releases]]
 version = "4.8.7"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.8.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.7-linux-x64.tar.gz"
 etag = "ccf19b560bb65f53132e6bb09b0eb9b1"
 
 [[releases]]
 version = "4.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.9.0-linux-x64.tar.gz"
 etag = "edb491d2bcc46fac4974319543610d84"
 
 [[releases]]
 version = "4.9.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v4.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.9.1-linux-x64.tar.gz"
 etag = "55cc20b7f650c25cd57c41dfffdd2bc1"
 
 [[releases]]
 version = "5.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.0.0-linux-x64.tar.gz"
 etag = "fdc2c555c36c94ebf114638ce335930c"
 
 [[releases]]
 version = "5.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.1.0-linux-x64.tar.gz"
 etag = "18b6afd5c49e93e5389b951e7e9c14a5"
 
 [[releases]]
 version = "5.1.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.1.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.1.1-linux-x64.tar.gz"
 etag = "0657d46ced225b0416198d1b3e263c40"
 
 [[releases]]
 version = "5.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.10.0-linux-x64.tar.gz"
 etag = "16beb606311791a408e612fd3837f17f"
 
 [[releases]]
 version = "5.10.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.10.1-linux-x64.tar.gz"
 etag = "4c2f9b58fdd04f44c253eec1fcda6c8b"
 
 [[releases]]
 version = "5.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.11.0-linux-x64.tar.gz"
 etag = "27b1e305aa8024b9254851a46101b5ac"
 
 [[releases]]
 version = "5.11.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.11.1-linux-x64.tar.gz"
 etag = "a410e0dd3f79a9030c5704abb24e4eed"
 
 [[releases]]
 version = "5.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.12.0-linux-x64.tar.gz"
 etag = "a573a36713bd2d77094794e39562c9a9"
 
 [[releases]]
 version = "5.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.2.0-linux-x64.tar.gz"
 etag = "547de6e8b2f42e6f6948e3e8e83205b0"
 
 [[releases]]
 version = "5.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.3.0-linux-x64.tar.gz"
 etag = "fd5b49ff2073e48667e9420cb8e14485"
 
 [[releases]]
 version = "5.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.4.0-linux-x64.tar.gz"
 etag = "29d19e2095e6610c69d5e3425467a837"
 
 [[releases]]
 version = "5.4.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.4.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.4.1-linux-x64.tar.gz"
 etag = "59504ee13daa0b00ee5d1ed9b8293c83"
 
 [[releases]]
 version = "5.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.5.0-linux-x64.tar.gz"
 etag = "da931cbd0d7ddabce6a8e4cd0bfea252"
 
 [[releases]]
 version = "5.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.6.0-linux-x64.tar.gz"
 etag = "9094bd62a5c44b5794e1c781186211a1"
 
 [[releases]]
 version = "5.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.7.0-linux-x64.tar.gz"
 etag = "e5703bedcb1796c323b4875476f1aa42"
 
 [[releases]]
 version = "5.7.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.7.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.7.1-linux-x64.tar.gz"
 etag = "23516f737f0301a02b653f6791bb1b7b"
 
 [[releases]]
 version = "5.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.8.0-linux-x64.tar.gz"
 etag = "6dc325980c02dbc6d2784f0f4a8ac2c0"
 
 [[releases]]
 version = "5.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.9.0-linux-x64.tar.gz"
 etag = "728b0fb8dd32ed22e9ececc7494ee017"
 
 [[releases]]
 version = "5.9.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v5.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.9.1-linux-x64.tar.gz"
 etag = "08c9841f4462cc3db1723b3f769545bb"
 
 [[releases]]
 version = "6.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.0.0-linux-x64.tar.gz"
 etag = "13b4c32b6547c960fe271dff9e5271ef"
 
 [[releases]]
 version = "6.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.1.0-linux-x64.tar.gz"
 etag = "7ae088e219791fc7b8ec2e113de351ed"
 
 [[releases]]
 version = "6.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.10.0-linux-x64.tar.gz"
 etag = "f5296665baa81cb1d2963e6e035bab3f"
 
 [[releases]]
 version = "6.10.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.10.1-linux-x64.tar.gz"
 etag = "b84f8dc95e36713130f02eb74a510f66"
 
 [[releases]]
 version = "6.10.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.10.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.10.2-linux-x64.tar.gz"
 etag = "422d938406ab4e87b540ff702cc0be0f"
 
 [[releases]]
 version = "6.10.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.10.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.10.3-linux-x64.tar.gz"
 etag = "30393301e956e1c1378b6e2b4134960d"
 
 [[releases]]
 version = "6.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.0-linux-x64.tar.gz"
 etag = "e6ade07945c32f82da184ebbcb5347dc"
 
 [[releases]]
 version = "6.11.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.1-linux-x64.tar.gz"
 etag = "07ad56154c716d5d4024485cf541cacd"
 
 [[releases]]
 version = "6.11.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.11.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.2-linux-x64.tar.gz"
 etag = "a9d11ee59c2f1323dd7779f22319da0b"
 
 [[releases]]
 version = "6.11.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.11.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.3-linux-x64.tar.gz"
 etag = "27ca55c32e83981d0262c86b3098ab53"
 
 [[releases]]
 version = "6.11.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.11.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.4-linux-x64.tar.gz"
 etag = "c6ef84d3d69e83cece7fe70b34fb3ead"
 
 [[releases]]
 version = "6.11.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.11.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.5-linux-x64.tar.gz"
 etag = "feb8cc0de5bdcd852b6ead5ca449c54e"
 
 [[releases]]
 version = "6.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.12.0-linux-x64.tar.gz"
 etag = "3bb30780f5a2375186050d3331124eb3"
 
 [[releases]]
 version = "6.12.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.12.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.12.1-linux-x64.tar.gz"
 etag = "fe934ea079157537e519ab8abac97821"
 
 [[releases]]
 version = "6.12.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.12.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.12.2-linux-x64.tar.gz"
 etag = "d17c3d9d7abc2b6fa87d77b1194f49ed"
 
 [[releases]]
 version = "6.12.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.12.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.12.3-linux-x64.tar.gz"
 etag = "3449dadfee5ae4310806b586b22415ea"
 
 [[releases]]
 version = "6.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.13.0-linux-x64.tar.gz"
 etag = "bb14c7dc4cdcdda93864b54641a904eb"
 
 [[releases]]
 version = "6.13.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.13.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.13.1-linux-x64.tar.gz"
 etag = "8ea19d0947367394b64196d6ef31d279"
 
 [[releases]]
 version = "6.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.0-linux-x64.tar.gz"
 etag = "55df304d39af6d80b2fea82bc3a0c23c"
 
 [[releases]]
 version = "6.14.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.1-linux-x64.tar.gz"
 etag = "2a9d81e30b09a4f097426e469d67d159"
 
 [[releases]]
 version = "6.14.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.14.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.2-linux-x64.tar.gz"
 etag = "18ccee563e25f5c4561681bfcccd815b"
 
 [[releases]]
 version = "6.14.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.14.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.3-linux-x64.tar.gz"
 etag = "c03210f252a9a6f1025a32abd817466b"
 
 [[releases]]
 version = "6.14.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.14.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.4-linux-x64.tar.gz"
 etag = "c81242d62dbad357134ad9e8c938fce6"
 
 [[releases]]
 version = "6.15.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.15.0-linux-x64.tar.gz"
 etag = "bc75fc652bb28aa07d92e99b212dd75e"
 
 [[releases]]
 version = "6.15.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.15.1-linux-x64.tar.gz"
 etag = "8b6b409811ba540653b06a2f87af2b58"
 
 [[releases]]
 version = "6.16.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.16.0-linux-x64.tar.gz"
 etag = "e4b7d1cc7c4156ae36af213795b9a2ab"
 
 [[releases]]
 version = "6.17.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.17.0-linux-x64.tar.gz"
 etag = "24b84466f5f921fa793243f87915800a"
 
 [[releases]]
 version = "6.17.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.17.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.17.1-linux-x64.tar.gz"
 etag = "eb59e6ef416d02bfcd1188b4151bddcd"
 
 [[releases]]
 version = "6.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.2.0-linux-x64.tar.gz"
 etag = "fdd0261e3c7bafee1cc7fc65984fdf88"
 
 [[releases]]
 version = "6.2.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.2.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.2.1-linux-x64.tar.gz"
 etag = "f3d14bdcb186588b49d62e79e7f01485"
 
 [[releases]]
 version = "6.2.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz"
 etag = "a6fec1180281f7ac2d4958e6ce7d3389"
 
 [[releases]]
 version = "6.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.3.0-linux-x64.tar.gz"
 etag = "41d14f57079c5935a4f0b470abd9f6b6"
 
 [[releases]]
 version = "6.3.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.3.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.3.1-linux-x64.tar.gz"
 etag = "6eef640b0ec7aa824495648de0b98b8a"
 
 [[releases]]
 version = "6.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.4.0-linux-x64.tar.gz"
 etag = "5a6a85902804e80805b9e768965de9e7"
 
 [[releases]]
 version = "6.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.5.0-linux-x64.tar.gz"
 etag = "9ecd8aa9b9604d0a00c8e49bf4972e8a"
 
 [[releases]]
 version = "6.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.6.0-linux-x64.tar.gz"
 etag = "d1d8e73c4bf00bd775134133eb272db1"
 
 [[releases]]
 version = "6.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.7.0-linux-x64.tar.gz"
 etag = "408f4cd1cb7ec43c3c160e8fed1976f5"
 
 [[releases]]
 version = "6.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.8.0-linux-x64.tar.gz"
 etag = "67095f5a08b9e43af45fb5ae0148518c"
 
 [[releases]]
 version = "6.8.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.8.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.8.1-linux-x64.tar.gz"
 etag = "755c549fe29a3a5b96c3389e09944f26"
 
 [[releases]]
 version = "6.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.0-linux-x64.tar.gz"
 etag = "04b33ad10f00911e1e62d1564b0291a5"
 
 [[releases]]
 version = "6.9.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.1-linux-x64.tar.gz"
 etag = "125817abbbe0268f7344a4bdc9f6ca6c"
 
 [[releases]]
 version = "6.9.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.9.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.2-linux-x64.tar.gz"
 etag = "93bed4cb06d1c70dd6c353eb464fcc14"
 
 [[releases]]
 version = "6.9.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.9.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.3-linux-x64.tar.gz"
 etag = "77c692175c2be398a5e3a293642e815f"
 
 [[releases]]
 version = "6.9.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.9.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.4-linux-x64.tar.gz"
 etag = "6ef6a9c5d2157605b8c1c8428d79562e"
 
 [[releases]]
 version = "6.9.5"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.9.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.5-linux-x64.tar.gz"
 etag = "07fe033bfc86aaa9f92f34d7b99fd26f"
 
 [[releases]]
 version = "7.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.0.0-linux-x64.tar.gz"
 etag = "9e9e91b3acb928e4ba648d8e74a1da58"
 
 [[releases]]
 version = "7.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.1.0-linux-x64.tar.gz"
 etag = "9ab4aebedf1ffaa3a969e967155fb682"
 
 [[releases]]
 version = "7.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.10.0-linux-x64.tar.gz"
 etag = "ec8a2ff9c2419699b6b64c23dadd0e97"
 
 [[releases]]
 version = "7.10.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.10.1-linux-x64.tar.gz"
 etag = "cfdda50dfcdc0cf220a3a2cde7c47eed"
 
 [[releases]]
 version = "7.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.2.0-linux-x64.tar.gz"
 etag = "0addb80324fde7895d575217e586de61"
 
 [[releases]]
 version = "7.2.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.2.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.2.1-linux-x64.tar.gz"
 etag = "c3bed6afc9602cf939db1d5fa17a8ecd"
 
 [[releases]]
 version = "7.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.3.0-linux-x64.tar.gz"
 etag = "f72707a8488b83b1c960a0f92f0c0407"
 
 [[releases]]
 version = "7.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.4.0-linux-x64.tar.gz"
 etag = "d39110f7d54c8232681af944e35a643a"
 
 [[releases]]
 version = "7.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.5.0-linux-x64.tar.gz"
 etag = "6deb5f26b7d6b1abb891ec1c91417a44"
 
 [[releases]]
 version = "7.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.6.0-linux-x64.tar.gz"
 etag = "ba3e24f7785494fa862bb09df962cb6a"
 
 [[releases]]
 version = "7.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.0-linux-x64.tar.gz"
 etag = "e39a464e4327f52b857a0014e5c834d5"
 
 [[releases]]
 version = "7.7.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.7.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.1-linux-x64.tar.gz"
 etag = "12cf3996237e73af1734abbb04aaa08e"
 
 [[releases]]
 version = "7.7.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.7.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.2-linux-x64.tar.gz"
 etag = "4d721a9751057c93c361b20285319ce9"
 
 [[releases]]
 version = "7.7.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.7.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.3-linux-x64.tar.gz"
 etag = "8fba665863dc1d8f22d5848e2464c66d"
 
 [[releases]]
 version = "7.7.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.7.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.4-linux-x64.tar.gz"
 etag = "e3382e0292c909731d0db2e98662dc35"
 
 [[releases]]
 version = "7.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.8.0-linux-x64.tar.gz"
 etag = "d338a977caa4908b9634c457eec00607"
 
 [[releases]]
 version = "7.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v7.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.9.0-linux-x64.tar.gz"
 etag = "905dd98406730fa6c7a6f142759797fe"
 
 [[releases]]
 version = "8.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.0.0-linux-x64.tar.gz"
 etag = "7c4a36c3fa8e26f6293f8b7419b80dce"
 
 [[releases]]
 version = "8.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.0-linux-x64.tar.gz"
 etag = "47785a1a21fee13cf0c257bb4f61c400"
 
 [[releases]]
 version = "8.1.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.1.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.1-linux-x64.tar.gz"
 etag = "66b23604717b0895162e24e372003bc0"
 
 [[releases]]
 version = "8.1.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.1.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.2-linux-x64.tar.gz"
 etag = "ae9ed0103665e67eded93b9ae52a6ec5"
 
 [[releases]]
 version = "8.1.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.1.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.3-linux-x64.tar.gz"
 etag = "ce89b28204e1b6d5c2d1bb08d3f85d95"
 
 [[releases]]
 version = "8.1.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.1.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.4-linux-x64.tar.gz"
 etag = "ae43cf579539b3898432a9c3d49cf9d3"
 
 [[releases]]
 version = "8.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.10.0-linux-x64.tar.gz"
 etag = "79b3e7736b4f5d0d902684f773748805"
 
 [[releases]]
 version = "8.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.0-linux-x64.tar.gz"
 etag = "3d3264b0503613ad6672858f271392a1"
 
 [[releases]]
 version = "8.11.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.1-linux-x64.tar.gz"
 etag = "cdfc6c0c8da81d697cb6e93219143817"
 
 [[releases]]
 version = "8.11.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.11.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.2-linux-x64.tar.gz"
 etag = "5d6bbd76cf31838ac22863cee6b35314"
 
 [[releases]]
 version = "8.11.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.11.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.3-linux-x64.tar.gz"
 etag = "55f2efc92e347c22d94f1c75e14cc4a9"
 
 [[releases]]
 version = "8.11.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.11.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.4-linux-x64.tar.gz"
 etag = "5764e757cee7ffa6eda727784ac2dde8"
 
 [[releases]]
 version = "8.12.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.12.0-linux-x64.tar.gz"
 etag = "c2dc07f9b840abe01461328caad03179"
 
 [[releases]]
 version = "8.13.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.13.0-linux-x64.tar.gz"
 etag = "ec5e096251b6b78f508971d7038a5d14"
 
 [[releases]]
 version = "8.14.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.14.0-linux-x64.tar.gz"
 etag = "6e1117831d6dfa9cf73a998f84a70aa2"
 
 [[releases]]
 version = "8.14.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.14.1-linux-x64.tar.gz"
 etag = "b62684a89bde079c53fb54dce47ff715"
 
 [[releases]]
 version = "8.15.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.15.0-linux-x64.tar.gz"
 etag = "117139b710ca7795feda9e643ce11fe9"
 
 [[releases]]
 version = "8.15.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.15.1-linux-x64.tar.gz"
 etag = "4c4497b86c0004401d5a93aa36c7e959"
 
 [[releases]]
 version = "8.16.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.16.0-linux-x64.tar.gz"
 etag = "caabf1838fba99b1d228dfa66c38254f"
 
 [[releases]]
 version = "8.16.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.16.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.16.1-linux-x64.tar.gz"
 etag = "7208de0aad92d58374fa8f3763d6305c"
 
 [[releases]]
 version = "8.16.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.16.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.16.2-linux-x64.tar.gz"
 etag = "327ec94535ca1a5390fd2eebb970936d"
 
 [[releases]]
 version = "8.17.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.17.0-linux-x64.tar.gz"
 etag = "6218e59c4e3632a4b4eae5214aceeb08"
 
 [[releases]]
 version = "8.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.2.0-linux-x64.tar.gz"
 etag = "68c673f28439316feca4d62e9422fa61"
 
 [[releases]]
 version = "8.2.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.2.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.2.1-linux-x64.tar.gz"
 etag = "771c0c0d6dee6eb23246acde43d9a322"
 
 [[releases]]
 version = "8.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.3.0-linux-x64.tar.gz"
 etag = "cd9f3d9d745ff7ed7b70e666120f6f33"
 
 [[releases]]
 version = "8.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.4.0-linux-x64.tar.gz"
 etag = "47995fbac1f5d13335b9793193852865"
 
 [[releases]]
 version = "8.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.5.0-linux-x64.tar.gz"
 etag = "fabf00e6bd0340ac7b9eea01c14b5553"
 
 [[releases]]
 version = "8.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.6.0-linux-x64.tar.gz"
 etag = "43086fd3d13a2f5da84ca0a425603384"
 
 [[releases]]
 version = "8.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.7.0-linux-x64.tar.gz"
 etag = "cc0009950642acd26d84cdd41fc6a63f"
 
 [[releases]]
 version = "8.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.8.0-linux-x64.tar.gz"
 etag = "9dbef387aa662bcd886e1d9e12c53391"
 
 [[releases]]
 version = "8.8.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.8.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.8.1-linux-x64.tar.gz"
 etag = "05a227ed26e6d10673d7b5d43548fa27"
 
 [[releases]]
 version = "8.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.0-linux-x64.tar.gz"
 etag = "344c4ece19f3288e49580aa924efb6b6"
 
 [[releases]]
 version = "8.9.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.1-linux-x64.tar.gz"
 etag = "4988b63c61a557d435ca84a8fd7b16e5"
 
 [[releases]]
 version = "8.9.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.9.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.2-linux-x64.tar.gz"
 etag = "d44840575fb65f8af588f104b191f1fa"
 
 [[releases]]
 version = "8.9.3"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.9.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.3-linux-x64.tar.gz"
 etag = "bcb479799cf91d21c5dea9f11be3e8f0"
 
 [[releases]]
 version = "8.9.4"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v8.9.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.4-linux-x64.tar.gz"
 etag = "53afee57c2832145d0192075cee3a0f5"
 
 [[releases]]
 version = "9.0.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.0.0-linux-x64.tar.gz"
 etag = "daf114d7fc0feedaddee00fffb05795c"
 
 [[releases]]
 version = "9.1.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.1.0-linux-x64.tar.gz"
 etag = "f1f3e6c33c998aec8bc976dff9bd288a"
 
 [[releases]]
 version = "9.10.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.10.0-linux-x64.tar.gz"
 etag = "72f8c387f69e787eb62a711a6bcb567e"
 
 [[releases]]
 version = "9.10.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.10.1-linux-x64.tar.gz"
 etag = "7c8500163ca5129ae369b1c385fe510b"
 
 [[releases]]
 version = "9.11.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.11.0-linux-x64.tar.gz"
 etag = "333cebc3ddc900647bdf634dd0b85712"
 
 [[releases]]
 version = "9.11.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.11.1-linux-x64.tar.gz"
 etag = "c57e646e046d336ff99973f53f146e3e"
 
 [[releases]]
 version = "9.11.2"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.11.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.11.2-linux-x64.tar.gz"
 etag = "2e3946fb496d4fe7da658d4fe84d2f83"
 
 [[releases]]
 version = "9.2.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.2.0-linux-x64.tar.gz"
 etag = "d5fbf801c5b1e5fd920b6d06abedf64c"
 
 [[releases]]
 version = "9.2.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.2.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.2.1-linux-x64.tar.gz"
 etag = "794a1419d7b37ca31f6b26ec523fe9a1"
 
 [[releases]]
 version = "9.3.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.3.0-linux-x64.tar.gz"
 etag = "0b7d3a357d309cb9a49d4bf26d9dc279"
 
 [[releases]]
 version = "9.4.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.4.0-linux-x64.tar.gz"
 etag = "513c419b06c88bf467ab8c153bd4f311"
 
 [[releases]]
 version = "9.5.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.5.0-linux-x64.tar.gz"
 etag = "3d7a719f4839b67751c4293de1cc4a25"
 
 [[releases]]
 version = "9.6.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.6.0-linux-x64.tar.gz"
 etag = "6b1fda53508ebf1d18c987d23007daa7"
 
 [[releases]]
 version = "9.6.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.6.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.6.1-linux-x64.tar.gz"
 etag = "51a778e44a46edf617985416e52a4eba"
 
 [[releases]]
 version = "9.7.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.7.0-linux-x64.tar.gz"
 etag = "684489f171a42c96ccc2734b6dbe6035"
 
 [[releases]]
 version = "9.7.1"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.7.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.7.1-linux-x64.tar.gz"
 etag = "eafd7894337e4c8325ad318df6e8f5c8"
 
 [[releases]]
 version = "9.8.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.8.0-linux-x64.tar.gz"
 etag = "f16b1750184ebed9dc4144a549bbabfc"
 
 [[releases]]
 version = "9.9.0"
 channel = "release"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v9.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.9.0-linux-x64.tar.gz"
 etag = "b6d0dd7311e34f96057b66280ac29e7a"
 
 [[releases]]
 version = "10.10.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.10.0-darwin-x64.tar.gz"
 etag = "c442bca910c01b931661a9e91186e8ef"
 
 [[releases]]
 version = "10.11.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.11.0-darwin-x64.tar.gz"
 etag = "b58541d7e9eee8eda30fd5b67b4a9f11"
 
 [[releases]]
 version = "10.12.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.12.0-darwin-x64.tar.gz"
 etag = "9a153115f11dd2c076c2d72a55c5a9fc"
 
 [[releases]]
 version = "10.13.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.13.0-darwin-x64.tar.gz"
 etag = "65d2400b91b5ba7bda813572bf08442f"
 
 [[releases]]
 version = "10.14.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.14.0-darwin-x64.tar.gz"
 etag = "b0eb309e9a7e749117c42a9725d5f769"
 
 [[releases]]
 version = "10.14.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.14.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.14.1-darwin-x64.tar.gz"
 etag = "002f5683eb664e14d26a54330334b320"
 
 [[releases]]
 version = "10.14.2"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.14.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.14.2-darwin-x64.tar.gz"
 etag = "77d55c4112ee4b66a6b2ce3eb8ead6c3"
 
 [[releases]]
 version = "10.15.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.15.0-darwin-x64.tar.gz"
 etag = "e640e01d12d42797f80434f2475492b4"
 
 [[releases]]
 version = "10.15.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.15.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.15.1-darwin-x64.tar.gz"
 etag = "9d6698c8132924a9b98e035295959cd1"
 
 [[releases]]
 version = "10.15.2"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.15.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.15.2-darwin-x64.tar.gz"
 etag = "515022c63ae40f50929c11795703309d"
 
 [[releases]]
 version = "10.15.3"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.15.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.15.3-darwin-x64.tar.gz"
 etag = "03828afe26a0926962a4390d7d956127"
 
 [[releases]]
 version = "10.16.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.16.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.16.0-darwin-x64.tar.gz"
 etag = "a286ed1c4acfffa9124d9df0ac273fd6"
 
 [[releases]]
 version = "10.16.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.16.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.16.1-darwin-x64.tar.gz"
 etag = "ebaf420919ef4e764ca05d27139af28b"
 
 [[releases]]
 version = "10.16.2"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.16.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.16.2-darwin-x64.tar.gz"
 etag = "5f5af433d60067ddd955012313f1bcc6"
 
 [[releases]]
 version = "10.16.3"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.16.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.16.3-darwin-x64.tar.gz"
 etag = "5f419fa2f5a19bf880416f44cd147749"
 
 [[releases]]
 version = "10.17.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.17.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.17.0-darwin-x64.tar.gz"
 etag = "d829b260a537d5124b632b53cfbb7cd4"
 
 [[releases]]
 version = "10.18.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.18.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.18.0-darwin-x64.tar.gz"
 etag = "4a899925537f4e935c55e69c3ec9d47b"
 
 [[releases]]
 version = "10.18.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.18.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.18.1-darwin-x64.tar.gz"
 etag = "82848bb435183a6264b6470c27aae2d9"
 
 [[releases]]
 version = "10.19.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.19.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.19.0-darwin-x64.tar.gz"
 etag = "e0a89df131a21f5659bd05304ffdca36"
 
 [[releases]]
 version = "10.20.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.20.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.20.0-darwin-x64.tar.gz"
 etag = "9333a777f0a74f5b7ea87550d74262c3-3"
 
 [[releases]]
 version = "10.20.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.20.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.20.1-darwin-x64.tar.gz"
 etag = "878c0c4323e31dd9106d756abb0b9002-3"
 
 [[releases]]
 version = "10.21.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.21.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.21.0-darwin-x64.tar.gz"
 etag = "3df5c0dec214c35f2d731726733b1c6a-3"
 
 [[releases]]
 version = "10.22.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.22.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.22.0-darwin-x64.tar.gz"
 etag = "0037544c07933ec1d5da9c33092f6831-3"
 
 [[releases]]
 version = "10.22.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.22.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.22.1-darwin-x64.tar.gz"
 etag = "d32be387d0f7f21abf2642e23d47b19c-3"
 
 [[releases]]
 version = "10.9.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.9.0-darwin-x64.tar.gz"
 etag = "589b2b59735c2756fa3ab64cdfb1f1a9"
 
 [[releases]]
 version = "11.0.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.0.0-darwin-x64.tar.gz"
 etag = "ecc3e19ec147553f53a1d55cd7985054"
 
 [[releases]]
 version = "11.1.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.1.0-darwin-x64.tar.gz"
 etag = "58249d44f40a5a5299fa83f3fd1ee36c"
 
 [[releases]]
 version = "11.10.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.10.0-darwin-x64.tar.gz"
 etag = "bf5fd780114c9e7981146a4909e2ffde"
 
 [[releases]]
 version = "11.10.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.10.1-darwin-x64.tar.gz"
 etag = "80ac0921ffeca782eabae1e543cf5a1d"
 
 [[releases]]
 version = "11.11.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.11.0-darwin-x64.tar.gz"
 etag = "736858f23fb79479af941461817424a4"
 
 [[releases]]
 version = "11.12.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.12.0-darwin-x64.tar.gz"
 etag = "77636576d7ba54c52a984e9891413b16"
 
 [[releases]]
 version = "11.13.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.13.0-darwin-x64.tar.gz"
 etag = "56d811e1709ae0ba4b591ee2489003c3"
 
 [[releases]]
 version = "11.14.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.14.0-darwin-x64.tar.gz"
 etag = "59478d7f4976d5d4248b8e6d24b19270"
 
 [[releases]]
 version = "11.15.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.15.0-darwin-x64.tar.gz"
 etag = "3cc7ff95006b05b6d8cb7b727388c19b"
 
 [[releases]]
 version = "11.2.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.2.0-darwin-x64.tar.gz"
 etag = "3dbded714a5cebaf5ac447c4484e32fe"
 
 [[releases]]
 version = "11.3.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.3.0-darwin-x64.tar.gz"
 etag = "d15a0a760aeb7fcd4c0b6a25529759c0"
 
 [[releases]]
 version = "11.4.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.4.0-darwin-x64.tar.gz"
 etag = "0badf49f8d6aa6d8132916052547865d"
 
 [[releases]]
 version = "11.5.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.5.0-darwin-x64.tar.gz"
 etag = "f1968a180739aec5a35e7778b77d4bea"
 
 [[releases]]
 version = "11.6.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.6.0-darwin-x64.tar.gz"
 etag = "bc6044faecbd1a216d11ab8ac05f3a41"
 
 [[releases]]
 version = "11.7.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.7.0-darwin-x64.tar.gz"
 etag = "ccea4d6956bf66ce6af96cefb93d1f04"
 
 [[releases]]
 version = "11.8.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.8.0-darwin-x64.tar.gz"
 etag = "d7d522f5bf1e1821d258cdb3ebf87e7c"
 
 [[releases]]
 version = "11.9.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v11.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.9.0-darwin-x64.tar.gz"
 etag = "1dce07e744fd518a9d3bf1611c0e721a"
 
 [[releases]]
 version = "12.0.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.0.0-darwin-x64.tar.gz"
 etag = "9bd5425992b3e8b27542dd0017140feb"
 
 [[releases]]
 version = "12.1.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.1.0-darwin-x64.tar.gz"
 etag = "f6464cf5569dcd84a7930dd463636418"
 
 [[releases]]
 version = "12.10.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.10.0-darwin-x64.tar.gz"
 etag = "ae17569da0e787b77f7811b255c528cb"
 
 [[releases]]
 version = "12.11.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.11.0-darwin-x64.tar.gz"
 etag = "cfb6ddede26476faa95e4e445dee6254"
 
 [[releases]]
 version = "12.11.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.11.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.11.1-darwin-x64.tar.gz"
 etag = "870f6467a4e95f1d3b29f08f8158dde1"
 
 [[releases]]
 version = "12.12.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.12.0-darwin-x64.tar.gz"
 etag = "72b892d17a1de38b40cddd7fdb39e8e7"
 
 [[releases]]
 version = "12.13.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.13.0-darwin-x64.tar.gz"
 etag = "e5cb03e25d7996ae24a230a4512c5817"
 
 [[releases]]
 version = "12.13.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.13.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.13.1-darwin-x64.tar.gz"
 etag = "a347868afbb81d5b18116619b57f016a-3"
 
 [[releases]]
 version = "12.14.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.14.0-darwin-x64.tar.gz"
 etag = "1ec6c21238c6af4b8c2cb20ae6630df8"
 
 [[releases]]
 version = "12.14.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.14.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.14.1-darwin-x64.tar.gz"
 etag = "d98df77c47b0b83b3d0cb04d97374e90"
 
 [[releases]]
 version = "12.15.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.15.0-darwin-x64.tar.gz"
 etag = "8bf0ff87a9cd53de20f9905a4266b445"
 
 [[releases]]
 version = "12.16.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.16.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.16.0-darwin-x64.tar.gz"
 etag = "5504043d93837eeee1fb3dbfaa52eaa6"
 
 [[releases]]
 version = "12.16.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.16.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.16.1-darwin-x64.tar.gz"
 etag = "3bcfe9b7553b9836878c87394d585fbd"
 
 [[releases]]
 version = "12.16.2"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.16.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.16.2-darwin-x64.tar.gz"
 etag = "a92da45fe607326748c57adf4aada73f-3"
 
 [[releases]]
 version = "12.16.3"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.16.3-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.16.3-darwin-x64.tar.gz"
 etag = "db0e17a2dffe405e6077c817131a823d-3"
 
 [[releases]]
 version = "12.2.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.2.0-darwin-x64.tar.gz"
 etag = "d95b66b6c81e4bbddd94b7ddfa4a4a2f"
 
 [[releases]]
 version = "12.3.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.3.0-darwin-x64.tar.gz"
 etag = "3b55e52fc17ba959ce339c7fdcee0f56"
 
 [[releases]]
 version = "12.3.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.3.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.3.1-darwin-x64.tar.gz"
 etag = "67a1cf0fd7d2b623ff3503f5026b21d4"
 
 [[releases]]
 version = "12.4.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.4.0-darwin-x64.tar.gz"
 etag = "1327d9429ca77b14ce14b52b622031f2"
 
 [[releases]]
 version = "12.5.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.5.0-darwin-x64.tar.gz"
 etag = "ace7c880c8178bbdbdc2efae749a9ac7"
 
 [[releases]]
 version = "12.6.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.6.0-darwin-x64.tar.gz"
 etag = "cf1326bb477c17e4b2cd660a9b450143"
 
 [[releases]]
 version = "12.7.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.7.0-darwin-x64.tar.gz"
 etag = "336ee36ab6bcfd2c40f4a1a943f03b84"
 
 [[releases]]
 version = "12.8.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.8.0-darwin-x64.tar.gz"
 etag = "a6bf0fad73dd99a3eb92c8dffdf73a9e"
 
 [[releases]]
 version = "12.8.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.8.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.8.1-darwin-x64.tar.gz"
 etag = "288f89d653725c41cb148d9724ff09ab"
 
 [[releases]]
 version = "12.9.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.9.0-darwin-x64.tar.gz"
 etag = "db54bea21ff05b1faf4515b62df166cc"
 
 [[releases]]
 version = "12.9.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v12.9.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.9.1-darwin-x64.tar.gz"
 etag = "5095b55f99b9d740343ef7f2bd6af0b5"
 
 [[releases]]
 version = "13.0.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.0.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.0.0-darwin-x64.tar.gz"
 etag = "c29a2d0512dad49563013dcb8d2388a3"
 
 [[releases]]
 version = "13.0.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.0.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.0.1-darwin-x64.tar.gz"
 etag = "38d4e72e84dd08cfdf155e165df8c30d"
 
 [[releases]]
 version = "13.1.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.1.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.1.0-darwin-x64.tar.gz"
 etag = "5b3a440dc47f3a8be6c0bae473dbb529"
 
 [[releases]]
 version = "13.10.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.10.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.10.0-darwin-x64.tar.gz"
 etag = "ace887b3fabcb29c467748b45cceac48"
 
 [[releases]]
 version = "13.10.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.10.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.10.1-darwin-x64.tar.gz"
 etag = "6d5164fbe7b24fc12c238ee28722582c"
 
 [[releases]]
 version = "13.11.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.11.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.11.0-darwin-x64.tar.gz"
 etag = "4370def07b18d225755e4acca647593d-4"
 
 [[releases]]
 version = "13.12.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.12.0-darwin-x64.tar.gz"
 etag = "f014fcc400f09fc071ea300b7b68eed3-4"
 
 [[releases]]
 version = "13.2.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.2.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.2.0-darwin-x64.tar.gz"
 etag = "5357dc8b60f0467c37f5408667fc1915"
 
 [[releases]]
 version = "13.3.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.3.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.3.0-darwin-x64.tar.gz"
 etag = "a2090fb5b2388c6e3a970d66a982b267"
 
 [[releases]]
 version = "13.4.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.4.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.4.0-darwin-x64.tar.gz"
 etag = "253f2ddb1e1507e16793df039d5c9282"
 
 [[releases]]
 version = "13.5.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.5.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.5.0-darwin-x64.tar.gz"
 etag = "a3660b576ee4e0afd9d631819748d7eb"
 
 [[releases]]
 version = "13.6.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.6.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.6.0-darwin-x64.tar.gz"
 etag = "4b02b6953ad7f299be3047e9337abbd9"
 
 [[releases]]
 version = "13.7.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.7.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.7.0-darwin-x64.tar.gz"
 etag = "e109ac3d1a92a3cc147b4be24c8d96e8"
 
 [[releases]]
 version = "13.8.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.8.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.8.0-darwin-x64.tar.gz"
 etag = "d314a378a6622eacdd7bd1cd138fc22f"
 
 [[releases]]
 version = "13.9.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v13.9.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.9.0-darwin-x64.tar.gz"
 etag = "25433a0b64a3b71b981656b01b3b0031"
 
 [[releases]]
 version = "6.14.4"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v6.14.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.14.4-darwin-x64.tar.gz"
 etag = "0bb04f12c5041367429175a765e0f948"
 
 [[releases]]
 version = "6.15.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v6.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.15.0-darwin-x64.tar.gz"
 etag = "d8db6fa9ab2757996604a0b6e5af31d4"
 
 [[releases]]
 version = "6.15.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v6.15.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.15.1-darwin-x64.tar.gz"
 etag = "f4c860c829f4749ee9196f94239cd2ad"
 
 [[releases]]
 version = "6.16.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v6.16.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.16.0-darwin-x64.tar.gz"
 etag = "ece449be5f8b9a7a5acc6d7c75d2a97e"
 
 [[releases]]
 version = "6.17.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v6.17.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.17.0-darwin-x64.tar.gz"
 etag = "0a3afceae5144b47d497c01d40e57fed"
 
 [[releases]]
 version = "6.17.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v6.17.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.17.1-darwin-x64.tar.gz"
 etag = "55394ba4babf46ec8eeded045c1c8c56"
 
 [[releases]]
 version = "8.11.4"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.11.4-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.11.4-darwin-x64.tar.gz"
 etag = "c30ef72d947f05a2a803f7bfd32d511b"
 
 [[releases]]
 version = "8.12.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.12.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.12.0-darwin-x64.tar.gz"
 etag = "f1489227237471edcbe1f02505b49ce4"
 
 [[releases]]
 version = "8.13.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.13.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.13.0-darwin-x64.tar.gz"
 etag = "77934dd4a77be45aab6069a2e2cc327c"
 
 [[releases]]
 version = "8.14.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.14.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.14.0-darwin-x64.tar.gz"
 etag = "cd6cfa062d4f62e7126ad653f8ed42aa"
 
 [[releases]]
 version = "8.14.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.14.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.14.1-darwin-x64.tar.gz"
 etag = "bf1e2d414c9b8b4ced0fb921536396fd"
 
 [[releases]]
 version = "8.15.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.15.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.15.0-darwin-x64.tar.gz"
 etag = "2b8d16fd1b804feb2534e5dc9d513e4f"
 
 [[releases]]
 version = "8.15.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.15.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.15.1-darwin-x64.tar.gz"
 etag = "bf05532c0ef3262c5a40a4af4ee8273a"
 
 [[releases]]
 version = "8.16.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.16.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.16.0-darwin-x64.tar.gz"
 etag = "765e9fb02e197f83d80f8afddf97438d"
 
 [[releases]]
 version = "8.16.1"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.16.1-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.16.1-darwin-x64.tar.gz"
 etag = "0d5148d32e59dafe82c772ede431290c"
 
 [[releases]]
 version = "8.16.2"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.16.2-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.16.2-darwin-x64.tar.gz"
 etag = "f5e20750bcc2d5b8642c1d0221f5ae71"
 
 [[releases]]
 version = "8.17.0"
 channel = "staging"
 arch = "darwin-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v8.17.0-darwin-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.17.0-darwin-x64.tar.gz"
 etag = "794cf5d11fa08aab90c69e879f82a117"
 
 [[releases]]
 version = "10.10.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.10.0-linux-x64.tar.gz"
 etag = "32f0212328dd2ece196a5f24fc64166a"
 
 [[releases]]
 version = "10.11.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.11.0-linux-x64.tar.gz"
 etag = "03cd8caf351086d45bd3482dc6d0a4fc"
 
 [[releases]]
 version = "10.12.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.12.0-linux-x64.tar.gz"
 etag = "1756916da001a529fac147f7e1b0eb20"
 
 [[releases]]
 version = "10.13.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.13.0-linux-x64.tar.gz"
 etag = "8f483498e00b376bcce2c310361cd356"
 
 [[releases]]
 version = "10.14.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.14.0-linux-x64.tar.gz"
 etag = "7bcec1016ab379018158e0bdfb228c6a"
 
 [[releases]]
 version = "10.14.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.14.1-linux-x64.tar.gz"
 etag = "0c5d5d45ddb467f3de47811a3a342dee"
 
 [[releases]]
 version = "10.14.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.14.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.14.2-linux-x64.tar.gz"
 etag = "e8465364a3a1d970f28e2d8dc166e9bb"
 
 [[releases]]
 version = "10.15.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.15.0-linux-x64.tar.gz"
 etag = "145eadc24238a890e2cf3abf96029065"
 
 [[releases]]
 version = "10.15.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.15.1-linux-x64.tar.gz"
 etag = "0aa5f7e95724d9c8b9c07576454c9893"
 
 [[releases]]
 version = "10.15.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.15.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.15.2-linux-x64.tar.gz"
 etag = "c923ec2f672a8f4dd33d3239c9c9eb04"
 
 [[releases]]
 version = "10.15.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.15.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.15.3-linux-x64.tar.gz"
 etag = "7068b1553f2b87ef33a3f296c94236c2"
 
 [[releases]]
 version = "10.16.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.16.0-linux-x64.tar.gz"
 etag = "88a233b41b26c1603d38f8b18c793a87"
 
 [[releases]]
 version = "10.16.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.16.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.16.1-linux-x64.tar.gz"
 etag = "559a1bd566c17d5e709374700f0e0db2"
 
 [[releases]]
 version = "10.16.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.16.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.16.2-linux-x64.tar.gz"
 etag = "6ffb45f911f4fc6888d092c4ce4ecbdd"
 
 [[releases]]
 version = "10.16.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.16.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.16.3-linux-x64.tar.gz"
 etag = "e6d2eb2af1aa2bce9b8309cefbb5e15f"
 
 [[releases]]
 version = "10.17.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.17.0-linux-x64.tar.gz"
 etag = "6fc78926853e1a4746578fed7cb7d699"
 
 [[releases]]
 version = "10.18.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.18.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.18.0-linux-x64.tar.gz"
 etag = "089b445b64c0879f6827061b6f976d9d"
 
 [[releases]]
 version = "10.18.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.18.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.18.1-linux-x64.tar.gz"
 etag = "bc4bc398faba57963fd48cc2343a47dd"
 
 [[releases]]
 version = "10.19.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.19.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.19.0-linux-x64.tar.gz"
 etag = "441a8e19ab9cd9884cbd24f85840c7a6"
 
 [[releases]]
 version = "10.20.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.20.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.20.0-linux-x64.tar.gz"
 etag = "44eba89064618c8c2c79402bcd0be63f-3"
 
 [[releases]]
 version = "10.20.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.20.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.20.1-linux-x64.tar.gz"
 etag = "b0f14eb6a6310f464c3db7544a3af492-3"
 
 [[releases]]
 version = "10.21.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.21.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.21.0-linux-x64.tar.gz"
 etag = "8d2f778b455afe7f80e6d1ea201f5733-3"
 
 [[releases]]
 version = "10.22.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.22.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.22.0-linux-x64.tar.gz"
 etag = "7cf59442c716572239cb14fdabb0ead5-3"
 
 [[releases]]
 version = "10.22.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.22.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.22.1-linux-x64.tar.gz"
 etag = "92b244406470e9a4f49cc233675fdf96-3"
 
 [[releases]]
 version = "10.23.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.23.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.23.0-linux-x64.tar.gz"
 etag = "3cc926fb4db5ad0d0ef161916760c25e-3"
 
 [[releases]]
 version = "10.23.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.23.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.23.1-linux-x64.tar.gz"
 etag = "5387220383fd6512e7cab92ef287426f-3"
 
 [[releases]]
 version = "10.23.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.23.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.23.2-linux-x64.tar.gz"
 etag = "f511a3763a63e7616fb608416e00a253-3"
 
 [[releases]]
 version = "10.23.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.23.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.23.3-linux-x64.tar.gz"
 etag = "6a05b6db3a7e812691eb2992c8287670-3"
 
 [[releases]]
 version = "10.24.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.24.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.24.0-linux-x64.tar.gz"
 etag = "b179fd013f51c02a3c77281fe744dd41-3"
 
 [[releases]]
 version = "10.24.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.24.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.24.1-linux-x64.tar.gz"
 etag = "957994ef8bf3610b7f0b67365691ebaf-3"
 
 [[releases]]
 version = "10.9.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.9.0-linux-x64.tar.gz"
 etag = "70c617771708c7c4f36d5823fb413600"
 
 [[releases]]
 version = "11.0.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.0.0-linux-x64.tar.gz"
 etag = "6cc8a0761f4266183190c56b72363e98"
 
 [[releases]]
 version = "11.1.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.1.0-linux-x64.tar.gz"
 etag = "6f471bc29d30640097c743927c113f02"
 
 [[releases]]
 version = "11.10.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.10.0-linux-x64.tar.gz"
 etag = "a1239a07fbd8b9dc460e1e44246e5f29"
 
 [[releases]]
 version = "11.10.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.10.1-linux-x64.tar.gz"
 etag = "1e462fb3a741ce0abf3fe2b0d81574e2"
 
 [[releases]]
 version = "11.11.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.11.0-linux-x64.tar.gz"
 etag = "009c70629178fb47044333aa4a031c77"
 
 [[releases]]
 version = "11.12.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.12.0-linux-x64.tar.gz"
 etag = "da2736962216075cb9ad09e87a7f300e"
 
 [[releases]]
 version = "11.13.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.13.0-linux-x64.tar.gz"
 etag = "95d07b2b544793962b0214bd7e33441c"
 
 [[releases]]
 version = "11.14.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.14.0-linux-x64.tar.gz"
 etag = "d1ec8cc7a5a102c92d5486cfa9e03b00"
 
 [[releases]]
 version = "11.15.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.15.0-linux-x64.tar.gz"
 etag = "ab251fc5b77761064204d00be022fda3"
 
 [[releases]]
 version = "11.2.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.2.0-linux-x64.tar.gz"
 etag = "6f1e2002e2af3f660ec0d84dda5e8a6a"
 
 [[releases]]
 version = "11.3.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.3.0-linux-x64.tar.gz"
 etag = "dc1a836d178e97e06107e1673d3caf96"
 
 [[releases]]
 version = "11.4.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.4.0-linux-x64.tar.gz"
 etag = "2718dafe1f89dd3794a0da222ee365ae"
 
 [[releases]]
 version = "11.5.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.5.0-linux-x64.tar.gz"
 etag = "7a32d6b4c300f6a7b78f3a28ed4587e3"
 
 [[releases]]
 version = "11.6.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.6.0-linux-x64.tar.gz"
 etag = "9ab9d9540290c15caad5fdf0a32b40fa"
 
 [[releases]]
 version = "11.7.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.7.0-linux-x64.tar.gz"
 etag = "35c41456320eb8a712dde2aac4145166"
 
 [[releases]]
 version = "11.8.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.8.0-linux-x64.tar.gz"
 etag = "7a6bdb9ffd31bc5ae4c6d866b5462826"
 
 [[releases]]
 version = "11.9.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.9.0-linux-x64.tar.gz"
 etag = "8805aeb4cfb798106c6a99ed34536682"
 
 [[releases]]
 version = "12.0.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.0.0-linux-x64.tar.gz"
 etag = "246f00fcffbd01974f260b4383f91c58"
 
 [[releases]]
 version = "12.1.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.1.0-linux-x64.tar.gz"
 etag = "d4df5a60e1b73c062131985de2ada621"
 
 [[releases]]
 version = "12.10.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.10.0-linux-x64.tar.gz"
 etag = "74dc625cf656bd501f0cd08f28e92131"
 
 [[releases]]
 version = "12.11.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.11.0-linux-x64.tar.gz"
 etag = "3ad3502adff89d3a037cd910ef17f725"
 
 [[releases]]
 version = "12.11.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.11.1-linux-x64.tar.gz"
 etag = "fb56b6d4439d3ccca91a8ff419391c3e"
 
 [[releases]]
 version = "12.12.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.12.0-linux-x64.tar.gz"
 etag = "41e3b3ccc2e2254869234f1f4c50dffc"
 
 [[releases]]
 version = "12.13.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.13.0-linux-x64.tar.gz"
 etag = "5f1bc3459c59f8b80cf6ea3d38944da7"
 
 [[releases]]
 version = "12.13.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.13.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.13.1-linux-x64.tar.gz"
 etag = "169ca5c7407b7532ed947a2014a48b1e"
 
 [[releases]]
 version = "12.14.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.14.0-linux-x64.tar.gz"
 etag = "919f124e16acb7464459c58dd2cfd36e"
 
 [[releases]]
 version = "12.14.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.14.1-linux-x64.tar.gz"
 etag = "cf97b81a436bdd484e642660eb769e16"
 
 [[releases]]
 version = "12.15.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.15.0-linux-x64.tar.gz"
 etag = "6c5ee256556aec2f1ca11f02b58d81b4"
 
 [[releases]]
 version = "12.16.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.16.0-linux-x64.tar.gz"
 etag = "7f8d2520e715d7df82f368b0fab9d2b6"
 
 [[releases]]
 version = "12.16.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.16.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.16.1-linux-x64.tar.gz"
 etag = "656435219a1655586fe02ac5f8bfa694"
 
 [[releases]]
 version = "12.16.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.16.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.16.2-linux-x64.tar.gz"
 etag = "ee1bd62aa6e09c627610868e3d0117bf-3"
 
 [[releases]]
 version = "12.16.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.16.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.16.3-linux-x64.tar.gz"
 etag = "f0478be22ff8042183df5b8cf0e6a736-3"
 
 [[releases]]
 version = "12.17.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.17.0-linux-x64.tar.gz"
 etag = "4a9c63315d8b0c2e41711caf04121acd-3"
 
 [[releases]]
 version = "12.18.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.0-linux-x64.tar.gz"
 etag = "cce51b56de0a404d30864591c1b6695c-3"
 
 [[releases]]
 version = "12.18.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.1-linux-x64.tar.gz"
 etag = "8e2e94383d7e833eb42fa619c27ed4df-3"
 
 [[releases]]
 version = "12.18.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.2-linux-x64.tar.gz"
 etag = "655570eb6f1b10edafc64366878dd03e-3"
 
 [[releases]]
 version = "12.18.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.3-linux-x64.tar.gz"
 etag = "9e7444e9d66072035f73e9ac0ee51322-3"
 
 [[releases]]
 version = "12.18.4"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.4-linux-x64.tar.gz"
 etag = "fdecf94ced8dcdeb972e14b333c72e47-3"
 
 [[releases]]
 version = "12.19.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.19.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.19.0-linux-x64.tar.gz"
 etag = "1962f4127fb09f2942b82f48f4ae2cf8-3"
 
 [[releases]]
 version = "12.19.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.19.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.19.1-linux-x64.tar.gz"
 etag = "7851352d2c9d60d4c5779910af828755-3"
 
 [[releases]]
 version = "12.2.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.2.0-linux-x64.tar.gz"
 etag = "87dc21fee7f484defd9010a6c606aa92"
 
 [[releases]]
 version = "12.20.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.20.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.20.0-linux-x64.tar.gz"
 etag = "3383e1624171a83a04740f24831c5c92-3"
 
 [[releases]]
 version = "12.20.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.20.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.20.1-linux-x64.tar.gz"
 etag = "51c80c3820855d8e77f37c9a67b9d89b-3"
 
 [[releases]]
 version = "12.20.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.20.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.20.2-linux-x64.tar.gz"
 etag = "d296cca07540a62c9c583ce4f23afee7-3"
 
 [[releases]]
 version = "12.21.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.21.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.21.0-linux-x64.tar.gz"
 etag = "a0fe4d871fc223d21fbac24689c598fd-3"
 
 [[releases]]
 version = "12.22.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.0-linux-x64.tar.gz"
 etag = "b0eb62d33d028e6cd3f1b7220b962a55-3"
 
 [[releases]]
 version = "12.22.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.1-linux-x64.tar.gz"
 etag = "4648915ed3eb1be12cf7cbe1c5b3e867-3"
 
 [[releases]]
 version = "12.22.10"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.10-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.10-linux-x64.tar.gz"
 etag = "58fe1bdc055914f433ee3f07bb380f36-3"
 
 [[releases]]
 version = "12.22.11"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.11-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.11-linux-x64.tar.gz"
 etag = "98a9f79ab4d7840b31c95968e82e9569-3"
 
 [[releases]]
 version = "12.22.12"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.12-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.12-linux-x64.tar.gz"
 etag = "84488d656cf19837e8dbc27b1a9993c9-3"
 
 [[releases]]
 version = "12.22.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.2-linux-x64.tar.gz"
 etag = "a014e16e46f6c158facd9d48c6a450f7-3"
 
 [[releases]]
 version = "12.22.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.3-linux-x64.tar.gz"
 etag = "41956f3f2a7cbbfc012e0d52facee55d-3"
 
 [[releases]]
 version = "12.22.4"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.4-linux-x64.tar.gz"
 etag = "461546c7894049caaa06041520e4172e-3"
 
 [[releases]]
 version = "12.22.5"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.5-linux-x64.tar.gz"
 etag = "2e8f7e52697114e493a312d7c4493fb0-3"
 
 [[releases]]
 version = "12.22.6"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.6-linux-x64.tar.gz"
 etag = "d61482b86203da8b3542f25723ca8f6a-3"
 
 [[releases]]
 version = "12.22.7"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.7-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.7-linux-x64.tar.gz"
 etag = "28b7bdac5d0a1a5361cf4504898d985e-3"
 
 [[releases]]
 version = "12.22.8"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.8-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.8-linux-x64.tar.gz"
 etag = "e7ca67cb90ca08afe64d87f9cdfbe2f9-3"
 
 [[releases]]
 version = "12.22.9"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.22.9-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.9-linux-x64.tar.gz"
 etag = "827ab91c2a29f14e1ad39e0fbd2ede10-3"
 
 [[releases]]
 version = "12.3.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.3.0-linux-x64.tar.gz"
 etag = "123a93553a06e8a7615c444c1ea42882"
 
 [[releases]]
 version = "12.3.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.3.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.3.1-linux-x64.tar.gz"
 etag = "82721dca1c9757af1e50fda8f23a0175"
 
 [[releases]]
 version = "12.4.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.4.0-linux-x64.tar.gz"
 etag = "75341c471626e3155079041fc8737bab"
 
 [[releases]]
 version = "12.5.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.5.0-linux-x64.tar.gz"
 etag = "7377ca5f3d429dba8069808c57509f24"
 
 [[releases]]
 version = "12.6.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.6.0-linux-x64.tar.gz"
 etag = "259326813ae277cf8a2cd764c610df8c"
 
 [[releases]]
 version = "12.7.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.7.0-linux-x64.tar.gz"
 etag = "b013a541a950c7ac8547622e4588542e"
 
 [[releases]]
 version = "12.8.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.8.0-linux-x64.tar.gz"
 etag = "2bc1f6bf496bfb6447c3fa129cf8a3d6"
 
 [[releases]]
 version = "12.8.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.8.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.8.1-linux-x64.tar.gz"
 etag = "f0ad395a6b921fa1121cd60aa3f47fef"
 
 [[releases]]
 version = "12.9.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.9.0-linux-x64.tar.gz"
 etag = "406857cde2b0012cb860653de74777ea"
 
 [[releases]]
 version = "12.9.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.9.1-linux-x64.tar.gz"
 etag = "74001acf6e4f1980045a985a86b198d1"
 
 [[releases]]
 version = "13.0.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.0.0-linux-x64.tar.gz"
 etag = "80ec0dee495ddf5ac1f52658fc7004d8"
 
 [[releases]]
 version = "13.0.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.0.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.0.1-linux-x64.tar.gz"
 etag = "248b1a416a4c2af6b888ce1897df12cd"
 
 [[releases]]
 version = "13.1.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.1.0-linux-x64.tar.gz"
 etag = "ef41097c9220782c8cac61161fe9eb60"
 
 [[releases]]
 version = "13.10.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.10.0-linux-x64.tar.gz"
 etag = "fc533a5c86419ad4976f7e15b5333100"
 
 [[releases]]
 version = "13.10.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.10.1-linux-x64.tar.gz"
 etag = "e5e28ed8047859e8be1cee3b7155df4e"
 
 [[releases]]
 version = "13.11.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.11.0-linux-x64.tar.gz"
 etag = "2af22200c0261f417cf32a3279da2621-4"
 
 [[releases]]
 version = "13.12.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.12.0-linux-x64.tar.gz"
 etag = "8d22abc5a44d5645c0a9eab6177df570-4"
 
 [[releases]]
 version = "13.13.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.13.0-linux-x64.tar.gz"
 etag = "b9a24b0caa34a7a12ebb3e31b6830769-4"
 
 [[releases]]
 version = "13.14.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.14.0-linux-x64.tar.gz"
 etag = "70ecff1b96a40b3330cc0b98ddf529b5-4"
 
 [[releases]]
 version = "13.2.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.2.0-linux-x64.tar.gz"
 etag = "021173844878f2a62d6644da631b384e"
 
 [[releases]]
 version = "13.3.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.3.0-linux-x64.tar.gz"
 etag = "0984273970fbe1b55d46a74132c79768"
 
 [[releases]]
 version = "13.4.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.4.0-linux-x64.tar.gz"
 etag = "822b0185650e14a8e614caa4db36e1b2"
 
 [[releases]]
 version = "13.5.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.5.0-linux-x64.tar.gz"
 etag = "28e68b5893a353dae4525655d3230d19"
 
 [[releases]]
 version = "13.6.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.6.0-linux-x64.tar.gz"
 etag = "5758d37594fa78cabb0b4578771a01fd"
 
 [[releases]]
 version = "13.7.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.7.0-linux-x64.tar.gz"
 etag = "66087b902dac00d18558ec6b892de497"
 
 [[releases]]
 version = "13.8.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.8.0-linux-x64.tar.gz"
 etag = "308ec153bc621d3ef32a3d9731083e44"
 
 [[releases]]
 version = "13.9.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.9.0-linux-x64.tar.gz"
 etag = "ba1fcf56182c7afb8863b3bff9469fb2"
 
 [[releases]]
 version = "14.0.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.0.0-linux-x64.tar.gz"
 etag = "4894abb65e1b01df7847a72cf5711cd7-4"
 
 [[releases]]
 version = "14.1.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.1.0-linux-x64.tar.gz"
 etag = "5acc3c5cb805c9714ee666212eeb7da8-4"
 
 [[releases]]
 version = "14.10.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.10.0-linux-x64.tar.gz"
 etag = "0692912fe38915d832ac97d9c8e75b6f-5"
 
 [[releases]]
 version = "14.10.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.10.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.10.1-linux-x64.tar.gz"
 etag = "4cc3f36a5a752141310ce9462b83b9e1-5"
 
 [[releases]]
 version = "14.11.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.11.0-linux-x64.tar.gz"
 etag = "5f0b0d752a988c5846e2850251d0de6e-5"
 
 [[releases]]
 version = "14.12.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.12.0-linux-x64.tar.gz"
 etag = "d543750360e322f6172ebbac5180f794-5"
 
 [[releases]]
 version = "14.13.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.13.0-linux-x64.tar.gz"
 etag = "d8db874594a71ef0a537e563f69403d5-5"
 
 [[releases]]
 version = "14.13.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.13.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.13.1-linux-x64.tar.gz"
 etag = "5fd8b1ffb4fe1f889bd39be6911ef12a-5"
 
 [[releases]]
 version = "14.14.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.14.0-linux-x64.tar.gz"
 etag = "8048c3ed071d05c927c4fbf21b7ce1d8-5"
 
 [[releases]]
 version = "14.15.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.0-linux-x64.tar.gz"
 etag = "53ded239e3e7b19ff58c63a13fc7295a-5"
 
 [[releases]]
 version = "14.15.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.1-linux-x64.tar.gz"
 etag = "ee95fa0dd4b142e075f7f61d6e9fdd3c-5"
 
 [[releases]]
 version = "14.15.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.15.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.2-linux-x64.tar.gz"
 etag = "f344e8a0fb555aa7cad8df8ee227c053-4"
 
 [[releases]]
 version = "14.15.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.15.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.3-linux-x64.tar.gz"
 etag = "929b59a348873583cf0eece6e997f694-4"
 
 [[releases]]
 version = "14.15.4"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.15.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.4-linux-x64.tar.gz"
 etag = "ad295578e70f4838d619a289c7d7654e-4"
 
 [[releases]]
 version = "14.15.5"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.15.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.5-linux-x64.tar.gz"
 etag = "78ef6759634ee37a78d17be7af46ed79-4"
 
 [[releases]]
 version = "14.16.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.16.0-linux-x64.tar.gz"
 etag = "f2cbbae39184fee9c13b611437b10921-4"
 
 [[releases]]
 version = "14.16.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.16.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.16.1-linux-x64.tar.gz"
 etag = "e03bf3ea73d969d9c08c8b7ae5493613-4"
 
 [[releases]]
 version = "14.17.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.0-linux-x64.tar.gz"
 etag = "cdc57f6a3cc4ca6f12f49dadd75a554e-5"
 
 [[releases]]
 version = "14.17.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.17.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.1-linux-x64.tar.gz"
 etag = "b41c1f2d90ecda727af59f7cc7c5dcfb-5"
 
 [[releases]]
 version = "14.17.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.17.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.2-linux-x64.tar.gz"
 etag = "7021d231631d65ece0f74c95bbc43eb3-5"
 
 [[releases]]
 version = "14.17.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.17.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.3-linux-x64.tar.gz"
 etag = "0bdbb8e1b6e813dbc040da523831c684-5"
 
 [[releases]]
 version = "14.17.4"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.17.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.4-linux-x64.tar.gz"
 etag = "81ca69987ef377abff2ecb2ae35d7ad7-5"
 
 [[releases]]
 version = "14.17.5"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.17.5-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.5-linux-x64.tar.gz"
 etag = "4e872307dfbc942a43b0eb5e6e44765c-5"
 
 [[releases]]
 version = "14.17.6"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.17.6-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.6-linux-x64.tar.gz"
 etag = "888e9ad0d2a56802507f3f6cd27f7ebe-5"
 
 [[releases]]
 version = "14.18.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.18.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.18.0-linux-x64.tar.gz"
 etag = "a667cd6939a25a71d4773357a693e170-5"
 
 [[releases]]
 version = "14.18.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.18.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.18.1-linux-x64.tar.gz"
 etag = "4a620703f674343fe1041b2bd0dfba66-5"
 
 [[releases]]
 version = "14.18.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.18.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.18.2-linux-x64.tar.gz"
 etag = "dad4b0c2b0daed55d75fd98500e57d62-5"
 
 [[releases]]
 version = "14.18.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.18.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.18.3-linux-x64.tar.gz"
 etag = "af7ed8db30228507dad9cf71afcce543-5"
 
 [[releases]]
 version = "14.19.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.19.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.0-linux-x64.tar.gz"
 etag = "06a14f4fdc59ae064ba047d4e9736fa3-5"
 
 [[releases]]
 version = "14.19.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.19.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.1-linux-x64.tar.gz"
 etag = "fcb00a3d0c4b22c1b6e157a558949657-5"
 
 [[releases]]
 version = "14.19.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.19.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.2-linux-x64.tar.gz"
 etag = "a6dd0bfb2f656166aeefefa37cfa8122-5"
 
 [[releases]]
 version = "14.19.3"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.19.3-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.3-linux-x64.tar.gz"
 etag = "3990a70c4d0794e8646575c76bff11a7-5"
 
 [[releases]]
 version = "14.2.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.2.0-linux-x64.tar.gz"
 etag = "f41be74dd195a5714eabfeb4b3b95cc2-4"
 
 [[releases]]
 version = "14.3.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.3.0-linux-x64.tar.gz"
 etag = "4dcfa3708c0bab7b77783a543e37120e-4"
 
 [[releases]]
 version = "14.4.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.4.0-linux-x64.tar.gz"
 etag = "cb4e531dd8b4cca8883d3884b4345644-4"
 
 [[releases]]
 version = "14.5.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.5.0-linux-x64.tar.gz"
 etag = "5c92a547ff32fe8f9c507455863ab531-5"
 
 [[releases]]
 version = "14.6.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.6.0-linux-x64.tar.gz"
 etag = "e076d8f3ac1ffaf3540b6bff5fa14dd1-5"
 
 [[releases]]
 version = "14.7.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.7.0-linux-x64.tar.gz"
 etag = "98021eb36abb1d21ed54521a85ce5fa6-5"
 
 [[releases]]
 version = "14.8.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.8.0-linux-x64.tar.gz"
 etag = "00e00bc07580f6376df8f218b7196594-5"
 
 [[releases]]
 version = "14.9.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v14.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.9.0-linux-x64.tar.gz"
 etag = "2353027766ae1fdc82aa2fefc9cfad25-5"
 
 [[releases]]
 version = "15.0.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.0.0-linux-x64.tar.gz"
 etag = "39eea40a8dc5ca81ef1010088ae74ea5-5"
 
 [[releases]]
 version = "15.0.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.0.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.0.1-linux-x64.tar.gz"
 etag = "4066ea9cd7b29f9084c237a1024872c7-5"
 
 [[releases]]
 version = "15.1.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.1.0-linux-x64.tar.gz"
 etag = "e1d3af432eb7accbfc614a3cf48c7583-4"
 
 [[releases]]
 version = "15.10.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.10.0-linux-x64.tar.gz"
 etag = "485a712d740b014662a226e834bd9557-4"
 
 [[releases]]
 version = "15.11.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.11.0-linux-x64.tar.gz"
 etag = "ef6f1f9484a255594673ca7bcfbed280-4"
 
 [[releases]]
 version = "15.12.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.12.0-linux-x64.tar.gz"
 etag = "231a5764d7aafa2c8d99fcd147b0e875-4"
 
 [[releases]]
 version = "15.13.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.13.0-linux-x64.tar.gz"
 etag = "6a6b953c042ee7fca4a7e4482de60dc2-4"
 
 [[releases]]
 version = "15.14.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.14.0-linux-x64.tar.gz"
 etag = "0f2e0ef70eebc4840eab7547e59880ae-4"
 
 [[releases]]
 version = "15.2.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.2.0-linux-x64.tar.gz"
 etag = "784df9e5242bb304820b2c14512d9ce3-4"
 
 [[releases]]
 version = "15.2.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.2.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.2.1-linux-x64.tar.gz"
 etag = "ca1c922ba43df36fbb23fd8b3a8ea876-4"
 
 [[releases]]
 version = "15.3.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.3.0-linux-x64.tar.gz"
 etag = "292ba2368577fa093bedb1b7f5014402-4"
 
 [[releases]]
 version = "15.4.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.4.0-linux-x64.tar.gz"
 etag = "69eeff861c07a0fed33fda82b35a5ecb-4"
 
 [[releases]]
 version = "15.5.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.5.0-linux-x64.tar.gz"
 etag = "b5bc122b0bb815f48128c67709a76cf0-4"
 
 [[releases]]
 version = "15.5.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.5.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.5.1-linux-x64.tar.gz"
 etag = "37e51c2d28beb27f4488fbd5b4a58f59-4"
 
 [[releases]]
 version = "15.6.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.6.0-linux-x64.tar.gz"
 etag = "aeb1a459afa11e7fc482e0a672cf1fe2-4"
 
 [[releases]]
 version = "15.7.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.7.0-linux-x64.tar.gz"
 etag = "065a4833bd91372bf26a45a46820f77a-4"
 
 [[releases]]
 version = "15.8.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.8.0-linux-x64.tar.gz"
 etag = "e88c6266c1926b5c4348ad943e1c2ee2-4"
 
 [[releases]]
 version = "15.9.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v15.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.9.0-linux-x64.tar.gz"
 etag = "38308de828100c4f52adb07e8de3cc9d-4"
 
 [[releases]]
 version = "16.0.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.0.0-linux-x64.tar.gz"
 etag = "9ced677cf96c5ca3b4067f35c21311ac-4"
 
 [[releases]]
 version = "16.1.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.1.0-linux-x64.tar.gz"
 etag = "8d4e3e558429cf64b22302f210b3d7e5-4"
 
 [[releases]]
 version = "16.10.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.10.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.10.0-linux-x64.tar.gz"
 etag = "d91908102992fad63e2eb2c9b8082553-4"
 
 [[releases]]
 version = "16.11.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.11.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.11.0-linux-x64.tar.gz"
 etag = "c93e9efb20bf3f5807ec0e058bd83d5c-4"
 
 [[releases]]
 version = "16.11.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.11.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.11.1-linux-x64.tar.gz"
 etag = "ae7ebdb2d57c11865882e4dc3d6fc5e5-4"
 
 [[releases]]
 version = "16.12.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.12.0-linux-x64.tar.gz"
 etag = "66344ff27247c29c3a5fbe85fe5acb9d-4"
 
 [[releases]]
 version = "16.13.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.13.0-linux-x64.tar.gz"
 etag = "d445951da7d338a5d6d758aa24b6804d-4"
 
 [[releases]]
 version = "16.13.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.13.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.13.1-linux-x64.tar.gz"
 etag = "5ed5638fad670c7568cb216775f03cc6-4"
 
 [[releases]]
 version = "16.13.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.13.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.13.2-linux-x64.tar.gz"
 etag = "8104fa926e76b71b0c22236b24310732-4"
 
 [[releases]]
 version = "16.14.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.0-linux-x64.tar.gz"
 etag = "5bc4c0b1c1c94fad08c80561e259ee99-4"
 
 [[releases]]
 version = "16.14.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.1-linux-x64.tar.gz"
 etag = "64b4bbdf40af72cd2fe6accfc8054b16-4"
 
 [[releases]]
 version = "16.14.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.14.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.2-linux-x64.tar.gz"
 etag = "4db20ae2bbff10cf3c8aa2f7ea370fb0-4"
 
 [[releases]]
 version = "16.15.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.15.0-linux-x64.tar.gz"
 etag = "4df8f054993a43950ef0f2e42b9ff53d-4"
 
 [[releases]]
 version = "16.15.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.15.1-linux-x64.tar.gz"
 etag = "b863d244e4b1c0df901c8c8c8967dd68-4"
 
 [[releases]]
 version = "16.2.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.2.0-linux-x64.tar.gz"
 etag = "ee81bd1f587c60c54432650eba4c51bc-4"
 
 [[releases]]
 version = "16.3.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.3.0-linux-x64.tar.gz"
 etag = "b0a9cecd669951adac9e27a35102923d-4"
 
 [[releases]]
 version = "16.4.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.4.0-linux-x64.tar.gz"
 etag = "8a77e82e1ca44f4fe1922714403161e8-4"
 
 [[releases]]
 version = "16.4.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.4.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.4.1-linux-x64.tar.gz"
 etag = "558b0575a48ff39c21a1fd9402fa0b84-4"
 
 [[releases]]
 version = "16.4.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.4.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.4.2-linux-x64.tar.gz"
 etag = "722a9783a7201b020ad6a89b9703cc3b-4"
 
 [[releases]]
 version = "16.5.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.5.0-linux-x64.tar.gz"
 etag = "5322a660d103a2974b9e073eae890bfb-4"
 
 [[releases]]
 version = "16.6.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.6.0-linux-x64.tar.gz"
 etag = "dfbee0cdf68d776ad1e51ca482250b0a-4"
 
 [[releases]]
 version = "16.6.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.6.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.6.1-linux-x64.tar.gz"
 etag = "bc15b11b0fd5ff2b62c6bf83646c82df-4"
 
 [[releases]]
 version = "16.6.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.6.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.6.2-linux-x64.tar.gz"
 etag = "0f897c317d9f01058731d4d283ce1cf2-4"
 
 [[releases]]
 version = "16.7.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.7.0-linux-x64.tar.gz"
 etag = "5db3c31791f4f8f75a8e8737e2ad2382-4"
 
 [[releases]]
 version = "16.8.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.8.0-linux-x64.tar.gz"
 etag = "2cf9f82dd69a9d35ba71532459629f83-4"
 
 [[releases]]
 version = "16.9.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.9.0-linux-x64.tar.gz"
 etag = "f76ebd4df376e0a9a8138bfcbe3a3079-4"
 
 [[releases]]
 version = "16.9.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v16.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.9.1-linux-x64.tar.gz"
 etag = "b591f8229fa8bf2f0a387c23b8277c55-4"
 
 [[releases]]
 version = "17.0.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.0.0-linux-x64.tar.gz"
 etag = "86c99126a99b3a82d007caedabdb9fa1-6"
 
 [[releases]]
 version = "17.0.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.0.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.0.1-linux-x64.tar.gz"
 etag = "10dc62fa317414c345bed79c04cc71fc-6"
 
 [[releases]]
 version = "17.1.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.1.0-linux-x64.tar.gz"
 etag = "8bf50f0462ee3144f34c6da85ae09e32-6"
 
 [[releases]]
 version = "17.2.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.2.0-linux-x64.tar.gz"
 etag = "0aee67a645145fd83f1e9c333c68c655-6"
 
 [[releases]]
 version = "17.3.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.3.0-linux-x64.tar.gz"
 etag = "43a9c23500b6183f63c62fe1c72bbdcd-6"
 
 [[releases]]
 version = "17.3.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.3.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.3.1-linux-x64.tar.gz"
 etag = "89f0dc5714f090fb5255b2ab4b943c03-6"
 
 [[releases]]
 version = "17.4.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.4.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.4.0-linux-x64.tar.gz"
 etag = "72cd45ee41e736a3d15ccd255bc42ea5-6"
 
 [[releases]]
 version = "17.5.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.5.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.5.0-linux-x64.tar.gz"
 etag = "85ca8cdd9038440dbad047487fe5caad-6"
 
 [[releases]]
 version = "17.6.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.6.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.6.0-linux-x64.tar.gz"
 etag = "acb898de485f6fd431c5bba29737cdd6-6"
 
 [[releases]]
 version = "17.7.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.7.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.7.0-linux-x64.tar.gz"
 etag = "3ae4ee1f090945e80ad2209beb2c019e-6"
 
 [[releases]]
 version = "17.7.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.7.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.7.1-linux-x64.tar.gz"
 etag = "45444848e3db9df8e1906f30303f0b73-6"
 
 [[releases]]
 version = "17.7.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.7.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.7.2-linux-x64.tar.gz"
 etag = "5bfd0dc5e7e878dd4561fd0e41035051-6"
 
 [[releases]]
 version = "17.8.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.8.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.8.0-linux-x64.tar.gz"
 etag = "062cf4cae4ec3b032c41909a49df706e-6"
 
 [[releases]]
 version = "17.9.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.9.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.9.0-linux-x64.tar.gz"
 etag = "d82856ef7d8fd6ee756e0c4054e686aa-6"
 
 [[releases]]
 version = "17.9.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v17.9.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.9.1-linux-x64.tar.gz"
 etag = "5abb91fe234c1cb3709811ca8c62ee88-6"
 
 [[releases]]
 version = "18.0.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v18.0.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.0.0-linux-x64.tar.gz"
 etag = "48ae6c63e24f5ce074e86188287198e0-6"
 
 [[releases]]
 version = "18.1.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v18.1.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.1.0-linux-x64.tar.gz"
 etag = "37faa7d1b87accc2b5f8c5c8af3d4a85-6"
 
 [[releases]]
 version = "18.2.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v18.2.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.2.0-linux-x64.tar.gz"
 etag = "3e7b3258d258a95ba0e1ad06ed7f482d-6"
 
 [[releases]]
 version = "18.3.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v18.3.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.3.0-linux-x64.tar.gz"
 etag = "0882fd16bcfeabd57379441604051ca4-6"
 
 [[releases]]
 version = "6.14.4"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v6.14.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.14.4-linux-x64.tar.gz"
 etag = "c81242d62dbad357134ad9e8c938fce6"
 
 [[releases]]
 version = "6.15.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v6.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.15.0-linux-x64.tar.gz"
 etag = "bc75fc652bb28aa07d92e99b212dd75e"
 
 [[releases]]
 version = "6.15.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v6.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.15.1-linux-x64.tar.gz"
 etag = "8b6b409811ba540653b06a2f87af2b58"
 
 [[releases]]
 version = "6.16.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v6.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.16.0-linux-x64.tar.gz"
 etag = "e4b7d1cc7c4156ae36af213795b9a2ab"
 
 [[releases]]
 version = "6.17.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v6.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.17.0-linux-x64.tar.gz"
 etag = "24b84466f5f921fa793243f87915800a"
 
 [[releases]]
 version = "6.17.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v6.17.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.17.1-linux-x64.tar.gz"
 etag = "eb59e6ef416d02bfcd1188b4151bddcd"
 
 [[releases]]
 version = "8.11.4"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.11.4-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.11.4-linux-x64.tar.gz"
 etag = "5764e757cee7ffa6eda727784ac2dde8"
 
 [[releases]]
 version = "8.12.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.12.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.12.0-linux-x64.tar.gz"
 etag = "c2dc07f9b840abe01461328caad03179"
 
 [[releases]]
 version = "8.13.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.13.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.13.0-linux-x64.tar.gz"
 etag = "ec5e096251b6b78f508971d7038a5d14"
 
 [[releases]]
 version = "8.14.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.14.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.14.0-linux-x64.tar.gz"
 etag = "6e1117831d6dfa9cf73a998f84a70aa2"
 
 [[releases]]
 version = "8.14.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.14.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.14.1-linux-x64.tar.gz"
 etag = "b62684a89bde079c53fb54dce47ff715"
 
 [[releases]]
 version = "8.15.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.15.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.15.0-linux-x64.tar.gz"
 etag = "117139b710ca7795feda9e643ce11fe9"
 
 [[releases]]
 version = "8.15.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.15.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.15.1-linux-x64.tar.gz"
 etag = "4c4497b86c0004401d5a93aa36c7e959"
 
 [[releases]]
 version = "8.16.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.16.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.16.0-linux-x64.tar.gz"
 etag = "caabf1838fba99b1d228dfa66c38254f"
 
 [[releases]]
 version = "8.16.1"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.16.1-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.16.1-linux-x64.tar.gz"
 etag = "7208de0aad92d58374fa8f3763d6305c"
 
 [[releases]]
 version = "8.16.2"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.16.2-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.16.2-linux-x64.tar.gz"
 etag = "327ec94535ca1a5390fd2eebb970936d"
 
 [[releases]]
 version = "8.17.0"
 channel = "staging"
 arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v8.17.0-linux-x64.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.17.0-linux-x64.tar.gz"
 etag = "6218e59c4e3632a4b4eae5214aceeb08"
 

--- a/common/nodejs-utils/src/inv.rs
+++ b/common/nodejs-utils/src/inv.rs
@@ -94,8 +94,7 @@ mod tests {
 
     fn url(version: &str, arch: &str, channel: &str) -> String {
         format!(
-            "https://s3.amazonaws.com/heroku-nodebin/node/{}/{}/node-v{}-{}.tar.gz",
-            channel, arch, version, arch
+            "https://{BUCKET}.s3.{REGION}.amazonaws.com/node/{channel}/{arch}/node-v{version}-{arch}.tar.gz"
         )
     }
 

--- a/common/nodejs-utils/src/nodebin_s3.rs
+++ b/common/nodejs-utils/src/nodebin_s3.rs
@@ -1,4 +1,4 @@
-use crate::inv::{Inventory, Release, BUCKET};
+use crate::inv::{Inventory, Release, BUCKET, REGION};
 use crate::vrs::Version;
 use anyhow::{anyhow, Error};
 use chrono::{DateTime, Utc};
@@ -80,7 +80,10 @@ impl TryFrom<BucketContent> for Inventory {
                     channel: channel.as_str().to_string(),
                     // Amazon S3 returns a quoted string for ETags
                     etag: Some(content.etag.replace('\"', "")),
-                    url: format!("https://s3.amazonaws.com/{}/{}", BUCKET, &content.key),
+                    url: format!(
+                        "https://{BUCKET}.s3.{REGION}.amazonaws.com/{}",
+                        &content.key
+                    ),
                 })
             })
             .collect();


### PR DESCRIPTION
S3 URLs where the bucket name is part of the URL path are deprecated.

Instead, it's recommended to use the virtual-hosted style references, where the bucket name is part of the domain. 

The latter allows AWS to use DNS to direct requests directly to the appropriate region's S3 endpoint, rather than having to route via the global S3 endpoint (which AWS describe as being a single point of failure/harder to scale etc).

There is a small chance this may also help with some of the S3 reliability issues seen in [heroku/builder](https://github.com/heroku/builder) Circle CI runs - however even if it doesn't, at least we'll no longer be using the deprecated URLs/endpoints.

See:
https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.