### PR TITLE
Fix compilation of buildpack on ARM64

### DIFF
--- a/common/nodejs-utils/src/inv.rs
+++ b/common/nodejs-utils/src/inv.rs
@@ -15,7 +15,6 @@ pub const OS: &str = "darwin";
 pub const OS: &str = "linux";
 
 /// Default/assumed architecture for node release lookups
-#[cfg(target_arch = "x86_64")]
 pub const ARCH: &str = "x64";
 
 /// Represents a software inventory with releases.


### PR DESCRIPTION
Previously it wasn't possible to compile the Rust parts of the buildpack on ARM64 (such as when using an M1 Macbook), since the compile failed with:

```
error[E0425]: cannot find value `ARCH` in this scope
  --> common/nodejs-utils/src/inv.rs:45:45
   |
45 |         let platform = format!("{}-{}", OS, ARCH);
   |                                             ^^^^ not found in this scope
   |
help: consider importing this constant
   |
1  | use std::env::consts::ARCH;
   |
```

This makes contributing to the buildpack from an M1 machine frustrating, since one has to comment out the architecture conditional every time, then remember not to include it in the commit with the other changes.

At such time as the Node.js buildpack fully supports ARM64 Docker images, conditionals can be added back with the appropriate platform values.

Fixes #310.
GUS-W-11817789.