### PR TITLE
Create automated PR with token

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -23,14 +23,26 @@ jobs:
         run: "cargo run --bin generate_inventory node > buildpacks/nodejs-engine/inventory.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n{}/' buildpacks/nodejs-engine/CHANGELOG.md
+      - uses: heroku/use-app-token-action@main
+        id: generate-token
+        with:
+          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       - name: Create Pull Request
+        id: pr
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.generate-token.outputs.app_token }}
           title: "Update Node.js Engine Inventory"
           commit-message: "Update Inventory for heroku/nodejs-engine\n\n${{ steps.set-diff-msg.outputs.msg }}"
           branch: update-nodejs-inventory
           labels: "automation"
           body: "Automated pull-request to update heroku/nodejs-engine inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
+      - name: Configure PR
+        if: steps.pr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --auto "${{ steps.pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
   update-yarn-inventory:
     name: Update Node.js Yarn Inventory
     runs-on: pub-hk-ubuntu-22.04-small
@@ -49,11 +61,23 @@ jobs:
         run: "cargo run --bin generate_inventory yarn > buildpacks/nodejs-yarn/inventory.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n{}/' buildpacks/nodejs-yarn/CHANGELOG.md
+      - uses: heroku/use-app-token-action@main
+        id: generate-token
+        with:
+          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}   
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.generate-token.outputs.app_token }}
           title: "Update Node.js Yarn Inventory"
           commit-message: "Update Inventory for heroku/nodejs-yarn\n\n${{ steps.set-diff-msg.outputs.msg }}"
           branch: update-yarn-inventory
           labels: "automation"
           body: "Automated pull-request to update heroku/nodejs-yarn inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
+      - name: Configure PR
+        id: pr
+        if: steps.pr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --auto "${{ steps.pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -67,6 +67,7 @@ jobs:
           app_id: ${{ vars.LINGUIST_GH_APP_ID }}
           private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}   
       - name: Create Pull Request
+        id: pr
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ steps.generate-token.outputs.app_token }}
@@ -76,7 +77,6 @@ jobs:
           labels: "automation"
           body: "Automated pull-request to update heroku/nodejs-yarn inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
       - name: Configure PR
-        id: pr
         if: steps.pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto "${{ steps.pr.outputs.pull-request-number }}"
         env:


### PR DESCRIPTION
Generates a token from a GitHub app that can be used in automation tasks that create pull requests.

This is a redo of #556 which initially failed because [heroku/use-app-token-action](https://github.com/heroku/use-app-token-action) was a private action and those can't be used with public repositories.  The action is now public so this shouldn't be a problem anymore.