### PR TITLE
Split up pnpm text assertions

### DIFF
--- a/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
@@ -76,6 +76,12 @@ fn pnpm_8_hoist_heroku_22() {
                 [Installing dependencies]
                 Lockfile is up to date, resolution step is skipped
                 Progress: resolved 1, reused 0, downloaded 0, added 0
+            "}
+        );
+
+        assert_contains!(
+            ctx.pack_stdout,
+            &formatdoc! {"
                 Packages: +57
                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
             "}

--- a/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
@@ -25,6 +25,12 @@ fn pnpm_7_pnp_heroku_20() {
                 [Installing dependencies]
                 Lockfile is up to date, resolution step is skipped
                 Progress: resolved 1, reused 0, downloaded 0, added 0
+            "}
+        );
+
+        assert_contains!(
+            ctx.pack_stdout,
+            &formatdoc! {"
                 Packages: +60
                 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
             "}


### PR DESCRIPTION
When appropriate, `pnpm` emits a new version notification warning like this:

```
╭─────────────────────────────────────────────────────────────────╮
│                                                                 │
│                Update available! 7.32.3 → 8.4.0.                │
│   Changelog: https://github.com/pnpm/pnpm/releases/tag/v8.4.0   │
│     Run \"corepack prepare pnpm@8.4.0 --activate\" to update.   │
│                                                                 │
│     Follow @pnpmjs for updates: https://twitter.com/pnpmjs      │
│                                                                 │
╰─────────────────────────────────────────────────────────────────╯
```

However, this is an async process, so the location of this line in the build log may change. This causes some of our build log assertions to fail, as the message gets inserted in an unexpected place. This PR splits up a few assertions so that the update notice won't break the tests.