### PR TITLE
Update `sf-fx-runtime-nodejs` from 0.12.0 to 0.14.0

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Update `sf-fx-runtime-nodejs` from `0.12.0` to `0.14.0` for functions still using the implicit dependency
 
 ## [0.3.7] 2022/10/28
 - Fix `sf-fx-runtime-nodejs` dependency installing from `npx` at application startup when implicit runtime dependency is used ([#382](https://github.com/heroku/buildpacks-nodejs/pull/382))

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Update `sf-fx-runtime-nodejs` from `0.12.0` to `0.14.0` for functions still using the implicit dependency
+- Update `sf-fx-runtime-nodejs` from `0.12.0` to `0.14.0` for functions still using the implicit dependency ([#401](https://github.com/heroku/buildpacks-nodejs/pull/401))
 
 ## [0.3.7] 2022/10/28
 - Fix `sf-fx-runtime-nodejs` dependency installing from `npx` at application startup when implicit runtime dependency is used ([#382](https://github.com/heroku/buildpacks-nodejs/pull/382))

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -23,7 +23,7 @@ id = "heroku-22"
 
 [metadata.runtime]
 package_name = "@heroku/sf-fx-runtime-nodejs"
-package_version = "0.12.0"
+package_version = "0.14.0"
 
 [metadata.release]
 


### PR DESCRIPTION
Updates the buildpack to use the `0.14.0` version of the node function runtime for functions that still rely on the implicit dependency.