### PR TITLE
Fixup nodejs-corepack for release

### DIFF
--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "heroku/nodejs-corepack"
-version = "0.1.0"
+version = "0.1.1"
 name = "Heroku Node.js Corepack"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
 keywords = ["corepack", "node", "node.js", "nodejs", "javascript", "js"]

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Add `heroku/nodejs-corepack` as an optional buildpack
 
 ## [0.5.13] 2023/01/17
 * Upgraded `heroku/nodejs-yarn` to `0.3.1`

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Upgraded `heroku/nodejs-engine` to `0.8.15`
 * Upgraded `heroku/nodejs-yarn` to `0.3.2`
 
-
 ## [0.5.13] 2023/01/17
 * Upgraded `heroku/nodejs-yarn` to `0.3.1`
 * Upgraded `heroku/nodejs-engine` to `0.8.14`

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -16,6 +16,11 @@ id = "heroku/nodejs-engine"
 version = "0.8.14"
 
 [[order.group]]
+id = "heroku/nodejs-corepack"
+version = "0.1.0"
+optional = true
+
+[[order.group]]
 id = "heroku/nodejs-yarn"
 version = "0.3.1"
 

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -11,4 +11,10 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:ff412cdf4a797d342256d07a17957ec40a62daf214a7f31d306a1eb890ede1b0"
 
 [[dependencies]]
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:ff412cdf4a797d342256d07a17957ec40a62daf214a7f31d306a1eb890ede1b0"
+
+[[dependencies]]
+uri = "docker://docker.io/heroku/buildpack-nodejs-corepack@sha256:7b2f659a469766770d7c0422d2b65de2a0814bbea262e779e3c30b1e81011617"
+
+[[dependencies]]
 uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -11,9 +11,6 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:ff412cdf4a797d342256d07a17957ec40a62daf214a7f31d306a1eb890ede1b0"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:ff412cdf4a797d342256d07a17957ec40a62daf214a7f31d306a1eb890ede1b0"
-
-[[dependencies]]
 uri = "docker://docker.io/heroku/buildpack-nodejs-corepack@sha256:7b2f659a469766770d7c0422d2b65de2a0814bbea262e779e3c30b1e81011617"
 
 [[dependencies]]

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -14,7 +14,7 @@ version = "0.8.15"
 
 [[order.group]]
 id = "heroku/nodejs-corepack"
-version = "0.1.0"
+version = "0.1.1"
 optional = true
 
 [[order.group]]

--- a/test/meta-buildpacks/nodejs/package.toml
+++ b/test/meta-buildpacks/nodejs/package.toml
@@ -14,4 +14,7 @@ uri = "../../../buildpacks/npm"
 uri = "../../../buildpacks/nodejs-yarn"
 
 [[dependencies]]
+uri = "../../../buildpacks/nodejs-corepack"
+
+[[dependencies]]
 uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"


### PR DESCRIPTION
The last release automation for heroku/nodejs-corepack failed silently (https://github.com/heroku/buildpacks-nodejs/actions/runs/3941678312/jobs/6744391908) due to improper configuration, so the version was never incremented. This should fix that issue so that the next release works properly.

Additionally, nodejs-corepack was not included in the last heroku/nodejs release. This should fix that as well.