### PR TITLE
Update libcnb-test and toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,11 +82,11 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82e7850583ead5f8bbef247e2a3c37a19bd576e8420cd262a6711921827e1e5"
+checksum = "af254ed2da4936ef73309e9597180558821cb16ae9bba4cb24ce6b612d8d80ed"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -94,6 +100,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_repr",
  "serde_urlencoded",
  "thiserror",
  "tokio",
@@ -104,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.42.0-rc.3"
+version = "1.42.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+checksum = "602bda35f33aeb571cef387dcd4042c643a8bf689d8aaac2cc47ea24cb7bc7e0"
 dependencies = [
  "serde",
  "serde_with",
@@ -185,7 +192,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -283,41 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
  "quote",
  "syn",
 ]
@@ -543,7 +515,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
- "toml 0.5.10",
+ "toml 0.7.2",
  "ureq",
 ]
 
@@ -560,7 +532,7 @@ dependencies = [
  "tempfile",
  "test_support",
  "thiserror",
- "toml 0.5.10",
+ "toml 0.7.2",
 ]
 
 [[package]]
@@ -576,7 +548,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml 0.5.10",
+ "toml 0.7.2",
  "ureq",
  "url",
 ]
@@ -593,7 +565,7 @@ dependencies = [
  "tempfile",
  "test_support",
  "thiserror",
- "toml 0.5.10",
+ "toml 0.7.2",
  "ureq",
 ]
 
@@ -699,12 +671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +688,7 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -798,13 +765,13 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ed34a92d997ad9b0666ddbcc3995191e7642ee50ffa760497d2fb3bff7c5b5"
+checksum = "aacd18d358a1078cf48f518ef8398c504f8d4fc691ba2e8773bafa1a71d66b59"
 dependencies = [
  "cargo_metadata",
  "libcnb-data",
- "toml 0.5.10",
+ "toml 0.7.2",
  "which",
 ]
 
@@ -822,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-test"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f414f5b106078d0bbb67b9e3d3bf9e21012f3a318505649e8e99c9d36d200ea"
+checksum = "f86e8c1847c8ba3c37e30841ee241887203110f4373731e7967706ab77c42b7d"
 dependencies = [
  "bollard",
  "cargo_metadata",
@@ -1198,6 +1165,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,24 +1198,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+checksum = "85456ffac572dc8826334164f2fb6fb40a7c766aebe195a2a21ee69ee2885ecf"
 dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap",
  "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
+ "serde_json",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -1275,12 +1246,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1364,6 +1329,33 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -1543,7 +1535,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc0c46e911514c4edd735f38d2e493c182c1d4f7a1f89022e14ea3f9833be24b"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "flate2",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
- "toml 0.7.2",
+ "toml",
  "ureq",
 ]
 
@@ -532,7 +532,7 @@ dependencies = [
  "tempfile",
  "test_support",
  "thiserror",
- "toml 0.7.2",
+ "toml",
 ]
 
 [[package]]
@@ -548,7 +548,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml 0.7.2",
+ "toml",
  "ureq",
  "url",
 ]
@@ -565,7 +565,7 @@ dependencies = [
  "tempfile",
  "test_support",
  "thiserror",
- "toml 0.7.2",
+ "toml",
  "ureq",
 ]
 
@@ -747,7 +747,7 @@ dependencies = [
  "libcnb-proc-macros",
  "serde",
  "thiserror",
- "toml 0.7.2",
+ "toml",
 ]
 
 [[package]]
@@ -760,7 +760,7 @@ dependencies = [
  "libcnb-proc-macros",
  "serde",
  "thiserror",
- "toml 0.7.2",
+ "toml",
 ]
 
 [[package]]
@@ -771,7 +771,7 @@ checksum = "aacd18d358a1078cf48f518ef8398c504f8d4fc691ba2e8773bafa1a71d66b59"
 dependencies = [
  "cargo_metadata",
  "libcnb-data",
- "toml 0.7.2",
+ "toml",
  "which",
 ]
 
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8085f21847f46079ce900bf2169e3e51ffa3685dc298aa71056a29d96d4413cb"
+checksum = "878674906e0140191f89047ef1e8c142cb31becce91b4e64b1b6419fe03da7c1"
 dependencies = [
  "crossbeam-utils",
  "flate2",
@@ -819,7 +819,7 @@ dependencies = [
  "tar",
  "termcolor",
  "thiserror",
- "toml 0.5.10",
+ "toml",
  "ureq",
 ]
 
@@ -1413,15 +1413,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -12,7 +12,7 @@ libcnb = "0.11"
 libherokubuildpack = "0.11"
 serde = "1.0.149"
 tempfile = "3.4.0"
-toml = "0.5"
+toml = "0.7"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -12,7 +12,7 @@ libcnb = "0.11"
 libherokubuildpack = "0.11"
 serde = "1"
 thiserror = "1"
-toml = "0.5"
+toml = "0.7"
 
 [dev-dependencies]
 libcnb-test = "0.11"

--- a/buildpacks/nodejs-function-invoker/src/function.rs
+++ b/buildpacks/nodejs-function-invoker/src/function.rs
@@ -3,7 +3,6 @@ use libcnb::read_toml_file;
 use libherokubuildpack::toml::toml_select_value;
 use std::path::PathBuf;
 use thiserror::Error;
-use toml::Value;
 
 pub fn is_function<P>(d: P) -> bool
 where
@@ -13,7 +12,7 @@ where
     dir.join("function.toml").exists() || {
         read_toml_file(dir.join("project.toml"))
             .ok()
-            .and_then(|toml: Value| {
+            .and_then(|toml: toml::Value| {
                 toml_select_value(vec!["com", "salesforce", "type"], &toml)
                     .and_then(toml::Value::as_str)
                     .map(|value| value == "function")

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -13,7 +13,7 @@ libherokubuildpack = "0.11"
 serde = "1"
 tempfile = "3"
 thiserror = "1.0"
-toml = "0.5"
+toml = "0.7"
 
 [dev-dependencies]
 libcnb-test = "0.11"

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1", features = ['derive'] }
 serde_json = "1"
 serde-xml-rs = "0.6"
 thiserror = "1"
-toml = "0.5"
+toml = "0.7"
 ureq = "2"
 url = "2"
 


### PR DESCRIPTION
Updating libcnb-test and toml at the same time to prevent conflicts. This also required a libherokubuildpack update. Supersedes #485 and #471. 