### PR TITLE
Buildpack API 0.9 + libcnb.rs updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,9 +760,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libcnb"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4fd7573558173267930e31446da65a0275770bde88847cad4b4cf9a6ff8375"
+checksum = "027cd4a736600564c4e7aebf124eabb9d7dc622bcfeefb414cc7c4c7d7ac6595"
 dependencies = [
  "libcnb-data",
  "libcnb-proc-macros",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-data"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0112478d479c8900929894426818bea8e769ce923536a58baac719d3ca4dcb"
+checksum = "6e8840246c7aced3307fa193edc5d26482f92f992986a33860b6b3b523a67975"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacd18d358a1078cf48f518ef8398c504f8d4fc691ba2e8773bafa1a71d66b59"
+checksum = "27205236a28660f7395598a3f65afb9315de8ce3054c39375b0be673fa6288e7"
 dependencies = [
  "cargo_metadata",
  "libcnb-data",
@@ -798,21 +798,21 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5930cea22615255081c0c44b902e6e8b37a824ebe1374a7c7d52724d5b7d6e4e"
+checksum = "c9e31cc93a20d00f1d54ecb55dcff681669871e6d8a8b63ac0320e77fca1987c"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "libcnb-test"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86e8c1847c8ba3c37e30841ee241887203110f4373731e7967706ab77c42b7d"
+checksum = "ff3f26e5f4ad90ea4036618dcba858c567f8c46a281daa72856eab3be0972885"
 dependencies = [
  "bollard",
  "cargo_metadata",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878674906e0140191f89047ef1e8c142cb31becce91b4e64b1b6419fe03da7c1"
+checksum = "4ee2764ebf688454c4fcbcd7c52ff277b5cb2e196c502ff4ce92de563cb10ea2"
 dependencies = [
  "crossbeam-utils",
  "flate2",

--- a/buildpacks/nodejs-corepack/CHANGELOG.md
+++ b/buildpacks/nodejs-corepack/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade to Buildpack API version `0.9`. ([#552](https://github.com/heroku/buildpacks-nodejs/pull/552))
 - Drop explicit support for the End-of-Life stack `heroku-18`.
 
 ## [0.1.2] 2023/04/11

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -8,13 +8,13 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }
-libcnb = "0.11"
-libherokubuildpack = "0.11"
+libcnb = "0.12"
+libherokubuildpack = "0.12"
 serde = "1.0.163"
 thiserror = "1.0"
 indoc = "2.0"
 
 [dev-dependencies]
-libcnb-test = "0.11"
+libcnb-test = "0.12"
 test_support = { path = "../../test_support" }
 ureq = "2.6.2"

--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/nodejs-corepack"

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade to Buildpack API version `0.9`. ([#552](https://github.com/heroku/buildpacks-nodejs/pull/552))
+
 ## [0.8.22] 2023/05/22
 
 - Change release target from ECR to docker.io/heroku/buildpack-nodejs-engine.

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -8,13 +8,13 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }
-libcnb = "0.11"
-libherokubuildpack = "0.11"
+libcnb = "0.12"
+libherokubuildpack = "0.12"
 serde = "1.0.163"
 tempfile = "3.4.0"
 toml = "0.7"
 thiserror = "1.0"
 
 [dev-dependencies]
-libcnb-test = "0.11"
+libcnb-test = "0.12"
 ureq = "2.6.2"

--- a/buildpacks/nodejs-engine/buildpack.toml
+++ b/buildpacks/nodejs-engine/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/nodejs-engine"

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -106,10 +106,12 @@ impl Buildpack for NodeJsEngineBuildpack {
             .map(|path| {
                 LaunchBuilder::new()
                     .process(
-                        ProcessBuilder::new(process_type!("web"), "node")
-                            .args(vec![path.to_string_lossy()])
-                            .default(true)
-                            .build(),
+                        ProcessBuilder::new(
+                            process_type!("web"),
+                            ["node", &path.to_string_lossy()],
+                        )
+                        .default(true)
+                        .build(),
                     )
                     .build()
             });

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade to Buildpack API version `0.9`. ([#552](https://github.com/heroku/buildpacks-nodejs/pull/552))
 - Drop support for the heroku-20 stack. ([#536](https://github.com/heroku/buildpacks-nodejs/pull/536))
 
 ## [0.3.11] 2023/05/22

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -8,14 +8,14 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }
-libcnb = "0.11"
-libherokubuildpack = "0.11"
+libcnb = "0.12"
+libherokubuildpack = "0.12"
 serde = "1"
 thiserror = "1"
 toml = "0.7"
 
 [dev-dependencies]
-libcnb-test = "0.11"
+libcnb-test = "0.12"
 serde_json = "1"
 tempfile = "3"
 test_support = { path = "../../test_support" }

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/nodejs-function-invoker"

--- a/buildpacks/nodejs-function-invoker/opt/nodejs-runtime.sh
+++ b/buildpacks/nodejs-function-invoker/opt/nodejs-runtime.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 runtime_bin=$1
 function_dir=$2
 
-exec $runtime_bin serve $function_dir --workers 2 --host "::" --port "${PORT:-8080}" --debug-port "${DEBUG_PORT:-}"
+exec $runtime_bin serve "$function_dir" --workers 2 --host "::" --port "${PORT:-8080}" --debug-port "${DEBUG_PORT:-}"

--- a/buildpacks/nodejs-function-invoker/opt/nodejs-runtime.sh
+++ b/buildpacks/nodejs-function-invoker/opt/nodejs-runtime.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+runtime_bin=$1
+function_dir=$2
+
+exec $runtime_bin serve $function_dir --workers 2 --host "::" --port "${PORT:-8080}" --debug-port "${DEBUG_PORT:-}"

--- a/buildpacks/nodejs-function-invoker/src/layers/mod.rs
+++ b/buildpacks/nodejs-function-invoker/src/layers/mod.rs
@@ -1,3 +1,5 @@
 mod runtime;
+mod script;
 
-pub use runtime::*;
+pub(crate) use runtime::*;
+pub(crate) use script::*;

--- a/buildpacks/nodejs-function-invoker/src/layers/script.rs
+++ b/buildpacks/nodejs-function-invoker/src/layers/script.rs
@@ -1,0 +1,55 @@
+use crate::NodeJsInvokerBuildpack;
+use crate::NodeJsInvokerBuildpackError;
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::generic::GenericMetadata;
+use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub(crate) const NODEJS_RUNTIME_SCRIPT: &str = "nodejs-runtime.sh";
+
+/// A layer that installs a bash script used for passing environment variables
+/// on to sf-fx-runtime-nodejs as arguments.
+pub(crate) struct ScriptLayer;
+
+impl Layer for ScriptLayer {
+    type Buildpack = NodeJsInvokerBuildpack;
+    type Metadata = GenericMetadata;
+
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            launch: true,
+            build: false,
+            cache: false,
+        }
+    }
+
+    fn create(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, NodeJsInvokerBuildpackError> {
+        let layer_bin_dir = layer_path.join("bin");
+        let destination = layer_bin_dir.join(NODEJS_RUNTIME_SCRIPT);
+
+        fs::create_dir_all(&layer_bin_dir).map_err(ScriptLayerError::CouldNotWriteRuntimeScript)?;
+
+        fs::write(&destination, include_bytes!("../../opt/nodejs-runtime.sh"))
+            .map_err(ScriptLayerError::CouldNotWriteRuntimeScript)?;
+
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755))
+            .map_err(ScriptLayerError::CouldNotSetExecutableBitForRuntimeScript)?;
+
+        LayerResultBuilder::new(GenericMetadata::default()).build()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ScriptLayerError {
+    #[error("Could not write runtime script to layer: {0}")]
+    CouldNotWriteRuntimeScript(std::io::Error),
+    #[error("Could not set executable bit on runtime script: {0}")]
+    CouldNotSetExecutableBitForRuntimeScript(std::io::Error),
+}

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -112,9 +112,6 @@ impl Buildpack for NodeJsInvokerBuildpack {
                         ProcessBuilder::new(
                             process_type!("web"),
                             [
-                                "bash",
-                                "-c",
-                                &format!("{NODEJS_RUNTIME_SCRIPT} $1 $2"),
                                 NODEJS_RUNTIME_SCRIPT,
                                 command,
                                 &context.app_dir.to_string_lossy(),

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -105,22 +105,22 @@ impl Buildpack for NodeJsInvokerBuildpack {
             .launch(
                 LaunchBuilder::new()
                     .process(
-                        ProcessBuilder::new(process_type!("web"), command)
-                            .args(vec![
-                                "serve",
-                                &context.app_dir.to_string_lossy(),
-                                "--workers",
-                                "2",
-                                "--host",
-                                "::",
-                                "--port",
-                                "${PORT:-8080}",
-                                "--debug-port",
-                                "${DEBUG_PORT:-}",
-                            ])
-                            .default(true)
-                            .direct(false)
-                            .build(),
+                        ProcessBuilder::new(
+                            process_type!("web"),
+                            [command, serve, &context.app_dir.to_string_lossy()],
+                        )
+                        .args(vec![
+                            "--workers",
+                            "2",
+                            "--host",
+                            "::",
+                            "--port",
+                            "${PORT:-8080}",
+                            "--debug-port",
+                            "${DEBUG_PORT:-}",
+                        ])
+                        .default(true)
+                        .build(),
                     )
                     .build(),
             )

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -7,7 +7,9 @@ use crate::function::{
     get_declared_runtime_package_version, get_main, is_function, ExplicitRuntimeDependencyError,
     MainError,
 };
-use crate::layers::{RuntimeLayer, RuntimeLayerError};
+use crate::layers::{
+    RuntimeLayer, RuntimeLayerError, ScriptLayer, ScriptLayerError, NODEJS_RUNTIME_SCRIPT,
+};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::build_plan::BuildPlanBuilder;
 use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
@@ -70,11 +72,11 @@ impl Buildpack for NodeJsInvokerBuildpack {
         let package_version = &metadata_runtime.package_version;
 
         log_info("Checking for function file");
-        get_main(app_dir).map_err(NodeJsInvokerBuildpackError::MainFunctionError)?;
+        get_main(app_dir).map_err(NodeJsInvokerBuildpackError::MainFunction)?;
 
         let declared_runtime_package_version =
             get_declared_runtime_package_version(app_dir, package_name)
-                .map_err(NodeJsInvokerBuildpackError::ExplicitRuntimeDependencyFunctionError)?;
+                .map_err(NodeJsInvokerBuildpackError::ExplicitRuntimeDependencyFunction)?;
 
         if let Some(package_version) = declared_runtime_package_version.clone() {
             log_info(format!(
@@ -101,24 +103,23 @@ impl Buildpack for NodeJsInvokerBuildpack {
             None => "sf-fx-runtime-nodejs",                      // global (implicit)
         };
 
+        context.handle_layer(layer_name!("script"), ScriptLayer {})?;
+
         BuildResultBuilder::new()
             .launch(
                 LaunchBuilder::new()
                     .process(
                         ProcessBuilder::new(
                             process_type!("web"),
-                            [command, "serve", &context.app_dir.to_string_lossy()],
+                            [
+                                "bash",
+                                "-c",
+                                &format!("{NODEJS_RUNTIME_SCRIPT} $1 $2"),
+                                NODEJS_RUNTIME_SCRIPT,
+                                command,
+                                &context.app_dir.to_string_lossy(),
+                            ],
                         )
-                        .args(vec![
-                            "--workers",
-                            "2",
-                            "--host",
-                            "::",
-                            "--port",
-                            "${PORT:-8080}",
-                            "--debug-port",
-                            "${DEBUG_PORT:-}",
-                        ])
                         .default(true)
                         .build(),
                     )
@@ -132,16 +133,19 @@ impl Buildpack for NodeJsInvokerBuildpack {
             |bp_err| {
                 let err_string = bp_err.to_string();
                 match bp_err {
-                    NodeJsInvokerBuildpackError::MainFunctionError(_) => {
+                    NodeJsInvokerBuildpackError::MainFunction(_) => {
                         log_error(
                             "Node.js Function Invoker main function detection error",
                             err_string,
                         );
                     }
-                    NodeJsInvokerBuildpackError::RuntimeLayerError(_) => {
+                    NodeJsInvokerBuildpackError::RuntimeLayer(_) => {
                         log_error("Node.js Function Invoker runtime layer error", err_string);
                     }
-                    NodeJsInvokerBuildpackError::ExplicitRuntimeDependencyFunctionError(_) => {
+                    NodeJsInvokerBuildpackError::ScriptLayer(_) => {
+                        log_error("Node.js Function Invoker script layer error", err_string);
+                    }
+                    NodeJsInvokerBuildpackError::ExplicitRuntimeDependencyFunction(_) => {
                         log_error(
                             "Node.js Function Invoker explicit Node.js function runtime dependency error",
                             err_string,
@@ -157,11 +161,13 @@ impl Buildpack for NodeJsInvokerBuildpack {
 #[derive(Error, Debug)]
 pub enum NodeJsInvokerBuildpackError {
     #[error("{0}")]
-    MainFunctionError(#[from] MainError),
+    MainFunction(#[from] MainError),
     #[error("{0}")]
-    RuntimeLayerError(#[from] RuntimeLayerError),
+    RuntimeLayer(#[from] RuntimeLayerError),
     #[error("{0}")]
-    ExplicitRuntimeDependencyFunctionError(#[from] ExplicitRuntimeDependencyError),
+    ScriptLayer(#[from] ScriptLayerError),
+    #[error("{0}")]
+    ExplicitRuntimeDependencyFunction(#[from] ExplicitRuntimeDependencyError),
 }
 
 impl From<NodeJsInvokerBuildpackError> for libcnb::Error<NodeJsInvokerBuildpackError> {

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -107,7 +107,7 @@ impl Buildpack for NodeJsInvokerBuildpack {
                     .process(
                         ProcessBuilder::new(
                             process_type!("web"),
-                            [command, serve, &context.app_dir.to_string_lossy()],
+                            [command, "serve", &context.app_dir.to_string_lossy()],
                         )
                         .args(vec![
                             "--workers",

--- a/buildpacks/nodejs-pnpm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-install/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade to Buildpack API version `0.9`. ([#552](https://github.com/heroku/buildpacks-nodejs/pull/552))
 - Drop explicit support for the End-of-Life stack `heroku-18`.
 
 ## [0.1.0] 2023/04/17

--- a/buildpacks/nodejs-pnpm-install/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-install/Cargo.toml
@@ -8,13 +8,13 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }
-libcnb = "0.11"
-libherokubuildpack = "0.11"
+libcnb = "0.12"
+libherokubuildpack = "0.12"
 serde = "1"
 indoc = "2.0"
 toml = "0.7"
 
 [dev-dependencies]
-libcnb-test = "0.11"
+libcnb-test = "0.12"
 test_support = { path = "../../test_support" }
 ureq = "2"

--- a/buildpacks/nodejs-pnpm-install/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-install/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/nodejs-pnpm-install"

--- a/buildpacks/nodejs-pnpm-install/src/main.rs
+++ b/buildpacks/nodejs-pnpm-install/src/main.rs
@@ -95,8 +95,7 @@ impl Buildpack for PnpmInstallBuildpack {
                 .launch(
                     LaunchBuilder::new()
                         .process(
-                            ProcessBuilder::new(process_type!("web"), "pnpm")
-                                .arg("start")
+                            ProcessBuilder::new(process_type!("web"), ["pnpm", "start"])
                                 .default(true)
                                 .build(),
                         )

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade to Buildpack API version `0.9`. ([#552](https://github.com/heroku/buildpacks-nodejs/pull/552))
+
 ## [0.4.3] 2023/05/22
 
 - Change release target from ECR to docker.io/heroku/buildpack-nodejs-yarn.

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -8,14 +8,14 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils = { path = "../../common/nodejs-utils" }
-libcnb = "0.11"
-libherokubuildpack = "0.11"
+libcnb = "0.12"
+libherokubuildpack = "0.12"
 serde = "1"
 tempfile = "3"
 thiserror = "1.0"
 toml = "0.7"
 
 [dev-dependencies]
-libcnb-test = "0.11"
+libcnb-test = "0.12"
 test_support = { path = "../../test_support" }
 ureq = "2"

--- a/buildpacks/nodejs-yarn/buildpack.toml
+++ b/buildpacks/nodejs-yarn/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/nodejs-yarn"

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -152,8 +152,7 @@ impl Buildpack for YarnBuildpack {
                 .launch(
                     LaunchBuilder::new()
                         .process(
-                            ProcessBuilder::new(process_type!("web"), "yarn")
-                                .arg("start")
+                            ProcessBuilder::new(process_type!("web"), ["yarn", "start"])
                                 .default(true)
                                 .build(),
                         )

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -7,6 +7,6 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-libcnb-test = "0.11"
+libcnb-test = "0.12"
 tempfile = "3"
 ureq = "2"


### PR DESCRIPTION
This updates all libcnb.rs buildpacks to Buildpack API 0.9, and brings libcnb.rs up to date for each.

The changes to `ProcessBuilder` shown here are explained upstream: https://github.com/heroku/libcnb.rs/releases/tag/v0.12.0

The new `direct = true` default was incompatible with the heroku/nodejs-function-invoker buildpack. It was using bash-interpolated arguments (notably `${PORT:-8080}`), so doesn't work in `direct = true` mode. I added a layer with a bash script to do that work. It nearly mirrors what the JVM equivalent does here: https://github.com/heroku/buildpacks-jvm/blob/main/buildpacks/jvm-function-invoker/src/layers/opt.rs.