### PR TITLE
Don't overwrite WEB_CONCURRENCY with a different value

### DIFF
--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Don't overwrite WEB_CONCURRENCY if already set. ([#386](https://github.com/heroku/buildpacks-nodejs/pull/386))
+
 ## [0.8.10] 2022/10/28
 
 - Added node version 18.12.0.

--- a/buildpacks/nodejs-engine/src/bin/web_env.rs
+++ b/buildpacks/nodejs-engine/src/bin/web_env.rs
@@ -66,6 +66,8 @@ mod tests {
 
     #[test]
     fn test_web_env_default() {
+        env::remove_var("WEB_CONCURRENCY");
+        env::remove_var("WEB_MEMORY");
         let web_env = web_env();
         let web_concurrency: usize = web_env
             .get("WEB_CONCURRENCY")
@@ -78,6 +80,7 @@ mod tests {
             .parse()
             .expect("WEB_MEMORY should be a number");
 
+        println!("WEB_CONCURRENCY: {web_concurrency}");
         assert!((1..=32).contains(&web_concurrency));
         assert!((256..=2048).contains(&web_memory));
     }


### PR DESCRIPTION
Fixes #210. If `WEB_CONCURRENCY` is set, the buildpack shouldn't change the value.

[W-11985938](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00001B8AjcYAF)