### PR TITLE
Update active yarn versions to include Yarn 4 release candidates

### DIFF
--- a/common/nodejs-utils/src/distribution.rs
+++ b/common/nodejs-utils/src/distribution.rs
@@ -87,10 +87,12 @@ impl Distribution {
             Self::Yarn => "yarn",
         }
     }
+
+    /// The range of versions considered active for mirroring purposes.
     fn active_requirement(self) -> anyhow::Result<Requirement> {
         Requirement::parse(match self {
-            Self::Node => ">= 16",
-            Self::Yarn => ">= 1.22",
+            Self::Node => ">=16",
+            Self::Yarn => ">=1.22 >=4.0.0-rc.35",
         })
         .map_err(|e| anyhow!("{e}"))
     }


### PR DESCRIPTION
The new mirroring logic introduced in #524 is not mirroring the Yarn 4+ release candidates. This is due to a particularity in node-semver's resolution mechanics, explained here: https://github.com/npm/node-semver#prerelease-tags.

Basically, to have a prerelease satisfy a requirement, the requirement needs to specify that exact major, minor, patch and prerelease tag.

This PR expands what we view as mirrorable to include Yarn 4 release candidates. These release candidates are already in the inventory (see them [here](https://github.com/heroku/buildpacks-nodejs/blob/2730256fadf2c94dae6813dfc672065da9b406ce/buildpacks/nodejs-yarn/inventory.toml#L861C13-L877)), so we should continue to mirror them.