### PR TITLE
Make Yarn 2+ CLI versions available for install

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -31,3 +31,29 @@ jobs:
           branch: update-nodejs-inventory
           labels: "automation"
           body: "Automated pull-request to update heroku/nodejs-engine inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
+  update-yarn-inventory:
+    name: Update Node.js Yarn Inventory
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - id: install-rust-toolchain
+        name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - id: set-diff-msg
+        name: Set Diff Message
+        run: echo "::set-output name=msg::$(cargo run --bin diff_versions yarn buildpacks/nodejs-yarn/inventory.toml)"
+      - name: Rebuild Inventory
+        run: "cargo run --bin list_versions yarn > buildpacks/nodejs-yarn/inventory.toml"
+      - name: Update Changelog
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' buildpacks/nodejs-yarn/CHANGELOG.md
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "Update Node.js Yarn Inventory"
+          commit-message: "Update Inventory for heroku/nodejs-yarn\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          branch: update-yarn-inventory
+          labels: "automation"
+          body: "Automated pull-request to update heroku/nodejs-yarn inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add several yarn 2, 3, and 4 releases to inventory ([#457](https://github.com/heroku/buildpacks-nodejs/pull/457))
+
 ## [0.3.2] 2023/02/02
 
 - `name` is no longer a required field in package.json. ([#447](https://github.com/heroku/buildpacks-nodejs/pull/447))

--- a/buildpacks/nodejs-yarn/README.md
+++ b/buildpacks/nodejs-yarn/README.md
@@ -101,7 +101,7 @@ Alternatively, define `engines.yarn` in `package.json`. For example:
 // package.json
 {
   "engines": {
-    "yarn": "1.22.19"
+    "yarn": "3.1.x"
   }
 }
 ```

--- a/buildpacks/nodejs-yarn/README.md
+++ b/buildpacks/nodejs-yarn/README.md
@@ -78,7 +78,7 @@ for the build will be set to `yarn start`.
 
 ### Yarn version selection
 
-By default, this buildpack will install the latest yarn version from the `1.x`
+By default, this buildpack will install the latest yarn version from the `1.22.x`
 line. There are two ways to select a different yarn version:
 
 #### `packageManager`
@@ -95,7 +95,8 @@ yarn according to the `packageManager` key in `package.json`. For example:
 
 #### `engines.yarn`
 
-Alternatively, define `engines.yarn` in `package.json`. For example:
+Alternatively, define `engines.yarn` using a semver range in `package.json`. 
+For example:
 
 ```js
 // package.json

--- a/buildpacks/nodejs-yarn/inventory.toml
+++ b/buildpacks/nodejs-yarn/inventory.toml
@@ -1,602 +1,836 @@
 name = "yarn"
 
 [[releases]]
+version = "0.1.0"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.1.0.tar.gz"
+etag = "04f0882274fbf688b4a9a1872ca7560f"
+
+[[releases]]
+version = "0.1.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.1.1.tar.gz"
+etag = "d71e31fb70f2a3e07a929cfb5df27d7c"
+
+[[releases]]
+version = "0.1.2"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.1.2.tar.gz"
+etag = "ee7c247af62134ed51ef9c91947cdc6a"
+
+[[releases]]
+version = "0.1.3"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.1.3.tar.gz"
+etag = "5b586400263b0831802ba6cf723ba928"
+
+[[releases]]
+version = "0.15.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.15.1.tar.gz"
+etag = "36a7947e7f2c01901201790825c54a53"
+
+[[releases]]
 version = "0.16.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.16.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.16.0.tar.gz"
 etag = "e4cc76bea92fabb664edadc4db14a8f2"
 
 [[releases]]
 version = "0.16.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.16.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.16.1.tar.gz"
 etag = "b5445b351a68c573960b06564ef9267c"
 
 [[releases]]
 version = "0.17.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.0.tar.gz"
 etag = "49c1ab8d008eb831761cb223dc432466"
 
 [[releases]]
 version = "0.17.10"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.10.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.10.tar.gz"
 etag = "faec4c1a00eee8e76caaba32cd22ca83"
 
 [[releases]]
 version = "0.17.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.2.tar.gz"
 etag = "f4028eb5672205666c343c33e7b6a592"
 
 [[releases]]
 version = "0.17.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.3.tar.gz"
 etag = "3e832943295d44f9be9bcd9c409a6e79"
 
 [[releases]]
 version = "0.17.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.4.tar.gz"
 etag = "f385c5c6953a745accec7ec605eb7ebb"
 
 [[releases]]
 version = "0.17.5"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.5.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.5.tar.gz"
 etag = "0da233f2fd6c7a101ca0512aca902d1d"
 
 [[releases]]
 version = "0.17.6"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.6.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.6.tar.gz"
 etag = "e73409da852ceefeba4111d6e7c9c4e2"
 
 [[releases]]
 version = "0.17.7"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.7.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.7.tar.gz"
 etag = "82ee9ba3be948cf65f89554c79828f1f"
 
 [[releases]]
 version = "0.17.8"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.8.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.8.tar.gz"
 etag = "a8d1e7246e0aff37f47855b0e73e0dd3"
 
 [[releases]]
 version = "0.17.9"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.17.9.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.17.9.tar.gz"
 etag = "1d49af2d8a76dc9e3e0058f6d0ad63af"
 
 [[releases]]
 version = "0.18.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.18.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.18.0.tar.gz"
 etag = "e3fc0c09e7c3935c7f37729b6de3291d"
 
 [[releases]]
 version = "0.18.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.18.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.18.1.tar.gz"
 etag = "266a3f76f9ca02391074c87e661b5466"
 
 [[releases]]
 version = "0.18.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.18.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.18.2.tar.gz"
 etag = "d7aab1b37ffb6f308ef41366983c21af"
 
 [[releases]]
 version = "0.19.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.19.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.19.0.tar.gz"
 etag = "7749fa4e8be58114ca8a03932bad273f"
 
 [[releases]]
 version = "0.19.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.19.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.19.1.tar.gz"
 etag = "28b4eba034249540e03635dfaa89bedc"
 
 [[releases]]
 version = "0.20.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.20.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.20.0.tar.gz"
 etag = "12df75bdb018b0412580ccc5ffee5c6e"
 
 [[releases]]
 version = "0.20.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.20.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.20.3.tar.gz"
 etag = "9520b108ce17c2d3a0c8ce7e9b1e99ed"
 
 [[releases]]
 version = "0.20.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.20.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.20.4.tar.gz"
 etag = "b3a762307d08b8a2eac3661e966a6d71"
 
 [[releases]]
 version = "0.21.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.21.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.21.0.tar.gz"
 etag = "678759bcbf0676825cba2f4fb1417bca"
 
 [[releases]]
 version = "0.21.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.21.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.21.1.tar.gz"
 etag = "ec31fdc4ae983bafaf73c6291eb28098"
 
 [[releases]]
 version = "0.21.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.21.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.21.2.tar.gz"
 etag = "9ac335d46f4c0af97cd08b3013cf6d87"
 
 [[releases]]
 version = "0.21.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.21.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.21.3.tar.gz"
 etag = "779e0c868fbc2c8235d20755890202fc"
 
 [[releases]]
 version = "0.22.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.22.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.22.0.tar.gz"
 etag = "bd0fa3000a488d89f75b03efcbd32cec"
 
 [[releases]]
 version = "0.23.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.23.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.23.0.tar.gz"
 etag = "bf5ddf6d0031047afafe1fb9fbad5d5e"
+
+[[releases]]
+version = "0.23.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.23.1.tar.gz"
+etag = "433f35f863d619810e4edff174a70cee"
 
 [[releases]]
 version = "0.23.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.23.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.23.2.tar.gz"
 etag = "8c40f98256c9f14234e6afb04af910b0"
 
 [[releases]]
 version = "0.23.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.23.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.23.3.tar.gz"
 etag = "54850071e7b675d569fdbbc328ee6b36"
 
 [[releases]]
 version = "0.23.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.23.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.23.4.tar.gz"
 etag = "e6837e4ca870c1e83728a426b221e5c3"
 
 [[releases]]
 version = "0.24.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.24.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.24.0.tar.gz"
 etag = "0efe461e8326f0ad2a2cfac18cff642e"
 
 [[releases]]
 version = "0.24.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.24.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.24.1.tar.gz"
 etag = "45d38d55725bfb4ef6ef05115f452882"
 
 [[releases]]
 version = "0.24.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.24.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.24.2.tar.gz"
 etag = "735df9bb556e8457857ec2922f04ff7d"
 
 [[releases]]
 version = "0.24.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.24.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.24.3.tar.gz"
 etag = "24a7c444b19980db53e459fb10d288cd"
 
 [[releases]]
 version = "0.24.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.24.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.24.4.tar.gz"
 etag = "da248c8867553d500c08efc3179850f7"
 
 [[releases]]
 version = "0.24.5"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.24.5.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.24.5.tar.gz"
 etag = "c2484941f0ff0dd20079d2b1f5229845"
 
 [[releases]]
 version = "0.24.6"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.24.6.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.24.6.tar.gz"
 etag = "156eb82fc7a7635bbc2738a9af936fc5"
 
 [[releases]]
 version = "0.25.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.25.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.25.1.tar.gz"
 etag = "91a2bbaf068a347fa2ba43ded3274beb"
 
 [[releases]]
 version = "0.25.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.25.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.25.2.tar.gz"
 etag = "9d825f5f0cd06b4fce28eba54dafef30"
 
 [[releases]]
 version = "0.25.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.25.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.25.3.tar.gz"
 etag = "47c165d679874eff6c029da8a7affb97"
 
 [[releases]]
 version = "0.25.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.25.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.25.4.tar.gz"
 etag = "017785ed5d2ed48ae32db4b853d4ceeb"
+
+[[releases]]
+version = "0.26.0"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.26.0.tar.gz"
+etag = "1d519b37c0d940926c734d006a3903c4"
 
 [[releases]]
 version = "0.26.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.26.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.26.1.tar.gz"
 etag = "0bf0ee938c79e9286cd6eea2e2c58f61"
 
 [[releases]]
 version = "0.27.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.27.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.27.0.tar.gz"
 etag = "13e77d6b5affcac7c4c236e507c8a401"
 
 [[releases]]
 version = "0.27.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.27.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.27.1.tar.gz"
 etag = "12b771a045e13d63cf90952ddbcab76c"
 
 [[releases]]
 version = "0.27.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.27.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.27.2.tar.gz"
 etag = "48975e76fdd9121d7e1086ce84e49d04"
 
 [[releases]]
 version = "0.27.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.27.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.27.3.tar.gz"
 etag = "4ad6f69bcefb07ded5d4c5c308891dc4"
 
 [[releases]]
 version = "0.27.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.27.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.27.4.tar.gz"
 etag = "2bb09faf7673aa9a9a82558f1e1d1f3e"
 
 [[releases]]
 version = "0.27.5"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.27.5.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.27.5.tar.gz"
 etag = "7300299755265c169a8f05a1c7dfd4db"
 
 [[releases]]
 version = "0.28.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.28.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.28.1.tar.gz"
 etag = "cec620899d1e1e73e5915bd1cc404974"
 
 [[releases]]
 version = "0.28.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v0.28.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v0.28.4.tar.gz"
 etag = "60567689a1fd6bba33b2b6cdae6ef6ac"
 
 [[releases]]
 version = "1.0.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.0.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.0.0.tar.gz"
 etag = "5f66c6d6af1d4423c55291fe3f16925e"
 
 [[releases]]
 version = "1.0.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.0.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.0.1.tar.gz"
 etag = "bc4a5d0bebc7fdd43be6f8ca7d0c7ded"
 
 [[releases]]
 version = "1.0.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.0.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.0.2.tar.gz"
 etag = "bcdf44691092302858de5df1012861e3"
 
 [[releases]]
 version = "1.1.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.1.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.1.0.tar.gz"
 etag = "26588f716ac62a54a98094ee6c1284e4"
 
 [[releases]]
 version = "1.10.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.10.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.10.0.tar.gz"
 etag = "c8ad5d2a2f02ba666e92189dae951575"
 
 [[releases]]
 version = "1.10.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.10.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.10.1.tar.gz"
 etag = "3d34580367b4ea7ad6f4358e3aa6b2af"
 
 [[releases]]
 version = "1.11.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.11.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.11.0.tar.gz"
 etag = "d4f05075f534dd9a0a8c18c650b55f0d"
 
 [[releases]]
 version = "1.11.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.11.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.11.1.tar.gz"
 etag = "87308536d6e6bdad4d258d91e87c0980"
 
 [[releases]]
 version = "1.12.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.12.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.12.0.tar.gz"
 etag = "a02bfad92a883543cef480eedf9a92e4"
 
 [[releases]]
 version = "1.12.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.12.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.12.1.tar.gz"
 etag = "0f9197f5dceace96d93520e492c043a2"
 
 [[releases]]
 version = "1.12.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.12.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.12.3.tar.gz"
 etag = "925d0dd6eebf08f761a2efd4da981d17"
 
 [[releases]]
 version = "1.13.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.13.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.13.0.tar.gz"
 etag = "a466d851585045cf5a16f6c5bd7c3bad"
 
 [[releases]]
 version = "1.14.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.14.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.14.0.tar.gz"
 etag = "43175a59cfbb68aadb686b1ef62b074c"
 
 [[releases]]
 version = "1.15.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.15.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.15.0.tar.gz"
 etag = "197361f7c7c955eeb07950efd34af6e0"
 
 [[releases]]
 version = "1.15.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.15.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.15.1.tar.gz"
 etag = "affcf608656a9a5250fbfedf4b23a405"
 
 [[releases]]
 version = "1.15.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.15.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.15.2.tar.gz"
 etag = "35835237750040f08c0e87550e05dcea"
 
 [[releases]]
 version = "1.16.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.16.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.16.0.tar.gz"
 etag = "46790033c23803387890f545e4040690"
 
 [[releases]]
 version = "1.17.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.17.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.17.0.tar.gz"
 etag = "ce6a7e128618b5c9d058e2a8bd1a71f8"
 
 [[releases]]
 version = "1.17.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.17.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.17.1.tar.gz"
 etag = "15543697ad9ed6ee4e476f892128a41e"
 
 [[releases]]
 version = "1.17.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.17.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.17.2.tar.gz"
 etag = "e19c41ab602e43bbecc0e2ebf039ce4f"
 
 [[releases]]
 version = "1.17.3"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.17.3.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.17.3.tar.gz"
 etag = "4a02e1687a150113ad6b0215f9afdb3e"
 
 [[releases]]
 version = "1.18.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.18.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.18.0.tar.gz"
 etag = "dd0d505bdecc6b5d06a27df9927e0452"
 
 [[releases]]
 version = "1.19.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.19.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.19.0.tar.gz"
 etag = "e18cc1ee9aff041c634e3516d6d95702"
 
 [[releases]]
 version = "1.19.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.19.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.19.1.tar.gz"
 etag = "4d406e34b2461c4c4f2c3d1f93692bf8"
 
 [[releases]]
 version = "1.19.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.19.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.19.2.tar.gz"
 etag = "ad9878c3c55bfbd90c20c70146352610"
 
 [[releases]]
 version = "1.2.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.2.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.2.0.tar.gz"
 etag = "95b6c1c0e6504e5d4e31b720505471c9"
 
 [[releases]]
 version = "1.2.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.2.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.2.1.tar.gz"
 etag = "a16106e2b9a79bfdfad563d3fcbd97b4"
 
 [[releases]]
 version = "1.21.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.21.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.21.0.tar.gz"
 etag = "9ff2ac8062761ab1ed638d58df91bafb"
 
 [[releases]]
 version = "1.21.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.21.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.21.1.tar.gz"
 etag = "b7bfaa7dfe788074b3f51e57497a7c54"
 
 [[releases]]
 version = "1.22.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.0.tar.gz"
 etag = "451be8c7647720fa24ecc861715ee1dd"
 
 [[releases]]
 version = "1.22.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.1.tar.gz"
 etag = "480dec62fe76a52074f00734f444e823"
 
 [[releases]]
 version = "1.22.10"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.10.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.10.tar.gz"
 etag = "52e8dbe9d0cb90683dd3ee2ebf2becb8"
 
 [[releases]]
 version = "1.22.11"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.11.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.11.tar.gz"
 etag = "abac2ecbe725c04e91dafc56ae2163b3"
 
 [[releases]]
 version = "1.22.12"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.12.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.12.tar.gz"
 etag = "1ff62ef8049c14c3e5f2fa3bf594132a"
 
 [[releases]]
 version = "1.22.13"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.13.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.13.tar.gz"
 etag = "5083b9c6ac6ed6fb4f8c666c41c1cab1"
 
 [[releases]]
 version = "1.22.14"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.14.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.14.tar.gz"
 etag = "8e166ebb48570c137bf801e38dcf4c5c"
 
 [[releases]]
 version = "1.22.15"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.15.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.15.tar.gz"
 etag = "4113da7ab81a77fb30f74737a459a225"
 
 [[releases]]
 version = "1.22.16"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.16.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.16.tar.gz"
 etag = "f2cde1b4c22eae2885f2dcdd766ff1e6"
 
 [[releases]]
 version = "1.22.17"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.17.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.17.tar.gz"
 etag = "291fea6d3b993c201b946ab566de816c"
 
 [[releases]]
 version = "1.22.18"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.18.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.18.tar.gz"
 etag = "fd220e06ecd3a3cc86a38f9215efdd67"
+
+[[releases]]
+version = "1.22.19"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.19.tar.gz"
+etag = "c04ea97bf9f72386c1a3da6b1c8510e3"
 
 [[releases]]
 version = "1.22.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.4.tar.gz"
 etag = "faf483d50aa8ccbdc802efa0cac5d4d3"
 
 [[releases]]
 version = "1.22.5"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.5.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.5.tar.gz"
 etag = "a4d5802cc7eec88edf47bd8887acb06c"
+
+[[releases]]
+version = "1.22.6"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.6.tar.gz"
+etag = "37b0c35d17fc017dd834e8bc7ec84b42"
+
+[[releases]]
+version = "1.22.7"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.7.tar.gz"
+etag = "d7741b1cb50442be226106bc35309aea"
+
+[[releases]]
+version = "1.22.8"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.8.tar.gz"
+etag = "334b5a39f4ea1ab996215e40fb5551a1"
+
+[[releases]]
+version = "1.22.9"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.9.tar.gz"
+etag = "afac05a09b5106221c4a048f74e38b85"
+
+[[releases]]
+version = "1.3.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.3.1.tar.gz"
+etag = "6bddbe5c732f0f3acd9111e635d73e60"
 
 [[releases]]
 version = "1.3.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.3.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.3.2.tar.gz"
 etag = "db82fa09c996e9318f2f1d2ab99228f9"
 
 [[releases]]
 version = "1.4.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.4.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.4.0.tar.gz"
 etag = "e5ff3f0c369fc52e38e5cd78801605a2"
+
+[[releases]]
+version = "1.5.0"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.5.0.tar.gz"
+etag = "5a1ab00dfb8533c40819a95d443e95ee"
 
 [[releases]]
 version = "1.5.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.5.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.5.1.tar.gz"
 etag = "561ac9089c33402abece941bc424cdd4"
 
 [[releases]]
 version = "1.6.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.6.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.6.0.tar.gz"
 etag = "a11a3d8a5d62712fc497a6d1cbea25f6"
 
 [[releases]]
 version = "1.7.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.7.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.7.0.tar.gz"
 etag = "e149b4cc0c2cb903551a0b857a2b3c78"
 
 [[releases]]
 version = "1.8.0"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.8.0.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.8.0.tar.gz"
 etag = "3e20c3c91a97512fc38ea797df032d84"
 
 [[releases]]
 version = "1.9.1"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.9.1.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.9.1.tar.gz"
 etag = "aaab1f955228b43b11c6a4ab9467321d"
 
 [[releases]]
 version = "1.9.2"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.9.2.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.9.2.tar.gz"
 etag = "d7a98e7bc7a80fe604b271d04589c7e1"
 
 [[releases]]
 version = "1.9.4"
 channel = "release"
-url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.9.4.tar.gz"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.9.4.tar.gz"
 etag = "1202576a1a67d2228b44bb6f87a4eb64"
+
+[[releases]]
+version = "2.4.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v2.4.1.tar.gz"
+etag = "61bff0ab7cc560eb87ff74a3d4bbb227"
+
+[[releases]]
+version = "2.4.2"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v2.4.2.tar.gz"
+etag = "5ac10334c0ab3fd48c38a61255af427b"
+
+[[releases]]
+version = "3.0.0-rc.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.0.0-rc.1.tar.gz"
+etag = "bde803a6c4f6e16f11308a1a859d2615"
+
+[[releases]]
+version = "3.0.0-rc.2"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.0.0-rc.2.tar.gz"
+etag = "c77e85673b8d1e2dff0de16a4bac6f59"
+
+[[releases]]
+version = "3.0.0-rc.3"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.0.0-rc.3.tar.gz"
+etag = "26fdf2c4f07c1895ff29720153262fbc"
+
+[[releases]]
+version = "3.0.0-rc.4"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.0.0-rc.4.tar.gz"
+etag = "7931dfe982cc10edcea2302abaf7b76a"
+
+[[releases]]
+version = "3.0.0"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.0.0.tar.gz"
+etag = "859f1da1eab6f3043a2c879ebeba0876"
+
+[[releases]]
+version = "3.0.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.0.1.tar.gz"
+etag = "084c4d6d9d553e128e0ef9d256a7a27e"
+
+[[releases]]
+version = "3.0.2"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.0.2.tar.gz"
+etag = "5b4371940837264603339f03b97b4972"
+
+[[releases]]
+version = "3.1.0"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.1.0.tar.gz"
+etag = "030da650dd07bcd4f88c9989d95ad4e1"
+
+[[releases]]
+version = "3.1.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.1.1.tar.gz"
+etag = "a2179a62462f83074a99d92060aafb43"
+
+[[releases]]
+version = "3.2.0"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.2.0.tar.gz"
+etag = "d5da2ad77d8e3e35ab55143f719f0c90"
+
+[[releases]]
+version = "3.2.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.2.1.tar.gz"
+etag = "ca6c8cf07145de3bc36a847d714687c7"
+
+[[releases]]
+version = "3.2.2"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.2.2.tar.gz"
+etag = "b6ba309cb478625cad74c7ea7eb8d1e9"
+
+[[releases]]
+version = "3.2.3"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.2.3.tar.gz"
+etag = "8c0099f5335d6376f8edc5f6f24c7bcd"
+
+[[releases]]
+version = "3.2.4"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.2.4.tar.gz"
+etag = "b23e4d195939b778c31d5cfbb8a06a0f"
+
+[[releases]]
+version = "3.3.0"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.3.0.tar.gz"
+etag = "36761f8512b2584f152105c2f03e5347"
+
+[[releases]]
+version = "3.3.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.3.1.tar.gz"
+etag = "06600cdc3528c8409e903fa91a842991"
+
+[[releases]]
+version = "3.4.0"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.4.0.tar.gz"
+etag = "18d687cd85f571235c99925ccaee8848"
+
+[[releases]]
+version = "3.4.1"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.4.1.tar.gz"
+etag = "01c347052fb9a314856292d6c00f9c32"
+
+[[releases]]
+version = "4.0.0-rc.35"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0-rc.35.tar.gz"
+etag = "f203ecd637ad5d59ab9458ba0578591e"
+
+[[releases]]
+version = "4.0.0-rc.36"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0-rc.36.tar.gz"
+etag = "3f8ba91e1198e27cf9a0d306dd7e8a4b"
+
+[[releases]]
+version = "4.0.0-rc.37"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0-rc.37.tar.gz"
+etag = "87bc1619ea05f8ff0f515c85c8742e6b"
+
+[[releases]]
+version = "4.0.0-rc.38"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0-rc.38.tar.gz"
+etag = "65c19ccb356400ef5497f575e757a1c4"
+
+[[releases]]
+version = "4.0.0-rc.39"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0-rc.39.tar.gz"
+etag = "51a3824e46134d90d5b097457d2c0548"
 

--- a/buildpacks/nodejs-yarn/src/layers/cli.rs
+++ b/buildpacks/nodejs-yarn/src/layers/cli.rs
@@ -1,6 +1,5 @@
 use crate::{YarnBuildpack, YarnBuildpackError};
 use heroku_nodejs_utils::inv::Release;
-use heroku_nodejs_utils::vrs::{Requirement, VersionError};
 use libcnb::build::BuildContext;
 use libcnb::data::buildpack::StackId;
 use libcnb::data::layer_content_metadata::LayerTypes;
@@ -41,8 +40,6 @@ pub(crate) enum CliLayerError {
     Installation(std::io::Error),
     #[error("Couldn't set CLI permissions: {0}")]
     Permissions(std::io::Error),
-    #[error("Couldn't parse CLI version requirement: {0}")]
-    Requirement(VersionError),
 }
 
 const LAYER_VERSION: &str = "1";
@@ -74,10 +71,7 @@ impl Layer for CliLayer {
 
         log_info(format!("Installing yarn {}", self.release.version));
 
-        let dist_name = if Requirement::parse(">= 2.0.0")
-            .map_err(CliLayerError::Requirement)?
-            .satisfies(&self.release.version)
-        {
+        let dist_name = if layer_path.join("package").exists() {
             "package".to_string()
         } else {
             format!("yarn-v{}", self.release.version)

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -7,7 +7,7 @@ use crate::layers::{CliLayer, CliLayerError, DepsLayer, DepsLayerError};
 use crate::yarn::Yarn;
 use heroku_nodejs_utils::inv::Inventory;
 use heroku_nodejs_utils::package_json::{PackageJson, PackageJsonError};
-use heroku_nodejs_utils::vrs::Requirement;
+use heroku_nodejs_utils::vrs::{Requirement, VersionError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::build_plan::BuildPlanBuilder;
 use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
@@ -33,6 +33,7 @@ mod layers;
 mod yarn;
 
 const INVENTORY: &str = include_str!("../inventory.toml");
+const DEFAULT_YARN_REQUIREMENT: &str = "1.22.x";
 
 pub(crate) struct YarnBuildpack;
 
@@ -77,8 +78,9 @@ impl Buildpack for YarnBuildpack {
 
                 let requested_yarn_cli_range = match cfg::requested_yarn_range(&pkg_json) {
                     None => {
-                        log_info("Detected no yarn version range requirement");
-                        Requirement::any()
+                        log_info("No yarn version range requirement detected, using default ({DEFAULT_YARN_REQUIREMENT})");
+                        Requirement::parse(DEFAULT_YARN_REQUIREMENT)
+                            .map_err(YarnBuildpackError::YarnDefaultParse)?
                     }
                     Some(requirement) => {
                         log_info(format!(
@@ -191,7 +193,8 @@ impl Buildpack for YarnBuildpack {
                     }
                     YarnBuildpackError::YarnVersionDetect(_)
                     | YarnBuildpackError::YarnVersionResolve(_)
-                    | YarnBuildpackError::YarnVersionUnsupported(_) => {
+                    | YarnBuildpackError::YarnVersionUnsupported(_)
+                    | YarnBuildpackError::YarnDefaultParse(_) => {
                         log_error("Yarn version error", err_string);
                     }
                 }
@@ -227,6 +230,8 @@ pub(crate) enum YarnBuildpackError {
     YarnVersionUnsupported(u64),
     #[error("Couldn't resolve yarn version requirement ({0}) to a known yarn version")]
     YarnVersionResolve(Requirement),
+    #[error("Couldn't parse yarn default version range: {0}")]
+    YarnDefaultParse(VersionError),
 }
 
 impl From<YarnBuildpackError> for libcnb::Error<YarnBuildpackError> {

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -78,13 +78,13 @@ impl Buildpack for YarnBuildpack {
 
                 let requested_yarn_cli_range = match cfg::requested_yarn_range(&pkg_json) {
                     None => {
-                        log_info("No yarn version range requirement detected, using default ({DEFAULT_YARN_REQUIREMENT})");
+                        log_info("No yarn engine range detected in package.json, using default ({DEFAULT_YARN_REQUIREMENT})");
                         Requirement::parse(DEFAULT_YARN_REQUIREMENT)
                             .map_err(YarnBuildpackError::YarnDefaultParse)?
                     }
                     Some(requirement) => {
                         log_info(format!(
-                            "Detected yarn version range {requirement} from package.json"
+                            "Detected yarn engine version range {requirement} in package.json"
                         ));
                         requirement
                     }

--- a/common/nodejs-utils/src/nodebin_s3.rs
+++ b/common/nodejs-utils/src/nodebin_s3.rs
@@ -61,8 +61,8 @@ impl TryFrom<BucketContent> for Inventory {
             "node" => Regex::new(
                 r"node/(?P<channel>\w+)/(?P<arch>[\w-]+)/node-v(?P<version>\d+\.\d+\.\d+)[\w-]+\.tar\.gz",
             ),
-            _ => Err(regex::Error::Syntax(format!(
-                "Unknown inventory prefix: {inv}"
+            i => Err(regex::Error::Syntax(format!(
+                "Unknown S3 inventory prefix: {i}"
             ))),
         }?;
 
@@ -96,7 +96,7 @@ impl TryFrom<BucketContent> for Inventory {
             .collect();
 
         Ok(Self {
-            name: result.prefix.to_string(),
+            name: inv.to_string(),
             releases: releases?,
         })
     }

--- a/test/fixtures/yarn-2-modules-nonzero/package.json
+++ b/test/fixtures/yarn-2-modules-nonzero/package.json
@@ -1,6 +1,8 @@
 {
   "name": "yarn-2-modules-nonzero",
-  "packageManager": "yarn@2.4.1",
+  "engines": {
+    "yarn": "2.4.x"
+  },
   "scripts": {
     "start": "node ./server.js"
   },

--- a/test/fixtures/yarn-3-modules-zero/package.json
+++ b/test/fixtures/yarn-3-modules-zero/package.json
@@ -1,7 +1,8 @@
 {
   "name": "yarn-3-modules-zero",
   "engines": {
-    "node": "18.x"
+    "node": "18.x",
+    "yarn": "3.x"
   },
   "scripts": {
     "start": "node server.js"


### PR DESCRIPTION
This will make newer "berry" releases of Yarn (versions 2.x, 3.x, and 4.x) available for installation.

A few additional notes:

- To preserve backwards compatibility and match github.com/heroku/heroku-buildpack-nodejs, we default to yarn `1.22.x` if no version range is provided.

- The name of the first level directory in the archive is different depending on what yarn version was mirrored. There's a new conditional to address this.

- Some yarn berry releases don't have the entrypoint set as executable. This PR addresses that by manually setting permissions to `0755`.

- This also adds automation for yarn inventory updates, exactly like we have for Node releases already.

[W-12400621](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00001JdaBYYAZ)