### PR TITLE
Fix permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     name: Release ${{ github.event.inputs.requested_buildpack_id }}
     runs-on: ubuntu-20.04 # ubuntu-latest currently resolves to 18.04 which does not have aws-cli 2.x yet
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       REQUESTED_BUILDPACK_ID: ${{ github.event.inputs.requested_buildpack_id }}
     steps:


### PR DESCRIPTION
I noticed this in the https://github.com/heroku/buildpacks-jvm repository. It looks like the default token permissions have been overridden by an org-wide policy. This change restores the required permissions for the release workflow.

Refs: https://github.com/heroku/buildpacks-jvm/pull/389, GUS-W-11937667