### PR TITLE
Fix yarn active version calculation

### DIFF
--- a/common/nodejs-utils/src/distribution.rs
+++ b/common/nodejs-utils/src/distribution.rs
@@ -185,18 +185,39 @@ mod tests {
     }
 
     #[test]
-    fn filter_active_yarn() {
+    fn filter_inactive_yarn() {
         let versions = ["1.20.1", "1.22.19", "3.0.0-rc.1", "3.2.3", "4.0.0-rc.44"]
             .into_iter()
             .map(Version::parse)
             .collect::<Result<VersionSet, _>>()
             .expect("Expected to parse all valid versions");
 
-        let filtered: VersionSet = Distribution::Yarn {}
+        let filtered = Distribution::Yarn {}
             .filter_inactive_versions(versions.iter())
             .expect("Expected to filter versions without an error");
 
-        let expected: VersionSet = ["1.22.19", "3.2.3", "4.0.0-rc.44"]
+        let expected = ["1.22.19", "3.2.3", "4.0.0-rc.44"]
+            .into_iter()
+            .map(Version::parse)
+            .collect::<Result<VersionSet, _>>()
+            .expect("Expected to parse all valid versions");
+
+        assert_eq!(expected, filtered);
+    }
+
+    #[test]
+    fn filter_inactive_node() {
+        let versions = ["0.10.1", "14.2.4", "18.3.0", "20.2.0"]
+            .into_iter()
+            .map(Version::parse)
+            .collect::<Result<VersionSet, _>>()
+            .expect("Expected to parse all valid versions");
+
+        let filtered = Distribution::Node {}
+            .filter_inactive_versions(versions.iter())
+            .expect("Expected to filter versions without an error");
+
+        let expected = ["18.3.0", "20.2.0"]
             .into_iter()
             .map(Version::parse)
             .collect::<Result<VersionSet, _>>()

--- a/common/nodejs-utils/src/distribution.rs
+++ b/common/nodejs-utils/src/distribution.rs
@@ -129,6 +129,7 @@ fn list_upstream_yarn_versions() -> anyhow::Result<VersionSet> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vrs::VersionError;
 
     #[test]
     fn upstream_versions_node() {
@@ -181,5 +182,34 @@ mod tests {
             .get(&expected_version)
             .expect("Expected to find a matching version");
         assert_eq!(&expected_version, actual_version);
+    }
+
+    #[test]
+    fn filter_active_yarn() {
+        let versions = [
+            "0.20.2",
+            "1.20.1",
+            "1.22.19",
+            "2.0.0",
+            "3.2.3",
+            "4.0.0",
+            "4.0.0-rc.44",
+        ]
+        .into_iter()
+        .map(Version::parse)
+        .collect::<Result<Vec<Version>, VersionError>>()
+        .expect("Expected to parse all valid versions");
+
+        let filtered: Vec<String> = Distribution::Yarn {}
+            .filter_inactive_versions(versions.iter())
+            .expect("Expected to filter versions without an error")
+            .iter()
+            .map(Version::to_string)
+            .collect();
+        let expected: Vec<String> = ["1.22.19", "2.0.0", "3.2.3", "4.0.0", "4.0.0-rc.44"]
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        assert_eq!(expected, filtered);
     }
 }

--- a/common/nodejs-utils/src/distribution.rs
+++ b/common/nodejs-utils/src/distribution.rs
@@ -92,7 +92,7 @@ impl Distribution {
     fn active_requirement(self) -> anyhow::Result<Requirement> {
         Requirement::parse(match self {
             Self::Node => ">=16",
-            Self::Yarn => ">=1.22 >=4.0.0-rc.35",
+            Self::Yarn => ">=1.22 || >=4.0.0-rc.35",
         })
         .map_err(|e| anyhow!("{e}"))
     }
@@ -186,30 +186,22 @@ mod tests {
 
     #[test]
     fn filter_active_yarn() {
-        let versions = [
-            "0.20.2",
-            "1.20.1",
-            "1.22.19",
-            "2.0.0",
-            "3.2.3",
-            "4.0.0",
-            "4.0.0-rc.44",
-        ]
-        .into_iter()
-        .map(Version::parse)
-        .collect::<Result<Vec<Version>, VersionError>>()
-        .expect("Expected to parse all valid versions");
+        let versions = ["1.20.1", "1.22.19", "3.0.0-rc.1", "3.2.3", "4.0.0-rc.44"]
+            .into_iter()
+            .map(Version::parse)
+            .collect::<Result<VersionSet, _>>()
+            .expect("Expected to parse all valid versions");
 
-        let filtered: Vec<String> = Distribution::Yarn {}
+        let filtered: VersionSet = Distribution::Yarn {}
             .filter_inactive_versions(versions.iter())
-            .expect("Expected to filter versions without an error")
-            .iter()
-            .map(Version::to_string)
-            .collect();
-        let expected: Vec<String> = ["1.22.19", "2.0.0", "3.2.3", "4.0.0", "4.0.0-rc.44"]
-            .iter()
-            .map(std::string::ToString::to_string)
-            .collect();
+            .expect("Expected to filter versions without an error");
+
+        let expected: VersionSet = ["1.22.19", "3.2.3", "4.0.0-rc.44"]
+            .into_iter()
+            .map(Version::parse)
+            .collect::<Result<VersionSet, _>>()
+            .expect("Expected to parse all valid versions");
+
         assert_eq!(expected, filtered);
     }
 }

--- a/common/nodejs-utils/src/distribution.rs
+++ b/common/nodejs-utils/src/distribution.rs
@@ -129,7 +129,6 @@ fn list_upstream_yarn_versions() -> anyhow::Result<VersionSet> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vrs::VersionError;
 
     #[test]
     fn upstream_versions_node() {


### PR DESCRIPTION
In #537, I adjusted the version requirement for active versions of yarn. But, the semver parser handled the invalid `>= 1.22 >=4.0.0-rc.40` syntax by disregarding the first half, and using only `>=4.0.0-rc.40` half. So the mirroring logic was missing yarn versions less than 4 for a brief time. The problem was a missing `||` operator. I've also added some tests to make sure it's working correctly.