### PR TITLE
Support publishing images to dockerhub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         env:
           AWS_REGION: us-east-1
+      - id: dockerhub-login
+        name: "Login to Docker Hub"
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - id: install-musl-tools
         run: sudo apt-get install musl-tools
       - id: install-rust-toolchain


### PR DESCRIPTION
`heroku/nodejs-corepack` is intended to be published to dockerhub. This repository has no other dockerhub buildpacks, so dockerhub login needs to be added prior to publishing.