### PR TITLE
Drop heroku-20 support for Node.js Salesforce Functions

### DIFF
--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop support for the heroku-20 stack. ([#536](https://github.com/heroku/buildpacks-nodejs/pull/536))
+
 ## [0.3.11] 2023/05/22
 
 - Change release target from ECR to docker.io/heroku/buildpack-nodejs-function-invoker.

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -11,9 +11,6 @@ keywords = ["nodejs", "node", "node.js", "javascript", "js", "function"]
 type = "MIT"
 
 [[stacks]]
-id = "heroku-20"
-
-[[stacks]]
 id = "heroku-22"
 
 [metadata]

--- a/buildpacks/nodejs-function-invoker/tests/integration_test.rs
+++ b/buildpacks/nodejs-function-invoker/tests/integration_test.rs
@@ -2,9 +2,7 @@
 
 use libcnb_test::{assert_contains, assert_not_contains};
 use test_support::Builder::Heroku22;
-use test_support::{
-    assert_health_check_responds, get_function_invoker_build_config, test_node_function,
-};
+use test_support::{assert_health_check_responds, test_node_function};
 
 #[test]
 #[ignore]

--- a/buildpacks/nodejs-function-invoker/tests/integration_test.rs
+++ b/buildpacks/nodejs-function-invoker/tests/integration_test.rs
@@ -1,31 +1,15 @@
 #![warn(clippy::pedantic)]
 
 use libcnb_test::{assert_contains, assert_not_contains};
-use test_support::Builder::{Heroku20, Heroku22};
+use test_support::Builder::Heroku22;
 use test_support::{
     assert_health_check_responds, get_function_invoker_build_config, test_node_function,
 };
 
 #[test]
 #[ignore]
-fn simple_javascript_function_heroku_20() {
-    test_node_function("simple-function", Heroku20, |ctx| {
-        assert_health_check_responds(&ctx);
-    });
-}
-
-#[test]
-#[ignore]
 fn simple_javascript_function_heroku_22() {
     test_node_function("simple-function", Heroku22, |ctx| {
-        assert_health_check_responds(&ctx);
-    });
-}
-
-#[test]
-#[ignore]
-fn simple_typescript_function_heroku_20() {
-    test_node_function("simple-typescript-function", Heroku20, |ctx| {
         assert_health_check_responds(&ctx);
     });
 }
@@ -40,66 +24,10 @@ fn simple_typescript_function_heroku_22() {
 
 #[test]
 #[ignore]
-fn upgrade_simple_nodejs_function_from_heroku20_to_heroku22() {
-    test_node_function("simple-function", Heroku20, |ctx| {
-        assert_contains!(
-            ctx.pack_stdout,
-            "Installing Node.js Function Invoker Runtime"
-        );
-        assert_health_check_responds(&ctx);
-        ctx.rebuild(
-            get_function_invoker_build_config("simple-function", Heroku22),
-            |new_ctx| {
-                assert_contains!(
-                    new_ctx.pack_stdout,
-                    "Installing Node.js Function Invoker Runtime"
-                );
-                assert_health_check_responds(&new_ctx);
-            },
-        );
-    });
-}
-
-#[test]
-#[ignore]
-fn test_function_with_explicit_runtime_dependency_js_heroku_20() {
-    test_node_function(
-        "functions/with-explicit-runtime-dependency-js",
-        Heroku20,
-        |ctx| {
-            assert_contains!(
-                ctx.pack_stdout,
-                "Node.js function runtime declared in package.json"
-            );
-            assert_not_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
-            assert_health_check_responds(&ctx);
-        },
-    );
-}
-
-#[test]
-#[ignore]
 fn test_function_with_explicit_runtime_dependency_js_heroku_22() {
     test_node_function(
         "functions/with-explicit-runtime-dependency-js",
         Heroku22,
-        |ctx| {
-            assert_contains!(
-                ctx.pack_stdout,
-                "Node.js function runtime declared in package.json"
-            );
-            assert_not_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
-            assert_health_check_responds(&ctx);
-        },
-    );
-}
-
-#[test]
-#[ignore]
-fn test_function_with_explicit_runtime_dependency_ts_heroku_20() {
-    test_node_function(
-        "functions/with-explicit-runtime-dependency-ts",
-        Heroku20,
         |ctx| {
             assert_contains!(
                 ctx.pack_stdout,
@@ -130,44 +58,10 @@ fn test_function_with_explicit_runtime_dependency_ts_heroku_22() {
 
 #[test]
 #[ignore]
-fn test_function_with_implicit_runtime_dependency_js_heroku_20() {
-    test_node_function(
-        "functions/with-implicit-runtime-dependency-js",
-        Heroku20,
-        |ctx| {
-            assert_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
-            assert_not_contains!(
-                ctx.pack_stdout,
-                "Node.js function runtime declared in package.json"
-            );
-            assert_health_check_responds(&ctx);
-        },
-    );
-}
-
-#[test]
-#[ignore]
 fn test_function_with_implicit_runtime_dependency_js_heroku_22() {
     test_node_function(
         "functions/with-implicit-runtime-dependency-js",
         Heroku22,
-        |ctx| {
-            assert_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
-            assert_not_contains!(
-                ctx.pack_stdout,
-                "Node.js function runtime declared in package.json"
-            );
-            assert_health_check_responds(&ctx);
-        },
-    );
-}
-
-#[test]
-#[ignore]
-fn test_function_with_implicit_runtime_dependency_ts_heroku_20() {
-    test_node_function(
-        "functions/with-implicit-runtime-dependency-ts",
-        Heroku20,
         |ctx| {
             assert_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
             assert_not_contains!(

--- a/test/specs/node-function/cutlass/function_spec.rb
+++ b/test/specs/node-function/cutlass/function_spec.rb
@@ -3,45 +3,43 @@
 require_relative "../spec_helper"
 
 describe "Heroku's Nodejs CNB" do
-  ["heroku/buildpacks:20", "heroku/builder:22"].each do |builder|
-    describe "with #{builder}" do
-      it "generates a callable salesforce function" do
-        Cutlass::App.new("simple-function", builder: builder).transaction do |app|
-          app.pack_build do |pack_result|
-            expect(pack_result.stdout).to include("Installing Node.js Function Invoker")
-          end
+  let(:builder) { "heroku/builder:22" }
 
-          app.start_container(expose_ports: 8080, memory: 1e9) do |container|
-            body = { }
-            query = Cutlass::FunctionQuery.new(
-              port: container.get_host_port(8080),
-              body: body
-            ).call
-
-            expect(query.as_json).to eq("hello world")
-            expect(query.success?).to be_truthy
-
-            expect(container.logs.stdout).to include("logging info is a fun 1")
-          end
-        end
+  it "generates a callable salesforce function" do
+    Cutlass::App.new("simple-function", builder: builder).transaction do |app|
+      app.pack_build do |pack_result|
+        expect(pack_result.stdout).to include("Installing Node.js Function Invoker")
       end
 
-      it "generates a callable salesforce function from typescript" do
-        Cutlass::App.new("simple-typescript-function", builder: builder).transaction do |app|
-          app.pack_build do |pack_result|
-            expect(pack_result.stdout).to include("Installing Node.js Function Invoker")
-          end
+      app.start_container(expose_ports: 8080, memory: 1e9) do |container|
+        body = { }
+        query = Cutlass::FunctionQuery.new(
+          port: container.get_host_port(8080),
+          body: body
+        ).call
 
-          app.start_container(expose_ports: 8080, memory: 1e9) do |container|
-            body = { }
-            query = Cutlass::FunctionQuery.new(
-              port: container.get_host_port(8080),
-              body: body
-            ).call
+        expect(query.as_json).to eq("hello world")
+        expect(query.success?).to be_truthy
 
-            expect(query.as_json).to eq("hello world from typescript")
-            expect(query.success?).to be_truthy
-          end
+        expect(container.logs.stdout).to include("logging info is a fun 1")
+      end
+    end
+
+    it "generates a callable salesforce function from typescript" do
+      Cutlass::App.new("simple-typescript-function", builder: builder).transaction do |app|
+        app.pack_build do |pack_result|
+          expect(pack_result.stdout).to include("Installing Node.js Function Invoker")
+        end
+
+        app.start_container(expose_ports: 8080, memory: 1e9) do |container|
+          body = { }
+          query = Cutlass::FunctionQuery.new(
+            port: container.get_host_port(8080),
+            body: body
+          ).call
+
+          expect(query.as_json).to eq("hello world from typescript")
+          expect(query.success?).to be_truthy
         end
       end
     end

--- a/test/specs/node-function/cutlass/function_spec.rb
+++ b/test/specs/node-function/cutlass/function_spec.rb
@@ -24,23 +24,23 @@ describe "Heroku's Nodejs CNB" do
         expect(container.logs.stdout).to include("logging info is a fun 1")
       end
     end
+  end
 
-    it "generates a callable salesforce function from typescript" do
-      Cutlass::App.new("simple-typescript-function", builder: builder).transaction do |app|
-        app.pack_build do |pack_result|
-          expect(pack_result.stdout).to include("Installing Node.js Function Invoker")
-        end
+  it "generates a callable salesforce function from typescript" do
+    Cutlass::App.new("simple-typescript-function", builder: builder).transaction do |app|
+      app.pack_build do |pack_result|
+        expect(pack_result.stdout).to include("Installing Node.js Function Invoker")
+      end
 
-        app.start_container(expose_ports: 8080, memory: 1e9) do |container|
-          body = { }
-          query = Cutlass::FunctionQuery.new(
-            port: container.get_host_port(8080),
-            body: body
-          ).call
+      app.start_container(expose_ports: 8080, memory: 1e9) do |container|
+        body = { }
+        query = Cutlass::FunctionQuery.new(
+          port: container.get_host_port(8080),
+          body: body
+        ).call
 
-          expect(query.as_json).to eq("hello world from typescript")
-          expect(query.success?).to be_truthy
-        end
+        expect(query.as_json).to eq("hello world from typescript")
+        expect(query.success?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Building Salesforce Functions on the heroku-20 stack has been disabled in the following ways:

- All Salesforce Function builds happen on `heroku-22` only since last September: https://developer.salesforce.com/docs/platform/functions/guide/release-notes-intro.html#september-28-2022
- Function buildpacks were pulled from the `heroku/buildpacks:20` builder a few weeks ago: https://github.com/heroku/builder/pull/338

Therefore, it doesn't make sense to support `heroku-20` for the `heroku/nodejs-function` and `heroku/nodejs-function-invoker` buildpacks going forward. 

Node.js Salesforce Functions on `heroku-22` remain supported and otherwise unchanged.