### PR TITLE
Bump sf-fx-runtime-nodejs to 0.12.0

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update `sf-fx-runtime-nodejs` to `0.12.0`. ([#362](https://github.com/heroku/buildpacks-nodejs/pull/362))
 - Upgrade `libcnb` and `libherokubuildpack` to `0.11.0`. ([#360](https://github.com/heroku/buildpacks-nodejs/pull/360))
 
 ## [0.3.4] 2022/09/12

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -22,7 +22,7 @@ id = "heroku-22"
 [metadata]
 
 [metadata.runtime]
-package = "@heroku/sf-fx-runtime-nodejs@0.11.2"
+package = "@heroku/sf-fx-runtime-nodejs@0.12.0"
 
 [metadata.release]
 


### PR DESCRIPTION
This will make all the changes listed in https://github.com/forcedotcom/sf-fx-runtime-nodejs/blob/main/CHANGELOG.md#0120---2022-09-28 available.

GUS-W-11543492