### PR TITLE
Update meta-buildpacks for Docker Hub migration

### DIFF
--- a/meta-buildpacks/nodejs-function/CHANGELOG.md
+++ b/meta-buildpacks/nodejs-function/CHANGELOG.md
@@ -4,9 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Upgraded `heroku/nodejs-npm` to `0.5.4`
-* Upgraded `heroku/nodejs-function-invoker` to `0.3.12`
-* Upgraded `heroku/nodejs-engine` to `0.8.23`
+* Upgraded `heroku/nodejs-npm` to `0.5.3`
+* Upgraded `heroku/nodejs-function-invoker` to `0.3.11`
+* Upgraded `heroku/nodejs-engine` to `0.8.22`
 * Change release target from ECR to docker.io/heroku/buildpack-nodejs-function.
 
 ## [0.10.4] 2023/05/09

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -13,15 +13,15 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.23"
+version = "0.8.22"
 
 [[order.group]]
 id = "heroku/nodejs-npm"
-version = "0.5.4"
+version = "0.5.3"
 
 [[order.group]]
 id = "heroku/nodejs-function-invoker"
-version = "0.3.12"
+version = "0.3.11"
 
 [metadata]
 [metadata.release]

--- a/meta-buildpacks/nodejs-function/package.toml
+++ b/meta-buildpacks/nodejs-function/package.toml
@@ -2,10 +2,10 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@sha256:19a18c8829e7db59e9d2d7532758bd58fa17b86d6886608d14bc18d1baaf5717"
+uri = "docker://docker.io/heroku/buildpack-nodejs-engine@sha256:5578de3a6c79180abeefb024df8fe862da97b929e78b027428a9c2fd9fc02339"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha256:51c478e7398c4c17ae4e60486f8aa115992ae29d888ab7328a0b73d2c4bdbf45"
+uri = "docker://docker.io/heroku/buildpack-nodejs-npm@sha256:99d7bac02c7593dff5d79870ecd66fdaacea7118416aff2292e1fa13ccc8bc58"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-invoker-buildpack@sha256:25d0a28d1e9552e4726bc70959afef426892757f56ab1c7fb5641c420dfe3c44"
+uri = "docker://docker.io/heroku/buildpack-nodejs-function-invoker@sha256:2fca1217a5d4fc38d19e3f634a69e76214d05ce3fe9b672ef9d19c574ecda36c"

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -4,9 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Upgraded `heroku/nodejs-npm` to `0.5.4`
-* Upgraded `heroku/nodejs-yarn` to `0.4.4`
-* Upgraded `heroku/nodejs-engine` to `0.8.23`
+* Upgraded `heroku/nodejs-npm` to `0.5.3`
+* Upgraded `heroku/nodejs-yarn` to `0.4.3`
+* Upgraded `heroku/nodejs-engine` to `0.8.22`
 * Change release target from ECR to docker.io/heroku/buildpack-nodejs.
 
 ## [0.6.4] 2023/05/09

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -13,7 +13,7 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.23"
+version = "0.8.22"
 
 [[order.group]]
 id = "heroku/nodejs-corepack"
@@ -32,7 +32,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.23"
+version = "0.8.22"
 
 [[order.group]]
 id = "heroku/nodejs-corepack"
@@ -41,7 +41,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-yarn"
-version = "0.4.4"
+version = "0.4.3"
 
 [[order.group]]
 id = "heroku/procfile"
@@ -52,11 +52,11 @@ optional = true
 
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.8.23"
+version = "0.8.22"
 
 [[order.group]]
 id = "heroku/nodejs-npm"
-version = "0.5.4"
+version = "0.5.3"
 
 [[order.group]]
 id = "heroku/procfile"

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -2,16 +2,16 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@sha256:19a18c8829e7db59e9d2d7532758bd58fa17b86d6886608d14bc18d1baaf5717"
+uri = "docker://docker.io/heroku/buildpack-nodejs-engine@sha256:5578de3a6c79180abeefb024df8fe862da97b929e78b027428a9c2fd9fc02339"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha256:51c478e7398c4c17ae4e60486f8aa115992ae29d888ab7328a0b73d2c4bdbf45"
+uri = "docker://docker.io/heroku/buildpack-nodejs-npm@sha256:99d7bac02c7593dff5d79870ecd66fdaacea7118416aff2292e1fa13ccc8bc58"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/buildpack-nodejs-pnpm-install@sha256:12754c9155038ca92c12ed9e765158b8a6f873078c8f61215d133ff3038387f8"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:674d12371b7cd95e4d7e94eb70186cb27262875958ad55266b3605dd945e1d0c"
+uri = "docker://docker.io/heroku/buildpack-nodejs-yarn@sha256:34e87425fcd015f3ffe4f14af18a903825e6b9a825d0143d82687ad31d8a00a7"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/buildpack-nodejs-corepack@sha256:0ad3bd41ac2ce27ee7aeaa74051a2561ad885a6b8cb529d65ae3d0494e30a8a2"


### PR DESCRIPTION
Our release automation doesn't handle changes to buildpack registry hosts. Since we just changed to Docker Hub in #432, we can't publish new meta-buildpacks, since the meta-buildpacks point to incorrect urls and buildpack versions.

This PR nearly mirrors https://github.com/heroku/buildpacks-jvm/pull/491.