### PR TITLE
Post-release updates: heroku/nodejs@0.6.5, heroku/nodejs-function@0.10.5

### DIFF
--- a/meta-buildpacks/nodejs-function/CHANGELOG.md
+++ b/meta-buildpacks/nodejs-function/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.5] 2023/05/22
 * Upgraded `heroku/nodejs-npm` to `0.5.3`
 * Upgraded `heroku/nodejs-function-invoker` to `0.3.11`
 * Upgraded `heroku/nodejs-engine` to `0.8.22`

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.9"
 
 [buildpack]
 id = "heroku/nodejs-function"
-version = "0.10.5"
+version = "0.10.6"
 name = "Node.js Function"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
 

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5] 2023/05/22
 * Upgraded `heroku/nodejs-npm` to `0.5.3`
 * Upgraded `heroku/nodejs-yarn` to `0.4.3`
 * Upgraded `heroku/nodejs-engine` to `0.8.22`
@@ -15,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.3] 2023/04/20
 * Upgraded `heroku/nodejs-engine` to `0.8.20`
-
 * Add `pnpm` grouping for autodetection of `pnpm` apps ([#502](https://github.com/heroku/buildpacks-node/pull/502))
 
 ## [0.6.2] 2023/04/17

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.9"
 
 [buildpack]
 id = "heroku/nodejs"
-version = "0.6.5"
+version = "0.6.6"
 name = "Node.js"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
 


### PR DESCRIPTION
The last meta-buildpack release actions (https://github.com/heroku/buildpacks-nodejs/actions/runs/5049524949 and https://github.com/heroku/buildpacks-nodejs/actions/runs/5049523935) timed out due to instance queuing delays on the CNB side. The CNB releases eventually went out, but the rest of our release automation failed. This PR finishes up that process for `heroku/nodejs` and `heroku/nodejs-function`.