### PR TITLE
Strip nodejs-utils binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ version = "0.0.0"
 rust-version = "1.67"
 edition = "2021"
 publish = false
+
+[profile.release]
+strip = true

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -21,3 +21,6 @@ url = "2"
 
 [dev-dependencies]
 tempfile = "3"
+
+[profile.release]
+strip = true

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -21,6 +21,3 @@ url = "2"
 
 [dev-dependencies]
 tempfile = "3"
-
-[profile.release]
-strip = true


### PR DESCRIPTION
When compiling release binaries, we should strip them. This will keep them small, which is especially useful for cases like https://github.com/heroku/heroku-buildpack-nodejs/pull/1061, where the compiled binary is part of the repo.

The other crates in this repo are buildpacks, which are compiled with libcnb.rs, which already enforces stripping.