### PR TITLE
Optimize CI integration tests for runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo test --locked
 
   find-libcnb-buildpacks:
-    name: "Find libcnb buildpacks"
+    name: Find libcnb buildpacks
     runs-on: ubuntu-22.04
     outputs:
       buildpack_dirs: ${{ steps.find-buildpack-dirs.outputs.buildpack_dirs }}
@@ -67,8 +67,8 @@ jobs:
         name: Find libcnb buildpack directories
         run: echo "buildpack_dirs=$(find . -type d -execdir test -e "{}/buildpack.toml" -a -e "{}/Cargo.toml" \; -print | sort | uniq | jq -nRc '[inputs]')" >> $GITHUB_OUTPUT
 
-  integration-test:
-    name: Integration Tests (${{ matrix.buildpack-directory }})
+  rust-integration-test:
+    name: libcnb.rs integration tests (${{ matrix.buildpack-directory }})
     runs-on: pub-hk-ubuntu-22.04-large
     needs: find-libcnb-buildpacks
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,28 @@ jobs:
       - name: Run unit tests
         run: cargo test --locked
 
-  rust-integration-test:
+  find-libcnb-buildpacks:
+    name: "Find libcnb buildpacks"
     runs-on: ubuntu-22.04
+    outputs:
+      buildpack_dirs: ${{ steps.find-buildpack-dirs.outputs.buildpack_dirs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - id: find-buildpack-dirs
+        name: Find libcnb buildpack directories
+        run: echo "buildpack_dirs=$(find . -type d -execdir test -e "{}/buildpack.toml" -a -e "{}/Cargo.toml" \; -print | sort | uniq | jq -nRc '[inputs]')" >> $GITHUB_OUTPUT
+
+  integration-test:
+    name: Integration Tests (${{ matrix.buildpack-directory }})
+    runs-on: pub-hk-ubuntu-22.04-large
+    needs: find-libcnb-buildpacks
+    strategy:
+      fail-fast: false
+      matrix:
+        buildpack-directory: ${{ fromJson(needs.find-libcnb-buildpacks.outputs.buildpack_dirs) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -69,7 +89,8 @@ jobs:
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.1.0
       - name: Run integration tests
-        run: cargo test --locked -- --ignored
+        working-directory: ${{ matrix.buildpack-directory }}
+        run: cargo test --locked -- --ignored --test-threads 16
 
   shpec:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The integration tests are so slow... something must be done!

This PR changes the libcnb.rs integration test job to a matrix -- one job for each libcnb.rs buildpack, each of which uses a bigger instance.

This improves CI runtime from around 20 minutes to around 8 minutes.

Inspired largely by @Malax's work in https://github.com/heroku/buildpacks-jvm/pull/478.