### PR TITLE
Add heroku/nodejs-corepack leveraging libcnb.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "heroku-nodejs-corepack-buildpack"
+version = "0.0.0"
+dependencies = [
+ "heroku-nodejs-utils",
+ "libcnb",
+ "libcnb-test",
+ "libherokubuildpack",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "toml",
+ "ureq",
+]
+
+[[package]]
 name = "heroku-nodejs-engine-buildpack"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,9 +505,8 @@ dependencies = [
  "libcnb-test",
  "libherokubuildpack",
  "serde",
- "tempfile",
+ "test_support",
  "thiserror",
- "toml",
  "ureq",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ name = "heroku-nodejs-corepack-buildpack"
 version = "0.0.0"
 dependencies = [
  "heroku-nodejs-utils",
+ "indoc",
  "libcnb",
  "libcnb-test",
  "libherokubuildpack",
@@ -701,6 +702,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "indoc"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
 
 [[package]]
 name = "instant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "buildpacks/nodejs-engine",
+  "buildpacks/nodejs-corepack",
   "buildpacks/nodejs-function-invoker",
   "buildpacks/nodejs-yarn",
   "common/nodejs-utils",

--- a/buildpacks/nodejs-corepack/CHANGELOG.md
+++ b/buildpacks/nodejs-corepack/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+# 0.1.0
+
+- Initial implementation with libcnb.rs ([#418](https://github.com/heroku/buildpacks-nodejs/pull/418))

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "heroku-nodejs-corepack-buildpack"
+version = "0.0.0"
+description = "Heroku Node.js Corepack Cloud Native Buildpack"
+publish = false
+edition = "2021"
+rust-version = "1.64"
+
+[dependencies]
+heroku-nodejs-utils = { path = "../../common/nodejs-utils" }
+libcnb = "0.11"
+libherokubuildpack = "0.11"
+serde = "1.0.149"
+tempfile = "3.3.0"
+toml = "0.5"
+thiserror = "1.0"
+
+[dev-dependencies]
+libcnb-test = "0.11"
+ureq = "2.5.0"

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -11,10 +11,9 @@ heroku-nodejs-utils = { path = "../../common/nodejs-utils" }
 libcnb = "0.11"
 libherokubuildpack = "0.11"
 serde = "1.0.149"
-tempfile = "3.3.0"
-toml = "0.5"
 thiserror = "1.0"
 
 [dev-dependencies]
 libcnb-test = "0.11"
+test_support = { path = "../../test_support" }
 ureq = "2.5.0"

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -12,6 +12,7 @@ libcnb = "0.11"
 libherokubuildpack = "0.11"
 serde = "1.0.149"
 thiserror = "1.0"
+indoc = "1.0"
 
 [dev-dependencies]
 libcnb-test = "0.11"

--- a/buildpacks/nodejs-corepack/README.md
+++ b/buildpacks/nodejs-corepack/README.md
@@ -1,0 +1,78 @@
+# Node.js Yarn Cloud Native Buildpack
+
+Heroku's official Cloud Native Buildpack for [Yarn](https://yarnpkg.com).
+
+[![CI](https://github.com/heroku/buildpacks-nodejs/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/buildpacks-nodejs/actions/workflows/ci.yml)
+
+[![Registry](https://img.shields.io/badge/dynamic/json?url=https://registry.buildpacks.io/api/v1/buildpacks/heroku/nodejs-corepack&label=version&query=$.latest.version&color=DF0A6B&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAACSVJREFUaAXtWQ1sFMcVnp/9ub3zHT7AOEkNOMYYp4CQQFBLpY1TN05DidI2NSTF0CBFQAOBNrTlp0a14sipSBxIG6UYHKCO2ka4SXD4SUuaCqmoJJFMCapBtcGYGqMkDgQ4++52Z2e3b87es+/s+wNHVSUPsnZv9s2b97335v0MCI2NMQ2MaeD/WgP4FqQnX//2K4tVWfa0X+9+q/N4dfgWeESXPPjUUd+cu+5cYmMcPvzawQOtrdVG9GMaLxkD+OZDex6WVeUgwhiZnH1g62bNX4+sPpLGXvEkdPNzLd93e9y/cCnabIQJCnz+2Q9rNs9tjCdM9ltK9nGkb5jYxYjIyDJDSCLSV0yFHCr/XsObvQH92X+8u/b0SGvi5zZUn1joc/u2qapajglB4XAfUlQPoqpyRzxtqt8ZA+AIcQnZEb6WZSKCMSZUfSTLg8vv/86e3b03AztO/u3p7pE2fvInfy70TpiwRVKU5YqqygbTEWL9lISaiDFujbQu2VzGAIYzs5HFDUQo8WKibMzy0Yr7Ht5Td/Nyd0NLS3VQ0FesOjDurtwvPaWp6gZVc080TR2FQn0xrAgxkWVkLD8aBQD9cti2hWwAQimdImHpJTplcmXppF11hcV3Z/n92RsVVbuHc4bCod4YwZ0fHACYCCyS4Rg1AM6+ts2R+JOpNF/Okl/PyvLCeQc/j9O4Q+88hQWY/j+0gCOI84ycD0oRNxnSAVCqgYUFgDbTMeoWiBeAcRNRm8ZPD/uNCYfIZg6bTzXxxQKw4YCboH3SH7WSCRNxIQCb6fhiAYA0JgAgaQAQFhC0mY6MAYAzUIj9KN3jZoJbUEhWqQYBAJxZqX0tjlHGACyLtzKmM0pl2YKwmHzYcIjBt0kyuBhJVEKGHkKQ2DqT8xv+NWPEF9uOtOVNLz8B6XcqJVI+JGIIm4l8HCNVVSLfbctG8X9wOBDCFOl6+FRI19c07TvQjNDZRMyGSw8zGRdzUS7zVsnfyJtfSTHZLMlKkQ1lhUhmQ4cAl5XlgTwQu43IC4TK4PN6t8nMHR093bvOHPtZbGoeyijJeyznJISJPhWVvjAxL9u/VsZoHZGUif1u1a9EIbjLpQ4CgN/gegiE7uW2uffzgFV34tCK/yTinc78bQNwNllY9nKRy+feBE6xnEpS9HwoihwBQIgEGgdfs81mHjaeeeftJ/7prL2d56gBcIQoXfzbUpXKVUSWy8QcgQgkPMi0+IeQnZ899sYThxza0XiOOoABoQhUpJUypusRBFyO0W/ea/vLH1FrU0bd1mgAvD0ecNDRzGrl9pgkXB1RvlQw5dEyrKpVEI8+Ni19+6Xzr9+yby57sNrnK5y12u3xPhIOB8+d7mhbv//tTQaetmanROX5JueNXfzs7+7rPH7LffS1Rw9+zZvt34glktv3yaev4IIZK25CZPCKiAqVYx+yccONa589f/Xq4RG7qgT6ICtXv7ZU83i2ujXvLAQdmwiVXZyX/Lppn8Fo7ilnnW6xDwjnz+R31B915tJ53lj8++mu3JytxKVUSrIGCdiC8juMcNE9KyHmObkDkhKUwJZhdnHbqOvsC+xBVw5FuqpEmyxZtv+rvmzXNk3THsCQlETTIgaB7NojKSU7m/Zik+SeNAZyhCJobMjnNv8TENcWXKz/KBFvMX9uQe2EKQUz18kedb3syhrPuI6sgcQpwjQAeNyRPsrHBu1FLMLNFspYbXvHH96Mfhx4WbSorsh/5/hNbpdnmaIoqmnGnk8RNq/IVkl9czNi2P8+G5LkhPOq8J1Z7Aa37YZAyNg5p7vh8tA96tE8ecl3f7pc9bi3aJq3EGiRCTxwnLQjAnAY9QMRJbHdrKO+2sttTR/OXrjZ/+Wpdz8JGt+gaFqOaFjiM7BY3w/ALtl79OgwAA5/URSqYJGwbV6yLf58e+DC/gc+OdZ3/VsNZdTr3+bSXPfCfRFiSWqupACcjWxhdmYGFU19b9bsudO9Xl9xpHSwYksHh148oVYCC9gljcfeTQjAoZfA4hQEDXGjxZcz41PP5Mn3K5Is6dBjxyncWRJ9plWNYmgJIR+5PZrnIZeqpuxvBXcCFWiqWtWRQriGCZKCW81zQw8N1kDBkBFJgA5NomdaACKLoSnh0DGJsjdx9Tm4DQELhKAXEBukC0Sck7ARRrKhAgi45Rhkl/AtfQAWRCj4x5jw+dSssbAAzrzDEn0xNyAgpLGHQJU+ACC2QCsscmhTAxAuhFDm+cpm4oIrIwAiqKUWCIgghIEFBABoTlINASCE4arEphCsU1EPfhcWIGDlVBYQEgi2ElSJBqWSgofE6UF2sW8WCM5AOwJI8gE9M9g2GGTIJUnMsgkAEQ6Yah3IDQAsIzUAEbmEGJJlsqW2jZ+DEr4Y7m2TCicEMFOcAXF4xRkx9eAbNy+fORcIZzHDJb8KGz4Ot9lUhwiTbEQAJLEAFOeQOyQUNINdjIWrIsbNy6sYr2quH0HS+DFVlImYi01itSW0D/8vgLLHjR/2TQgkah8Ra8HFTjGOa06f3A797SCTCwWry8DSVXBvWhoJBgksLlM/3N6rw1xICOoCwXXOAlAU1tvBqzumdL18JcY7cwp+MH2cJG8CaVZgqPBE/HeG2FSWZCTi9NAhHFxkXYOzbpvznd2dZ3b19Bwf8Qb3AJqpLCgsrYRC6ecqJjMM4A+lxFB2SCbiLlWGucF5RXRzFgNK6yAzwzX551+MVswxABxOefmP3etS5a2YSuVizjkfBAo9l0tzyCDbSqKC7YUIu/daOFB3pbUxrf721B0rc/w+9zrYfK2K5QlhcCvnfFCigUr6L0ucDA3KeR8iYO3U8y8M6+ZGBDAgIc0vWl5BEakiijQTYmhkWpEVEBwOELgUt+y3QtysuXT21ahGoujSePl3/qpiRVK2wO3KY1ClyuJ8YHATcDPIyhQFud6JbfKr1vZz+xehd0a8e08GICKC318xzpejrpUQ3UAkaZK4yoGU/HduWts72hsPpyFnSpL2wjWlFNFfSoSWipqIWVYP1J27rwcCL839eF9PMgYpATiLJ01eOs2jaU+D03508cK/9iHUkm6F4LBI+hTlc9m0BSsVSufcCBkvzu7afSHpgrGPYxoY00BEA/8FOPrYBqYsE44AAAAASUVORK5CYII=&labelColor=white)](https://registry.buildpacks.io/buildpacks/heroku/nodejs-corepack)
+
+
+This buildpack relies on and builds on top of the [Node.js Engine Cloud Native Buildpack](https://github.com/heroku/nodejs-engine-buildpack) to leverage `corepack` for installing package managers.
+
+## What it does
+
+- Reads `package.json` to determine if and which package manager should be 
+  installed based on the `packageManager` field.
+- Uses `corepack enable` to install the package manager shim. The shim will
+  be cached between builds and available on `$PATH` at build and runtime.
+- Uses `corepack prepare` to install the target package manager version. The
+  package manager will be cached between builds.
+
+## Features
+
+### Supported:
+
+- Yarn major versions 1, 2, and 3.
+
+## Unsupported:
+
+- Installing `pnpm` (for now).
+- Installing `npm` (for now).
+
+## Reference
+
+### Detect
+
+`bin/detect` will pass if and only if a `package.json` exists in the root
+directory, has a `packageManager` field, the `packageManager` field has valid
+syntax (like `"yarn@3.2.0"`), and the `packageManager` name is supported.
+
+### Build Plan
+
+This buildpack `requires` `node` (from the [heroku/nodejs-engine](../nodejs-engine) buildpack).
+It `provides` and `requires` the package manager named in `packageManager` of
+`package.json` (for example, `yarn`).
+
+### Environment Variables
+
+#### PATH
+
+`$PATH` will be modified such that the package manager named in `packageManager`
+of `package.json` is available at build and runtime.
+
+`$COREPACK_HOME` will be set to point to the cached layer where the package
+manager is installed.
+
+## Usage
+
+For most users, it's simplest to build an app using [`pack`](https://buildpacks.io/docs/tools/pack/)
+and Heroku's [builder](https://github.com/builder), which includes this buildpack.
+
+```
+pack build example-app-image --builder heroku/builder:22 --path /my/example-app
+```
+
+For users desiring more control, this buildpack can be used as part of a
+buildpack group. For example, use [heroku/nodejs-engine](../nodejs-engine) to 
+install `node` and `corepack`, this buildpack ([heroku/nodejs-corepack](./)) to 
+install a package manager (like `yarn`), and a package manager buildpack 
+(like [heroku/nodejs-yarn](../nodejs-yarn/) to install packages.
+
+```
+pack build example-app-image --buildpack heroku/nodejs-engine --buildpack heroku/nodejs-corepack --buildpack heroku/nodejs-yarn --path /some/example-app
+```
+
+## Additional Info
+
+For development, dependencies, contribution, license and other info, please
+refer to the [root README.md](../../README.md).

--- a/buildpacks/nodejs-corepack/build.sh
+++ b/buildpacks/nodejs-corepack/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+buildpack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+pushd "${buildpack_dir}"
+
+cargo libcnb package --release
+
+rm -rf target
+cp -R ../../target/buildpack/release/heroku_nodejs-corepack target
+cp package.toml target/
+
+popd

--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -1,0 +1,30 @@
+api = "0.8"
+
+[buildpack]
+id = "heroku/nodejs-corepack"
+version = "0.8.14"
+name = "Heroku Node.js Corepack"
+homepage = "https://github.com/heroku/buildpacks-nodejs"
+keywords = ["corepack", "node", "node.js", "nodejs", "javascript", "js"]
+
+[[buildpack.licenses]]
+type = "MIT"
+
+[[stacks]]
+id = "heroku-18"
+
+[[stacks]]
+id = "heroku-20"
+
+[[stacks]]
+id = "heroku-22"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
+
+[metadata]
+
+[metadata.release]
+
+[metadata.release.docker]
+repository = "docker.io/heroku/buildpack-nodejs-corepack"

--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "heroku/nodejs-corepack"
-version = "0.8.14"
+version = "0.1.0"
 name = "Heroku Node.js Corepack"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
 keywords = ["corepack", "node", "node.js", "nodejs", "javascript", "js"]

--- a/buildpacks/nodejs-corepack/package.toml
+++ b/buildpacks/nodejs-corepack/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "."

--- a/buildpacks/nodejs-corepack/src/cfg.rs
+++ b/buildpacks/nodejs-corepack/src/cfg.rs
@@ -1,0 +1,11 @@
+use heroku_nodejs_utils::package_json::PackageJson;
+
+/// Return the package manager name from package.json if it's present and
+/// supported.
+pub(crate) fn get_supported_package_manager(pkg_json: &PackageJson) -> Option<String> {
+    let pkg_mgr_name = pkg_json.package_manager.clone()?.name;
+    match pkg_mgr_name.as_str() {
+        "yarn" => Some(pkg_mgr_name),
+        _ => None,
+    }
+}

--- a/buildpacks/nodejs-corepack/src/cfg.rs
+++ b/buildpacks/nodejs-corepack/src/cfg.rs
@@ -9,3 +9,35 @@ pub(crate) fn get_supported_package_manager(pkg_json: &PackageJson) -> Option<St
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use heroku_nodejs_utils::{package_json::PackageManager, vrs::Version};
+
+    #[test]
+    fn test_get_supported_package_manager_yarn() {
+        let pkg_json = PackageJson {
+            package_manager: Some(PackageManager {
+                name: "yarn".to_owned(),
+                version: Version::parse("3.1.2").unwrap(),
+            }),
+            ..PackageJson::default()
+        };
+        let pkg_mgr =
+            get_supported_package_manager(&pkg_json).expect("Expected to get a package manager");
+        assert_eq!("yarn", pkg_mgr);
+    }
+
+    #[test]
+    fn test_get_supported_package_manager_other() {
+        let pkg_json = PackageJson {
+            package_manager: Some(PackageManager {
+                name: "other-package-manager".to_owned(),
+                version: Version::parse("1.0.0").unwrap(),
+            }),
+            ..PackageJson::default()
+        };
+        assert!(get_supported_package_manager(&pkg_json).is_none());
+    }
+}

--- a/buildpacks/nodejs-corepack/src/cmd.rs
+++ b/buildpacks/nodejs-corepack/src/cmd.rs
@@ -1,0 +1,72 @@
+use heroku_nodejs_utils::vrs::Version;
+use libcnb::Env;
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Couldn't start corepack command: {0}")]
+    Spawn(std::io::Error),
+    #[error("Couldn't finish corepack  command: {0}")]
+    Wait(std::io::Error),
+    #[error("Corepack command finished with a non-zero exit code: {0}")]
+    Exit(std::process::ExitStatus),
+    #[error("Corepack output couldn't be parsed: {0}")]
+    Parse(String),
+}
+
+/// Execute `corepack --version` to determine corepack version
+pub(crate) fn corepack_version(env: &Env) -> Result<Version, Error> {
+    let output = Command::new("corepack")
+        .arg("--version")
+        .envs(env)
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(Error::Spawn)?
+        .wait_with_output()
+        .map_err(Error::Wait)?;
+
+    output
+        .status
+        .success()
+        .then_some(())
+        .ok_or(Error::Exit(output.status))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .parse()
+        .map_err(|_| Error::Parse(stdout.into_owned()))
+}
+
+/// Execute `corepack enable` to setup a corepack shim
+pub(crate) fn corepack_enable(
+    package_manager: &str,
+    shim_path: &Path,
+    env: &Env,
+) -> Result<(), Error> {
+    let shim_path_string = shim_path.to_string_lossy();
+    let mut process = Command::new("corepack")
+        .args([
+            "enable",
+            "--install-directory",
+            &shim_path_string,
+            package_manager,
+        ])
+        .envs(env)
+        .spawn()
+        .map_err(Error::Spawn)?;
+    let status = process.wait().map_err(Error::Wait)?;
+    status.success().then_some(()).ok_or(Error::Exit(status))
+}
+
+/// Execute `corepack prepare` to install the correct package manager
+pub(crate) fn corepack_prepare(env: &Env) -> Result<(), Error> {
+    let mut process = Command::new("corepack")
+        .arg("prepare")
+        .envs(env)
+        .spawn()
+        .map_err(Error::Spawn)?;
+    let status = process.wait().map_err(Error::Wait)?;
+    status.success().then_some(()).ok_or(Error::Exit(status))
+}

--- a/buildpacks/nodejs-corepack/src/cmd.rs
+++ b/buildpacks/nodejs-corepack/src/cmd.rs
@@ -9,7 +9,7 @@ use std::{
 pub(crate) enum Error {
     #[error("Couldn't start corepack command: {0}")]
     Spawn(std::io::Error),
-    #[error("Couldn't finish corepack  command: {0}")]
+    #[error("Couldn't finish corepack command: {0}")]
     Wait(std::io::Error),
     #[error("Corepack command finished with a non-zero exit code: {0}")]
     Exit(std::process::ExitStatus),

--- a/buildpacks/nodejs-corepack/src/errors.rs
+++ b/buildpacks/nodejs-corepack/src/errors.rs
@@ -1,0 +1,111 @@
+use indoc::formatdoc;
+use libherokubuildpack::log::log_error;
+
+use crate::CorepackBuildpackError;
+
+pub(crate) fn on_error(err: libcnb::Error<CorepackBuildpackError>) {
+    match err {
+        libcnb::Error::BuildpackError(bp_err) => on_buildpack_error(bp_err),
+        libcnb_err => log_error(
+            "heroku/nodejs-corepack internal buildpack error",
+            formatdoc! {"
+                An unexpected internal error was reported by the framework used
+                by this buildpack.
+
+                If the issue persists, consider opening an issue on the GitHub
+                repository. If you are unable to deploy to Heroku as a result
+                of this issue, consider opening a ticket for additional support.
+
+                Details: {libcnb_err}
+            "},
+        ),
+    };
+}
+
+fn on_buildpack_error(bp_err: CorepackBuildpackError) {
+    match bp_err {
+        CorepackBuildpackError::CorepackEnable(err) => on_corepack_cmd_error(
+            "Unable to install corepack shims via `corepack enable`",
+            err,
+        ),
+        CorepackBuildpackError::CorepackVersion(err) => on_corepack_cmd_error(
+            "Unable to check corepack version via `corepack --version`",
+            err,
+        ),
+        CorepackBuildpackError::CorepackPrepare(err) => on_corepack_cmd_error(
+            "Unable to download package manager via `corepack prepare`",
+            err,
+        ),
+        CorepackBuildpackError::ShimLayer(err) => on_layer_error("shim", &err),
+        CorepackBuildpackError::ManagerLayer(err) => on_layer_error("manager", &err),
+        CorepackBuildpackError::PackageJson(err) => log_error(
+            "heroku/nodejs-corepack package.json error",
+            formatdoc! {"
+                There was an error while attempting to parse this project's
+                package.json file. Please make sure it is present and properly
+                formatted.
+
+                Details: {err}
+            "},
+        ),
+        CorepackBuildpackError::PackageManager => log_error(
+            "heroku/nodejs-corepack packageManager error",
+            formatdoc! {"
+                There was an error decoding the `packageManager` key from
+                this project's package.json. Please make sure it is properly
+                formatted (for example: \"yarn@3.1.2\").
+            "},
+        ),
+    };
+}
+
+fn on_corepack_cmd_error(err_context: &str, cmd_err: crate::cmd::Error) {
+    let header = "heroku/nodejs-corepack corepack command error";
+    match cmd_err {
+        crate::cmd::Error::Exit(exit_err) => log_error(
+            header,
+            formatdoc! {"
+            {err_context}. The command did not exit successfully.
+
+            Details: {exit_err}
+        "},
+        ),
+        crate::cmd::Error::Parse(output) => log_error(
+            header,
+            formatdoc! {"
+            {err_context}. Error parsing the command output.
+
+            Output: {output}
+        "},
+        ),
+        crate::cmd::Error::Spawn(spawn_err) => log_error(
+            header,
+            formatdoc! {"
+            {err_context}. Error spawning the command. Please ensure corepack
+            was installed by another buildpack, such as heroku/nodejs-engine.
+
+            Details: {spawn_err}
+        "},
+        ),
+        crate::cmd::Error::Wait(wait_err) => log_error(
+            header,
+            formatdoc! {"
+            {err_context}. Error waiting for the command to exit.
+
+            Details: {wait_err}
+        "},
+        ),
+    }
+}
+
+fn on_layer_error(layer_name: &str, io_err: &std::io::Error) {
+    log_error(
+        "heroku/nodejs-corepack layer creation error",
+        formatdoc! {"
+            Couldn't create the {layer_name} layer. An unexpected I/O error
+            occurred.
+
+            Details: {io_err}
+        "},
+    );
+}

--- a/buildpacks/nodejs-corepack/src/errors.rs
+++ b/buildpacks/nodejs-corepack/src/errors.rs
@@ -65,35 +65,35 @@ fn on_corepack_cmd_error(err_context: &str, cmd_err: crate::cmd::Error) {
         crate::cmd::Error::Exit(exit_err) => log_error(
             header,
             formatdoc! {"
-            {err_context}. The command did not exit successfully.
+                {err_context}. The command did not exit successfully.
 
-            Details: {exit_err}
-        "},
+                Details: {exit_err}
+            "},
         ),
         crate::cmd::Error::Parse(output) => log_error(
             header,
             formatdoc! {"
-            {err_context}. Error parsing the command output.
+                {err_context}. Error parsing the command output.
 
-            Output: {output}
-        "},
+                Output: {output}
+            "},
         ),
         crate::cmd::Error::Spawn(spawn_err) => log_error(
             header,
             formatdoc! {"
-            {err_context}. Error spawning the command. Please ensure corepack
-            was installed by another buildpack, such as heroku/nodejs-engine.
+                {err_context}. Error spawning the command. Please ensure corepack
+                was installed by another buildpack, such as heroku/nodejs-engine.
 
-            Details: {spawn_err}
-        "},
+                Details: {spawn_err}
+            "},
         ),
         crate::cmd::Error::Wait(wait_err) => log_error(
             header,
             formatdoc! {"
-            {err_context}. Error waiting for the command to exit.
+                {err_context}. Error waiting for the command to exit.
 
-            Details: {wait_err}
-        "},
+                Details: {wait_err}
+            "},
         ),
     }
 }

--- a/buildpacks/nodejs-corepack/src/errors.rs
+++ b/buildpacks/nodejs-corepack/src/errors.rs
@@ -48,12 +48,12 @@ fn on_buildpack_error(bp_err: CorepackBuildpackError) {
                 Details: {err}
             "},
         ),
-        CorepackBuildpackError::PackageManager => log_error(
+        CorepackBuildpackError::PackageManagerMissing => log_error(
             "heroku/nodejs-corepack packageManager error",
             formatdoc! {"
                 There was an error decoding the `packageManager` key from
-                this project's package.json. Please make sure it is properly
-                formatted (for example: \"yarn@3.1.2\").
+                this project's package.json. Please make sure it is present
+                and properly formatted (for example: \"yarn@3.1.2\").
             "},
         ),
     };

--- a/buildpacks/nodejs-corepack/src/layers/manager.rs
+++ b/buildpacks/nodejs-corepack/src/layers/manager.rs
@@ -1,0 +1,94 @@
+use heroku_nodejs_utils::package_json::PackageManager;
+use heroku_nodejs_utils::vrs::Version;
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
+use libcnb::Buildpack;
+use libherokubuildpack::log::log_info;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+use thiserror::Error;
+
+use crate::{CorepackBuildpack, CorepackBuildpackError};
+
+/// `ManagerLayer` is a layer for caching shims installed by corepack. These
+/// shims will be cached until the corepack version changes.
+pub(crate) struct ManagerLayer {
+    pub(crate) package_manager: PackageManager,
+}
+
+#[derive(Deserialize, Serialize, Clone, PartialEq)]
+pub(crate) struct ManagerLayerMetadata {
+    manager_name: String,
+    manager_version: Version,
+    layer_version: String,
+}
+
+#[derive(Error, Debug)]
+#[error("Couldn't create corepack package manager cache: {0}")]
+pub(crate) struct ManagerLayerError(std::io::Error);
+
+const LAYER_VERSION: &str = "1";
+const CACHE_DIR: &str = "cache";
+
+impl Layer for ManagerLayer {
+    type Buildpack = CorepackBuildpack;
+    type Metadata = ManagerLayerMetadata;
+
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            build: true,
+            launch: true,
+            cache: true,
+        }
+    }
+
+    fn create(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, CorepackBuildpackError> {
+        let cache_path = layer_path.join(CACHE_DIR);
+        fs::create_dir(&cache_path).map_err(ManagerLayerError)?;
+        LayerResultBuilder::new(ManagerLayerMetadata::new(self))
+            .env(LayerEnv::new().chainable_insert(
+                Scope::All,
+                ModificationBehavior::Override,
+                "COREPACK_HOME",
+                cache_path,
+            ))
+            .build()
+    }
+
+    fn existing_layer_strategy(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        layer_data: &LayerData<Self::Metadata>,
+    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
+        if layer_data.content_metadata.metadata.is_reusable(self) {
+            log_info("Restoring corepack package manager cache");
+            Ok(ExistingLayerStrategy::Keep)
+        } else {
+            log_info("Package manager change detected. Clearing corepack package manager cache");
+            Ok(ExistingLayerStrategy::Recreate)
+        }
+    }
+}
+
+impl ManagerLayerMetadata {
+    fn is_reusable(&self, new_layer: &ManagerLayer) -> bool {
+        self.manager_name == new_layer.package_manager.name
+            && self.manager_version == new_layer.package_manager.version
+            && self.layer_version == *LAYER_VERSION
+    }
+
+    fn new(layer: &ManagerLayer) -> Self {
+        ManagerLayerMetadata {
+            manager_name: layer.package_manager.name.clone(),
+            manager_version: layer.package_manager.version.clone(),
+            layer_version: LAYER_VERSION.to_string(),
+        }
+    }
+}

--- a/buildpacks/nodejs-corepack/src/layers/manager.rs
+++ b/buildpacks/nodejs-corepack/src/layers/manager.rs
@@ -9,7 +9,6 @@ use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
-use thiserror::Error;
 
 use crate::{CorepackBuildpack, CorepackBuildpackError};
 
@@ -25,10 +24,6 @@ pub(crate) struct ManagerLayerMetadata {
     manager_version: Version,
     layer_version: String,
 }
-
-#[derive(Error, Debug)]
-#[error("Couldn't create corepack package manager cache: {0}")]
-pub(crate) struct ManagerLayerError(std::io::Error);
 
 const LAYER_VERSION: &str = "1";
 const CACHE_DIR: &str = "cache";
@@ -51,7 +46,7 @@ impl Layer for ManagerLayer {
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, CorepackBuildpackError> {
         let cache_path = layer_path.join(CACHE_DIR);
-        fs::create_dir(&cache_path).map_err(ManagerLayerError)?;
+        fs::create_dir(&cache_path).map_err(CorepackBuildpackError::ManagerLayer)?;
         LayerResultBuilder::new(ManagerLayerMetadata::new(self))
             .env(LayerEnv::new().chainable_insert(
                 Scope::All,

--- a/buildpacks/nodejs-corepack/src/layers/mod.rs
+++ b/buildpacks/nodejs-corepack/src/layers/mod.rs
@@ -1,0 +1,5 @@
+mod manager;
+mod shim;
+
+pub(crate) use manager::*;
+pub(crate) use shim::*;

--- a/buildpacks/nodejs-corepack/src/layers/shim.rs
+++ b/buildpacks/nodejs-corepack/src/layers/shim.rs
@@ -1,0 +1,80 @@
+use heroku_nodejs_utils::vrs::Version;
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::Buildpack;
+use libherokubuildpack::log::log_info;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+use thiserror::Error;
+
+use crate::{CorepackBuildpack, CorepackBuildpackError};
+
+/// `ShimLayer` is a layer for caching shims installed by corepack. These
+/// shims will be cached until the corepack version changes.
+pub(crate) struct ShimLayer {
+    pub(crate) corepack_version: Version,
+}
+
+#[derive(Deserialize, Serialize, Clone, PartialEq)]
+pub(crate) struct ShimLayerMetadata {
+    corepack_version: Version,
+    layer_version: String,
+}
+
+#[derive(Error, Debug)]
+#[error("Couldn't create corepack shim cache: {0}")]
+pub(crate) struct ShimLayerError(std::io::Error);
+
+const LAYER_VERSION: &str = "1";
+const BIN_DIR: &str = "bin";
+
+impl Layer for ShimLayer {
+    type Buildpack = CorepackBuildpack;
+    type Metadata = ShimLayerMetadata;
+
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            build: true,
+            launch: true,
+            cache: true,
+        }
+    }
+
+    fn create(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, CorepackBuildpackError> {
+        fs::create_dir(layer_path.join(BIN_DIR)).map_err(ShimLayerError)?;
+        LayerResultBuilder::new(ShimLayerMetadata::new(self)).build()
+    }
+
+    fn existing_layer_strategy(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        layer_data: &LayerData<Self::Metadata>,
+    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
+        if layer_data.content_metadata.metadata.is_reusable(self) {
+            log_info("Restoring corepack shim cache");
+            Ok(ExistingLayerStrategy::Keep)
+        } else {
+            log_info("Corepack change detected. Clearing corepack shim cache");
+            Ok(ExistingLayerStrategy::Recreate)
+        }
+    }
+}
+
+impl ShimLayerMetadata {
+    fn is_reusable(&self, new_layer: &ShimLayer) -> bool {
+        self.corepack_version == new_layer.corepack_version && self.layer_version == *LAYER_VERSION
+    }
+
+    fn new(layer: &ShimLayer) -> Self {
+        ShimLayerMetadata {
+            corepack_version: layer.corepack_version.clone(),
+            layer_version: LAYER_VERSION.to_string(),
+        }
+    }
+}

--- a/buildpacks/nodejs-corepack/src/layers/shim.rs
+++ b/buildpacks/nodejs-corepack/src/layers/shim.rs
@@ -7,7 +7,6 @@ use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
-use thiserror::Error;
 
 use crate::{CorepackBuildpack, CorepackBuildpackError};
 
@@ -22,10 +21,6 @@ pub(crate) struct ShimLayerMetadata {
     corepack_version: Version,
     layer_version: String,
 }
-
-#[derive(Error, Debug)]
-#[error("Couldn't create corepack shim cache: {0}")]
-pub(crate) struct ShimLayerError(std::io::Error);
 
 const LAYER_VERSION: &str = "1";
 const BIN_DIR: &str = "bin";
@@ -47,7 +42,7 @@ impl Layer for ShimLayer {
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, CorepackBuildpackError> {
-        fs::create_dir(layer_path.join(BIN_DIR)).map_err(ShimLayerError)?;
+        fs::create_dir(layer_path.join(BIN_DIR)).map_err(CorepackBuildpackError::ShimLayer)?;
         LayerResultBuilder::new(ShimLayerMetadata::new(self)).build()
     }
 

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -1,0 +1,109 @@
+#![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(clippy::module_name_repetitions)]
+
+use heroku_nodejs_utils::package_json::{PackageJson, PackageJsonError};
+use layers::{ManagerLayer, ManagerLayerError, ShimLayer, ShimLayerError};
+use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+use libcnb::data::build_plan::BuildPlanBuilder;
+use libcnb::data::layer_name;
+use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
+use libcnb::generic::GenericMetadata;
+use libcnb::generic::GenericPlatform;
+use libcnb::layer_env::Scope;
+use libcnb::{buildpack_main, Buildpack, Env};
+use libherokubuildpack::log::{log_error, log_header, log_info};
+use thiserror::Error;
+
+#[cfg(test)]
+use libcnb_test as _;
+
+#[cfg(test)]
+use ureq as _;
+
+mod cmd;
+mod layers;
+
+pub(crate) struct CorepackBuildpack;
+
+impl Buildpack for CorepackBuildpack {
+    type Platform = GenericPlatform;
+    type Metadata = GenericMetadata;
+    type Error = CorepackBuildpackError;
+
+    fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+        // Corepack requires the `packageManager` key from `package.json`.
+        // This buildpack won't be detected without it.
+        PackageJson::read(context.app_dir.join("package.json"))
+            .map_err(CorepackBuildpackError::PackageJson)?
+            .package_manager
+            .map_or(DetectResultBuilder::fail().build(), |pkg_mgr| {
+                DetectResultBuilder::pass()
+                    .build_plan(
+                        BuildPlanBuilder::new()
+                            .provides(pkg_mgr.name)
+                            .requires("node")
+                            .build(),
+                    )
+                    .build()
+            })
+    }
+
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        let pkg_mgr = PackageJson::read(context.app_dir.join("package.json"))
+            .map_err(CorepackBuildpackError::PackageJson)?
+            .package_manager
+            .ok_or(CorepackBuildpackError::PackageManager {})?;
+
+        let env = &Env::from_current();
+
+        log_header("Checking corepack version");
+        let corepack_version = cmd::corepack_version(env).map_err(CorepackBuildpackError::Cmd)?;
+        log_info(format!("Detected corepack version {corepack_version}"));
+
+        log_header("Installing corepack shim");
+        let shims_layer =
+            context.handle_layer(layer_name!("shim"), ShimLayer { corepack_version })?;
+        cmd::corepack_enable(&pkg_mgr.name, &shims_layer.path.join("bin"), env)
+            .map_err(CorepackBuildpackError::Cmd)?;
+
+        log_header(format!("Installing {} with corepack enable", pkg_mgr.name));
+        let mgr_layer = context.handle_layer(
+            layer_name!("mgr"),
+            ManagerLayer {
+                package_manager: pkg_mgr,
+            },
+        )?;
+        let mgr_env = mgr_layer.env.apply(Scope::Build, env);
+        cmd::corepack_prepare(&mgr_env).map_err(CorepackBuildpackError::Cmd)?;
+
+        BuildResultBuilder::new().build()
+    }
+
+    fn on_error(&self, _error: libcnb::Error<Self::Error>) {
+        log_error("Buildpack Error!", "TODO");
+    }
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum CorepackBuildpackError {
+    #[error("Couldn't detect corepack packageManager")]
+    PackageManager,
+    #[error("Couldn't parse package.json: {0}")]
+    PackageJson(#[from] PackageJsonError),
+    #[error("Couldn't create corepack shims: {0}")]
+    ShimLayer(#[from] ShimLayerError),
+    #[error("Couldn't create corepack package manager cache: {0}")]
+    ManagerLayer(#[from] ManagerLayerError),
+    #[error("Couldn't execute corepack command: {0}")]
+    Cmd(#[from] cmd::Error),
+}
+
+impl From<CorepackBuildpackError> for libcnb::Error<CorepackBuildpackError> {
+    fn from(e: CorepackBuildpackError) -> Self {
+        libcnb::Error::BuildpackError(e)
+    }
+}
+
+buildpack_main!(CorepackBuildpack);

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -64,7 +64,7 @@ impl Buildpack for CorepackBuildpack {
         let pkg_mgr = PackageJson::read(context.app_dir.join("package.json"))
             .map_err(CorepackBuildpackError::PackageJson)?
             .package_manager
-            .ok_or(CorepackBuildpackError::PackageManager)?;
+            .ok_or(CorepackBuildpackError::PackageManagerMissing)?;
 
         let env = &Env::from_current();
 
@@ -100,7 +100,7 @@ impl Buildpack for CorepackBuildpack {
 
 #[derive(Debug)]
 pub(crate) enum CorepackBuildpackError {
-    PackageManager,
+    PackageManagerMissing,
     PackageJson(PackageJsonError),
     ShimLayer(std::io::Error),
     ManagerLayer(std::io::Error),

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -14,7 +14,6 @@ use libcnb::generic::GenericPlatform;
 use libcnb::layer_env::Scope;
 use libcnb::{buildpack_main, Buildpack, Env};
 use libherokubuildpack::log::log_header;
-use thiserror::Error;
 
 #[cfg(test)]
 use libcnb_test as _;
@@ -94,21 +93,14 @@ impl Buildpack for CorepackBuildpack {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub(crate) enum CorepackBuildpackError {
-    #[error("Couldn't detect corepack packageManager")]
     PackageManager,
-    #[error("Couldn't parse package.json: {0}")]
-    PackageJson(#[from] PackageJsonError),
-    #[error("Couldn't create corepack shims: {0}")]
+    PackageJson(PackageJsonError),
     ShimLayer(std::io::Error),
-    #[error("Couldn't create corepack package manager cache: {0}")]
     ManagerLayer(std::io::Error),
-    #[error("Couldn't execute corepack --version command: {0}")]
     CorepackVersion(cmd::Error),
-    #[error("Couldn't execute corepack enable: {0}")]
     CorepackEnable(cmd::Error),
-    #[error("Couldn't execute corepack command: {0}")]
     CorepackPrepare(cmd::Error),
 }
 

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -37,22 +37,27 @@ impl Buildpack for CorepackBuildpack {
     fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
         // Corepack requires the `packageManager` key from `package.json`.
         // This buildpack won't be detected without it.
-        let pkg_json = PackageJson::read(context.app_dir.join("package.json"))
-            .map_err(CorepackBuildpackError::PackageJson)?;
-        cfg::get_supported_package_manager(&pkg_json).map_or(
-            DetectResultBuilder::fail().build(),
-            |pkg_mgr_name| {
-                DetectResultBuilder::pass()
-                    .build_plan(
-                        BuildPlanBuilder::new()
-                            .requires("node")
-                            .requires(&pkg_mgr_name)
-                            .provides(pkg_mgr_name)
-                            .build(),
-                    )
-                    .build()
-            },
-        )
+        let pkg_json_path = context.app_dir.join("package.json");
+        if pkg_json_path.exists() {
+            let pkg_json =
+                PackageJson::read(pkg_json_path).map_err(CorepackBuildpackError::PackageJson)?;
+            cfg::get_supported_package_manager(&pkg_json).map_or_else(
+                || DetectResultBuilder::fail().build(),
+                |pkg_mgr| {
+                    DetectResultBuilder::pass()
+                        .build_plan(
+                            BuildPlanBuilder::new()
+                                .requires("node")
+                                .requires(&pkg_mgr)
+                                .provides(pkg_mgr)
+                                .build(),
+                        )
+                        .build()
+                },
+            )
+        } else {
+            DetectResultBuilder::fail().build()
+        }
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -72,8 +72,8 @@ impl Buildpack for CorepackBuildpack {
             cmd::corepack_version(env).map_err(CorepackBuildpackError::CorepackVersion)?;
 
         log_header(format!(
-            "Installing {} {} via corepack {}",
-            pkg_mgr.name, pkg_mgr.version, corepack_version
+            "Installing {} {} via corepack {corepack_version}",
+            pkg_mgr.name, pkg_mgr.version
         ));
 
         let shims_layer =

--- a/buildpacks/nodejs-corepack/tests/integration_test.rs
+++ b/buildpacks/nodejs-corepack/tests/integration_test.rs
@@ -1,0 +1,38 @@
+#![warn(clippy::pedantic)]
+
+use libcnb_test::{assert_contains, ContainerConfig};
+use test_support::test_corepack_app;
+use test_support::Builder::{Heroku20, Heroku22};
+
+#[test]
+#[ignore = "integration test"]
+fn corepack_yarn_2_heroku_20() {
+    test_corepack_app("yarn-2-pnp-zero", Heroku20, |ctx| {
+        assert_contains!(ctx.pack_stdout, "Preparing yarn@2.4.1");
+        ctx.start_container(
+            ContainerConfig::new()
+                .entrypoint(["launcher"])
+                .command(["yarn", "--version"]),
+            |ctr| {
+                let logs = ctr.logs_wait();
+                assert_contains!(logs.stdout, "2.4.1");
+            },
+        );
+    });
+}
+#[test]
+#[ignore = "integration test"]
+fn corepack_yarn_3_heroku_22() {
+    test_corepack_app("yarn-3-pnp-nonzero", Heroku22, |ctx| {
+        assert_contains!(ctx.pack_stdout, "Preparing yarn@3.2.0");
+        ctx.start_container(
+            ContainerConfig::new()
+                .entrypoint(["launcher"])
+                .command(["yarn", "--version"]),
+            |ctr| {
+                let logs = ctr.logs_wait();
+                assert_contains!(logs.stdout, "3.2.0");
+            },
+        );
+    });
+}

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -13,6 +13,11 @@ id = "heroku/nodejs-engine"
 version = "0.8.14"
 
 [[order.group]]
+id = "heroku/nodejs-corepack"
+version = "0.1.0"
+optional = true
+
+[[order.group]]
 id = "heroku/nodejs-yarn"
 version = "0.3.1"
 

--- a/test/meta-buildpacks/nodejs/package.toml
+++ b/test/meta-buildpacks/nodejs/package.toml
@@ -5,6 +5,9 @@ uri = "."
 uri = "../../../buildpacks/nodejs-engine"
 
 [[dependencies]]
+uri = "../../../buildpacks/nodejs-corepack"
+
+[[dependencies]]
 uri = "../../../buildpacks/npm"
 
 [[dependencies]]

--- a/test/specs/node/cutlass/basic_spec.rb
+++ b/test/specs/node/cutlass/basic_spec.rb
@@ -46,14 +46,27 @@ describe "Heroku's Nodejs CNB" do
         end
       end
 
-      it "installs dependencies using Yarn if yarn.lock exists" do
+      it "Installs yarn and installs dependencies with yarn if yarn.lock exists" do
         Cutlass::App.new("yarn-1-typescript", builder: builder).transaction do |app|
           app.pack_build do |pack_result|
             expect(pack_result.stdout).to include("Installing Node")
-            expect(pack_result.stdout).to include("Installing yarn")
+            expect(pack_result.stdout).to_not include("corepack")
+            expect(pack_result.stdout).to include("Installing yarn CLI")
             expect(pack_result.stdout).to include("Installing dependencies");
             expect(pack_result.stdout).to_not include("Installing node modules from ./package-lock.json")
             expect(pack_result.stdout).to include("Running `build` script");
+          end
+        end
+      end
+
+      it "Installs yarn with corepack and installs dependencies if yarn.lock exists and packageManager is yarn" do
+        Cutlass::App.new("yarn-2-pnp-zero", builder: builder).transaction do |app|
+          app.pack_build do |pack_result|
+            expect(pack_result.stdout).to include("Installing Node")
+            expect(pack_result.stdout).to include("Installing yarn 2.4.1 via corepack")
+            expect(pack_result.stdout).to_not include("Installing yarn CLI")
+            expect(pack_result.stdout).to include("Installing dependencies");
+            expect(pack_result.stdout).to_not include("Installing node modules from ./package-lock.json")
           end
         end
       end

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -37,6 +37,13 @@ pub fn get_yarn_buildpacks() -> Vec<BuildpackReference> {
     ]
 }
 
+pub fn get_corepack_buildpacks() -> Vec<BuildpackReference> {
+    vec![
+        BuildpackReference::Other(String::from("heroku/nodejs-engine")),
+        BuildpackReference::Crate,
+    ]
+}
+
 pub fn get_function_invoker_build_config(fixture: &str, builder: Builder) -> BuildConfig {
     BuildConfig::new(
         builder.to_string(),
@@ -55,6 +62,15 @@ pub fn get_yarn_build_config(fixture: &str, builder: Builder) -> BuildConfig {
     .to_owned()
 }
 
+pub fn get_corepack_build_config(fixture: &str, builder: Builder) -> BuildConfig {
+    BuildConfig::new(
+        builder.to_string(),
+        format!("../../test/fixtures/{fixture}"),
+    )
+    .buildpacks(get_corepack_buildpacks())
+    .to_owned()
+}
+
 pub fn test_node_function(fixture: &str, builder: Builder, test_body: fn(TestContext)) {
     TestRunner::default().build(get_function_invoker_build_config(fixture, builder), |ctx| {
         test_body(ctx)
@@ -63,6 +79,12 @@ pub fn test_node_function(fixture: &str, builder: Builder, test_body: fn(TestCon
 
 pub fn test_yarn_app(fixture: &str, builder: Builder, test_body: fn(TestContext)) {
     TestRunner::default().build(get_yarn_build_config(fixture, builder), |ctx| {
+        test_body(ctx)
+    });
+}
+
+pub fn test_corepack_app(fixture: &str, builder: Builder, test_body: fn(TestContext)) {
+    TestRunner::default().build(get_corepack_build_config(fixture, builder), |ctx| {
         test_body(ctx)
     });
 }


### PR DESCRIPTION
This PR adds a `heroku/nodejs-corepack` buildpack. A full description of the buildpacks functionality is available in the [README](https://github.com/heroku/buildpacks-nodejs/blob/corepack/buildpacks/nodejs-corepack/README.md). For now, the corepack buildpack will only install `yarn` (though corepack can install `pnpm` and `npm`).

There are also changes to the yarn buildpack -- it will no longer install `yarn` if it's already installed (otherwise, `heroku/nodejs-corepack` + `heroku/nodejs-yarn` would result in two `yarn` installations.

The yarn use case is the primary reason for adding this, but the design should allow adding `pnpm` and `npm` support later without too much trouble.

[W-12131343](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00001F2GFiYAN)