### PR TITLE
Update to latest pnpm releases in fixtures

### DIFF
--- a/buildpacks/nodejs-corepack/tests/integration_test.rs
+++ b/buildpacks/nodejs-corepack/tests/integration_test.rs
@@ -42,14 +42,14 @@ fn corepack_yarn_3_heroku_22() {
 #[ignore = "integration test"]
 fn corepack_pnpm_7() {
     test_corepack_app("pnpm-7-pnp", Heroku20, |ctx| {
-        assert_contains!(ctx.pack_stdout, "Preparing pnpm@7.31.0");
+        assert_contains!(ctx.pack_stdout, "Preparing pnpm@7.32.3");
         ctx.start_container(
             ContainerConfig::new()
                 .entrypoint(["launcher"])
                 .command(["pnpm", "--version"]),
             |ctr| {
                 let logs = ctr.logs_wait();
-                assert_contains!(logs.stdout, "7.31.0");
+                assert_contains!(logs.stdout, "7.32.3");
             },
         );
     });
@@ -59,14 +59,14 @@ fn corepack_pnpm_7() {
 #[ignore = "integration test"]
 fn corepack_pnpm_8() {
     test_corepack_app("pnpm-8-hoist", Heroku22, |ctx| {
-        assert_contains!(ctx.pack_stdout, "Preparing pnpm@8.1.1");
+        assert_contains!(ctx.pack_stdout, "Preparing pnpm@8.4.0");
         ctx.start_container(
             ContainerConfig::new()
                 .entrypoint(["launcher"])
                 .command(["pnpm", "--version"]),
             |ctr| {
                 let logs = ctr.logs_wait();
-                assert_contains!(logs.stdout, "8.1.1");
+                assert_contains!(logs.stdout, "8.4.0");
             },
         );
     });

--- a/test/fixtures/pnpm-7-pnp/package.json
+++ b/test/fixtures/pnpm-7-pnp/package.json
@@ -1,7 +1,10 @@
 {
   "name": "pnpm-7-pnp",
   "version": "1.0.0",
-  "packageManager": "pnpm@7.31.0",
+  "packageManager": "pnpm@7.32.3",
+  "engines": {
+    "node": "18.x"
+  },
   "scripts": {
     "start": "node ./server.js"
   },

--- a/test/fixtures/pnpm-8-hoist/package.json
+++ b/test/fixtures/pnpm-8-hoist/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pnpm-8-hoist",
   "version": "1.0.0",
-  "packageManager": "pnpm@8.1.1",
+  "packageManager": "pnpm@8.4.0",
   "dependencies": {
     "express": "^4.18.2"
   }


### PR DESCRIPTION
Versions of `pnpm` released prior to the Node.js 20 release are not compatible with Node.js 20.x. This incompatibility is causing all of our `pnpm` integration tests to fail. This PR updates the pnpm 8 fixture to use the Node.js 20.x compatible version of pnpm, and locks the pnpm 7 fixture to Node.js 18.

Example CI failure that this fixes: https://github.com/heroku/buildpacks-nodejs/actions/runs/4850258691/jobs/8782159932?pr=515#step:8:336