### PR TITLE
Revert "Create automated PR with token (#556)"

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -23,26 +23,14 @@ jobs:
         run: "cargo run --bin generate_inventory node > buildpacks/nodejs-engine/inventory.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n{}/' buildpacks/nodejs-engine/CHANGELOG.md
-      - uses: heroku/use-app-token-action@main
-        id: generate-token
-        with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       - name: Create Pull Request
-        id: pr
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
           title: "Update Node.js Engine Inventory"
           commit-message: "Update Inventory for heroku/nodejs-engine\n\n${{ steps.set-diff-msg.outputs.msg }}"
           branch: update-nodejs-inventory
           labels: "automation"
           body: "Automated pull-request to update heroku/nodejs-engine inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
-      - name: Configure PR
-        if: steps.pr.outputs.pull-request-operation == 'created'
-        run: gh pr merge --auto "${{ steps.pr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
   update-yarn-inventory:
     name: Update Node.js Yarn Inventory
     runs-on: pub-hk-ubuntu-22.04-small
@@ -61,23 +49,11 @@ jobs:
         run: "cargo run --bin generate_inventory yarn > buildpacks/nodejs-yarn/inventory.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n{}/' buildpacks/nodejs-yarn/CHANGELOG.md
-      - uses: heroku/use-app-token-action@main
-        id: generate-token
-        with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}   
       - name: Create Pull Request
-        id: pr
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
           title: "Update Node.js Yarn Inventory"
           commit-message: "Update Inventory for heroku/nodejs-yarn\n\n${{ steps.set-diff-msg.outputs.msg }}"
           branch: update-yarn-inventory
           labels: "automation"
           body: "Automated pull-request to update heroku/nodejs-yarn inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
-      - name: Configure PR
-        if: steps.pr.outputs.pull-request-operation == 'created'
-        run: gh pr merge --auto "${{ steps.pr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}


### PR DESCRIPTION
This reverts commit 6728b1662193f2a114a3b7b274a8425d2c31f67d. The change in #556 didn't work, since https://github.com/heroku/use-app-token-action is private. Failed run: https://github.com/heroku/buildpacks-nodejs/actions/runs/5245698173.