### PR TITLE
Use private runner for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     name: Release ${{ github.event.inputs.requested_buildpack_id }}
-    runs-on: ubuntu-20.04 # ubuntu-latest currently resolves to 18.04 which does not have aws-cli 2.x yet
+    runs-on: pub-hk-ubuntu-22.04-small
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Release workflows are failing due to IP whitelisting, for example: https://github.com/heroku/buildpacks-nodejs/actions/runs/4600643908. This puts the release workflow on private runners.