### PR TITLE
Make package.json's `name` field optional

### DIFF
--- a/buildpacks/nodejs-corepack/CHANGELOG.md
+++ b/buildpacks/nodejs-corepack/CHANGELOG.md
@@ -4,4 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `name` is no longer a required field in package.json. ([#447](https://github.com/heroku/buildpacks-nodejs/pull/447))
+
+## [0.1.0] 2023/01/17
+
 - Initial implementation with libcnb.rs ([#418](https://github.com/heroku/buildpacks-nodejs/pull/418))

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -4,7 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `name` is no longer a required field in package.json. ([#447](https://github.com/heroku/buildpacks-nodejs/pull/447))
 - Added node version 19.5.0.
+
 ## [0.8.14] 2023/01/17
 
 - Added node version 18.13.0, 19.4.0.

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `name` is no longer a required field in package.json. ([#447](https://github.com/heroku/buildpacks-nodejs/pull/447))
+
 ## [0.3.9] 2022/12/06
 - Update `sf-fx-runtime-nodejs` from `0.14.0` to `0.14.1`
 

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `name` is no longer a required field in package.json. ([#447](https://github.com/heroku/buildpacks-nodejs/pull/447))
+
 ## [0.3.1] 2023/01/17
 
 - No longer installs `yarn` if it's already been installed by another buildpack,

--- a/common/nodejs-utils/src/package_json.rs
+++ b/common/nodejs-utils/src/package_json.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 #[derive(Deserialize, Debug, Default, Clone)]
 pub struct PackageJson {
-    pub name: String,
+    pub name: Option<String>,
     pub version: Option<Version>,
     pub engines: Option<Engines>,
     pub scripts: Option<Scripts>,
@@ -112,11 +112,20 @@ mod tests {
     use tempfile::Builder;
 
     #[test]
+    fn read_empty_package() {
+        let mut f = Builder::new().tempfile().unwrap();
+        write!(f, "{{ }}").unwrap();
+        let pkg = PackageJson::read(f.path()).unwrap();
+        assert_eq!(pkg.name, None);
+        assert_eq!(pkg.version, None);
+    }
+
+    #[test]
     fn read_valid_package() {
         let mut f = Builder::new().tempfile().unwrap();
         write!(f, "{{\"name\": \"foo\",\"version\": \"0.0.0\"}}").unwrap();
         let pkg = PackageJson::read(f.path()).unwrap();
-        assert_eq!(pkg.name, "foo");
+        assert_eq!(pkg.name.unwrap(), "foo");
         assert_eq!(pkg.version.unwrap().to_string(), "0.0.0");
     }
 


### PR DESCRIPTION
It looks like `name` could be optional for packages that aren't intended to be published: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#name

Resolves #371.