### PR TITLE
Post release updates heroku/nodejs-engine 0.8.17, heroku/nodejs-yarn 0.4.1

### DIFF
--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -5,13 +5,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added node version 19.9.0.
+
+## [0.8.17] 2023/04/03
+
 - Added node version 16.20.0.
 - Added node version 19.8.1, 19.8.0.
 - Added node version 18.15.0.
+
 ## [0.8.16] 2023/02/27
 
 - Added node version 19.7.0, 19.6.1, 14.21.3, 16.19.1, 18.14.1, 18.14.2.
 - Added node version 18.14.0, 19.6.0.
+
 ## [0.8.15] 2023/02/02
 
 - `name` is no longer a required field in package.json. ([#447](https://github.com/heroku/buildpacks-nodejs/pull/447))
@@ -21,14 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added node version 18.13.0, 19.4.0.
 - Added node version 19.3.0, 16.19.0, 14.21.2.
+
 ## [0.8.13] 2022/12/05
 
 - Added node version 19.2.0.
 - Added node version 19.1.0.
+
 ## [0.8.12] 2022/11/04
 
 - Added node version 19.0.1, 14.21.1, 18.12.1, 16.18.1.
 - Added node version 14.21.0.
+
 ## [0.8.11] 2022/11/01
 
 - Don't overwrite WEB_CONCURRENCY if already set. ([#386](https://github.com/heroku/buildpacks-nodejs/pull/386))
@@ -38,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added node version 18.12.0.
 - Added node version 19.0.0.
 - Added node version 16.18.0, 18.11.0, 18.10.0.
+
 ## [0.8.9] 2022/09/28
 
 - Added node version 14.20.1, 18.9.1, 16.17.1.

--- a/buildpacks/nodejs-engine/buildpack.toml
+++ b/buildpacks/nodejs-engine/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "heroku/nodejs-engine"
-version = "0.8.17"
+version = "0.8.18"
 name = "Heroku Node.js Engine"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
 keywords = ["node", "node.js", "nodejs", "javascript", "js"]

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -4,10 +4,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] 2023/04/03
+
 - Added yarn version 4.0.0-rc.42.
 - Added yarn version 4.0.0-rc.41.
 - Added yarn version 3.5.0.
 - Added yarn version 4.0.0-rc.40.
+
 ## [0.4.0] 2023/02/27
 
 - Add several yarn 2, 3, and 4 releases to inventory ([#457](https://github.com/heroku/buildpacks-nodejs/pull/457))

--- a/buildpacks/nodejs-yarn/buildpack.toml
+++ b/buildpacks/nodejs-yarn/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "heroku/nodejs-yarn"
-version = "0.4.1"
+version = "0.4.2"
 name = "Heroku Node.js Yarn"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
 keywords = ["node", "node.js", "nodejs", "javascript", "js", "yarn", "yarnpkg"]

--- a/meta-buildpacks/nodejs-function/CHANGELOG.md
+++ b/meta-buildpacks/nodejs-function/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] 2023/02/27
 * Update to CNB Buildpack API version 0.9
 * Upgraded `heroku/nodejs-engine` to `0.8.16`
+* Upgraded `heroku/nodejs-engine` to `0.8.17`
 
 ## [0.9.18] 2023/02/02
 * Upgraded `heroku/nodejs-engine` to `0.8.15`

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -13,7 +13,7 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.16"
+version = "0.8.17"
 
 [[order.group]]
 id = "heroku/nodejs-npm"

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 * Upgraded `heroku/nodejs-corepack` to `0.1.2`
+* Upgraded `heroku/nodejs-engine` to `0.8.17`
+* Upgraded `heroku/nodejs-yarn` to `0.4.1`
 
 ## [0.6.0] 2023/02/27
 * Upgraded `heroku/nodejs-yarn` to `0.4.0`

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -13,7 +13,7 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.16"
+version = "0.8.17"
 
 [[order.group]]
 id = "heroku/nodejs-corepack"
@@ -33,7 +33,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.16"
+version = "0.8.17"
 
 [[order.group]]
 id = "heroku/nodejs-npm"

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -22,7 +22,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-yarn"
-version = "0.4.0"
+version = "0.4.1"
 
 [[order.group]]
 id = "heroku/procfile"

--- a/test/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/test/meta-buildpacks/nodejs-function/buildpack.toml
@@ -13,7 +13,7 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.17"
+version = "0.8.18"
 
 [[order.group]]
 id = "heroku/nodejs-npm"

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/heroku/buildpacks-nodejs"
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.17"
+version = "0.8.18"
 
 [[order.group]]
 id = "heroku/nodejs-corepack"

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -19,7 +19,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-yarn"
-version = "0.4.1"
+version = "0.4.2"
 
 [[order.group]]
 id = "heroku/procfile"

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -30,7 +30,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.17"
+version = "0.8.18"
 
 [[order.group]]
 id = "heroku/nodejs-npm"


### PR DESCRIPTION
Usually, these changes would have been automated PRs. However, they were missed since both https://github.com/heroku/buildpacks-nodejs/actions/runs/4600643908/jobs/8127500398 and https://github.com/heroku/buildpacks-nodejs/actions/runs/4600648025/jobs/8127509886 failed on IP whitelisting issues.

Note that the IP whitelisting issues should be fixed in the future thanks to #487.