### PR TITLE
Add a pnpm group to heroku/nodejs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
         buildpack-dir:
         - buildpacks/nodejs-engine
         - buildpacks/nodejs-function-invoker
+        - buildpacks/nodejs-pnpm-install
         - buildpacks/nodejs-yarn
         - buildpacks/npm
         - meta-buildpacks/nodejs

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `pnpm` grouping for autodetection of `pnpm` apps ([#502](https://github.com/heroku/buildpacks-node/pull/502))
+
 ## [0.6.2] 2023/04/17
 * Upgraded `heroku/nodejs-engine` to `0.8.19`
 

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -18,6 +18,25 @@ version = "0.8.19"
 [[order.group]]
 id = "heroku/nodejs-corepack"
 version = "0.1.2"
+
+[[order.group]]
+id = "heroku/nodejs-pnpm-install"
+version = "0.1.0"
+
+[[order.group]]
+id = "heroku/procfile"
+version = "2.0.0"
+optional = true
+
+[[order]]
+
+[[order.group]]
+id = "heroku/nodejs-engine"
+version = "0.8.19"
+
+[[order.group]]
+id = "heroku/nodejs-corepack"
+version = "0.1.2"
 optional = true
 
 [[order.group]]

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -8,6 +8,9 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha256:51c478e7398c4c17ae4e60486f8aa115992ae29d888ab7328a0b73d2c4bdbf45"
 
 [[dependencies]]
+uri = "docker://docker.io/heroku/buildpack-nodejs-pnpm-install@sha256:12754c9155038ca92c12ed9e765158b8a6f873078c8f61215d133ff3038387f8"
+
+[[dependencies]]
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:43b6703c4aa37f5182427dc43844ac31a626b16d083f3aa30c4e14260fa7a27e"
 
 [[dependencies]]

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -15,6 +15,25 @@ version = "0.8.20"
 [[order.group]]
 id = "heroku/nodejs-corepack"
 version = "0.1.3"
+
+[[order.group]]
+id = "heroku/nodejs-pnpm-install"
+version = "0.1.1"
+
+[[order.group]]
+id = "heroku/procfile"
+version = "2.0.0"
+optional = true
+
+[[order]]
+
+[[order.group]]
+id = "heroku/nodejs-engine"
+version = "0.8.20"
+
+[[order.group]]
+id = "heroku/nodejs-corepack"
+version = "0.1.3"
 optional = true
 
 [[order.group]]

--- a/test/meta-buildpacks/nodejs/package.toml
+++ b/test/meta-buildpacks/nodejs/package.toml
@@ -11,6 +11,9 @@ uri = "../../../buildpacks/nodejs-corepack"
 uri = "../../../buildpacks/npm"
 
 [[dependencies]]
+uri = "../../../buildpacks/nodejs-pnpm-install"
+
+[[dependencies]]
 uri = "../../../buildpacks/nodejs-yarn"
 
 [[dependencies]]


### PR DESCRIPTION
This will allow `heroku/nodejs` to detect and build corepack apps.

Related: 
- #488 
- #489 

[W-13055295](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00001PifhGYAR)