### PR TITLE
Drop the extra dash in the inventory changelog

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Rebuild Inventory
         run: "cargo run --bin generate_inventory node > buildpacks/nodejs-engine/inventory.toml"
       - name: Update Changelog
-        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' buildpacks/nodejs-engine/CHANGELOG.md
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n{}/' buildpacks/nodejs-engine/CHANGELOG.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Rebuild Inventory
         run: "cargo run --bin generate_inventory yarn > buildpacks/nodejs-yarn/inventory.toml"
       - name: Update Changelog
-        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' buildpacks/nodejs-yarn/CHANGELOG.md
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n{}/' buildpacks/nodejs-yarn/CHANGELOG.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
In #550, there is an extra dash in the changelog. This will fix the automation so there will only be one dash on the next inventory update.