### PR TITLE
Drop references to heroku-18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
     strategy:
       matrix:
         stack-version:
-        - '18'
         - '20'
         - '22'
         buildpack-dir:

--- a/buildpacks/nodejs-corepack/CHANGELOG.md
+++ b/buildpacks/nodejs-corepack/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop explicit support for the End-of-Life stack `heroku-18`.
+
 ## [0.1.2] 2023/04/11
 
 - Will now install `pnpm`. ([#489](https://github.com/heroku/buildpacks-nodejs/pull/489))

--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -11,9 +11,6 @@ keywords = ["corepack", "node", "node.js", "nodejs", "javascript", "js"]
 type = "MIT"
 
 [[stacks]]
-id = "heroku-18"
-
-[[stacks]]
 id = "heroku-20"
 
 [[stacks]]

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop explicit support for the End-of-Life stack `heroku-18`.
+
 ## [0.8.21] 2023/05/08
 
 - Added node version 20.1.0.

--- a/buildpacks/nodejs-engine/buildpack.toml
+++ b/buildpacks/nodejs-engine/buildpack.toml
@@ -11,9 +11,6 @@ keywords = ["node", "node.js", "nodejs", "javascript", "js"]
 type = "MIT"
 
 [[stacks]]
-id = "heroku-18"
-
-[[stacks]]
 id = "heroku-20"
 
 [[stacks]]

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop explicit support for the End-of-Life stack `heroku-18`.
+
 ## [0.3.10] 2023/02/02
 
 - `name` is no longer a required field in package.json. ([#447](https://github.com/heroku/buildpacks-nodejs/pull/447))

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -11,9 +11,6 @@ keywords = ["nodejs", "node", "node.js", "javascript", "js", "function"]
 type = "MIT"
 
 [[stacks]]
-id = "heroku-18"
-
-[[stacks]]
 id = "heroku-20"
 
 [[stacks]]

--- a/buildpacks/nodejs-pnpm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-install/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop explicit support for the End-of-Life stack `heroku-18`.
+
 ## [0.1.0] 2023/04/17
 
 - Initial release ([#488](https://github.com/heroku/buildpacks-nodejs/pull/488))

--- a/buildpacks/nodejs-pnpm-install/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-install/buildpack.toml
@@ -14,9 +14,6 @@ type = "MIT"
 id = "*"
 
 [[stacks]]
-id = "heroku-18"
-
-[[stacks]]
 id = "heroku-20"
 
 [[stacks]]

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop explicit support for the End-of-Life stack `heroku-18`.
+
 ## [0.4.2] 2023/05/08
 
 - Added yarn version 3.5.1, 4.0.0-rc.43.

--- a/buildpacks/nodejs-yarn/buildpack.toml
+++ b/buildpacks/nodejs-yarn/buildpack.toml
@@ -14,9 +14,6 @@ type = "MIT"
 id = "*"
 
 [[stacks]]
-id = "heroku-18"
-
-[[stacks]]
 id = "heroku-20"
 
 [[stacks]]

--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop explicit support for the End-of-Life stack `heroku-18`.
+
 ## [0.5.2] 2022/04/05
 
 - Add support for all stacks

--- a/buildpacks/npm/README.md
+++ b/buildpacks/npm/README.md
@@ -86,8 +86,8 @@ For local development, you'll want the file to look like this:
 
 [stack]
   id = "heroku-22"
-  build-image = "heroku/buildpacks:22"
-  run-image = "heroku/buildpacks:22"
+  build-image = "heroku/buildpacks:22-cnb-build"
+  run-image = "heroku/buildpacks:22-cnb"
 ```
 
 Create the builder with `pack`:

--- a/buildpacks/npm/README.md
+++ b/buildpacks/npm/README.md
@@ -85,7 +85,7 @@ For local development, you'll want the file to look like this:
   ]
 
 [stack]
-  id = "heroku-18"
+  id = "heroku-22"
   build-image = "heroku/buildpacks:22"
   run-image = "heroku/buildpacks:22"
 ```

--- a/buildpacks/npm/README.md
+++ b/buildpacks/npm/README.md
@@ -86,8 +86,8 @@ For local development, you'll want the file to look like this:
 
 [stack]
   id = "heroku-22"
-  build-image = "heroku/buildpacks:22-cnb-build"
-  run-image = "heroku/buildpacks:22-cnb"
+  build-image = "heroku/heroku:22-cnb-build"
+  run-image = "heroku/heroku:22-cnb"
 ```
 
 Create the builder with `pack`:

--- a/buildpacks/npm/README.md
+++ b/buildpacks/npm/README.md
@@ -86,8 +86,8 @@ For local development, you'll want the file to look like this:
 
 [stack]
   id = "heroku-18"
-  build-image = "heroku/pack:18"
-  run-image = "heroku/pack:18"
+  build-image = "heroku/buildpacks:22"
+  run-image = "heroku/buildpacks:22"
 ```
 
 Create the builder with `pack`:

--- a/buildpacks/npm/buildpack.toml
+++ b/buildpacks/npm/buildpack.toml
@@ -14,9 +14,6 @@ type = "MIT"
 id = "*"
 
 [[stacks]]
-id = "heroku-18"
-
-[[stacks]]
 id = "heroku-20"
 
 [[stacks]]


### PR DESCRIPTION
The `heroku-18` stack is now EOL, as documented [here](https://help.heroku.com/X5OE6BCA/heroku-18-end-of-life-faq). It no longer makes sense for these buildpacks to support `heroku-18`.