### PR TITLE
Update all crates to Rust 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,9 @@ members = [
   "common/nodejs-utils",
   "test_support"
 ]
+
+[workspace.package]
+version = "0.0.0"
+rust-version = "1.67"
+edition = "2021"
+publish = false

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "heroku-nodejs-corepack-buildpack"
-version = "0.0.0"
 description = "Heroku Node.js Corepack Cloud Native Buildpack"
-publish = false
-edition = "2021"
-rust-version = "1.64"
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "heroku-nodejs-corepack-buildpack"
 description = "Heroku Node.js Corepack Cloud Native Buildpack"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "heroku-nodejs-engine-buildpack"
-version = "0.0.0"
 description = "Heroku Node.js Engine Cloud Native Buildpack"
-publish = false
-edition = "2021"
-rust-version = "1.64"
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "heroku-nodejs-engine-buildpack"
 description = "Heroku Node.js Engine Cloud Native Buildpack"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "heroku-nodejs-function-invoker-buildpack"
-version = "0.0.0"
 description = "Heroku Node.js Function Invoker Cloud Native Buildpack"
-publish = false
-edition = "2021"
-rust-version = "1.66"
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "heroku-nodejs-function-invoker-buildpack"
 description = "Heroku Node.js Function Invoker Cloud Native Buildpack"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "heroku-nodejs-yarn-buildpack"
 description = "Heroku Node.js Yarn Cloud Native Buildpack"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "heroku-nodejs-yarn-buildpack"
-version = "0.0.0"
 description = "Heroku Node.js Yarn Cloud Native Buildpack"
-publish = false
-edition = "2021"
-rust-version = "1.66"
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -82,8 +82,7 @@ impl Buildpack for YarnBuildpack {
                     }
                     Some(requirement) => {
                         log_info(format!(
-                            "Detected yarn version range {} from package.json",
-                            requirement
+                            "Detected yarn version range {requirement} from package.json"
                         ));
                         requirement
                     }

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "heroku-nodejs-utils"
 description = "Libs and bins for Heroku Node.js Buildpacks"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "heroku-nodejs-utils"
-version = "0.0.0"
 description = "Libs and bins for Heroku Node.js Buildpacks"
-publish = false
-edition = "2021"
-rust-version = "1.66"
 
 [dependencies]
 anyhow = "1"

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "test_support"
 description = "Test support functions for integration tests"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 libcnb-test = "0.11"

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "test_support"
-version = "0.0.0"
 description = "Test support functions for integration tests"
-publish = false
-edition = "2021"
-rust-version = "1.66"
 
 [dependencies]
 libcnb-test = "0.11"


### PR DESCRIPTION
Some PRs are failing CI due to clippy issues on rust 1.67 ([this one](https://github.com/heroku/buildpacks-nodejs/actions/runs/4062621370/jobs/6993899601) for example). This PR updates all crates to rust 1.67 and fixes the clippy issue. This also changes several common cargo settings to be shared across all crates in the repo.