### PR TITLE
fix: use the proper command path for local/global runtime

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix `sf-fx-runtime-nodejs` dependency installing from `npx` at application startup when implicit runtime dependency is used ([#382](https://github.com/heroku/buildpacks-nodejs/pull/382))
 
 ## [0.3.6] 2022/10/26
 - Support explicit Functions Runtime for Node.js as dependency in package.json ([#373](https://github.com/heroku/buildpacks-nodejs/pull/373))

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -6,6 +6,7 @@ use std::fmt::Formatter;
 use std::time::Duration;
 
 const PORT: u16 = 8080;
+const TIMEOUT: u64 = 10;
 
 pub enum Builder {
     Heroku20,
@@ -46,7 +47,7 @@ pub fn test_node_function(fixture: &str, builder: Builder, test_body: fn(TestCon
 
 pub fn assert_health_check_responds(ctx: &TestContext) {
     ctx.start_container(ContainerConfig::new().expose_port(PORT), |container| {
-        std::thread::sleep(Duration::from_secs(5));
+        std::thread::sleep(Duration::from_secs(TIMEOUT));
 
         let addr = container
             .address_for_port(PORT)


### PR DESCRIPTION
This is a fix against the changes introduced with [#373](https://github.com/heroku/buildpacks-nodejs/pull/373) where the use of `npx` was not detecting the runtime command (`sf-fx-runtime-nodejs`) already installed globally.

The effect of which was the runtime would be downloaded when the Function application initially starts up which is not ideal since it causes slower boot times + may cause non-deterministic behavior.

[W-11854639](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000017vsgyYAA/view?ws=%2Flightning%2Fr%2FADM_Epic__c%2Fa3QEE000000MuDF2A0%2Fview)