### PR TITLE
Support yarn 2.4.3

### DIFF
--- a/common/bin/download-verify-npm-package
+++ b/common/bin/download-verify-npm-package
@@ -20,17 +20,17 @@ if [ -z "$package_version" ]; then
 fi
 
 if [ "yarn" = "${package_name}" ]; then
-	# Yarn 2+ (aka: "berry") is hosted under a different npm package.
+	# Yarn 2+ (aka: "berry") is hosted under a different npm package (except for version 2.4.3).
 	major_version=$(echo "$package_version" | cut -d "." -f 1)
-	package_name=$([ "$major_version" -ge 2 ] && echo "@yarnpkg/cli-dist" || echo "yarn")
+	package_name=$([ "$major_version" -ge 2 ] && [ "$package_version" != "2.4.3" ] && echo "@yarnpkg/cli-dist" || echo "yarn")
 fi
 
 npm_url="https://registry.npmjs.com/${package_name}/${package_version}"
 
-echo "Determining dist url from ${npm_url}"
+echo "Determining dist url from ${npm_url}" >&2
 url=$(curl -sSf "${npm_url}" | jq -r '.dist.tarball')
 
-echo "Downloading ${package_name} tarball..." >&2
+echo "Downloading ${package_name} tarball from ${url} ..." >&2
 curl -sSf -o "./${package_name}-v${package_version}.tar.gz" "${url}"
 
 # Check the file's sha against npm's published sha. This section assumes all


### PR DESCRIPTION
When listing the upstream yarn distributions there is a version `2.4.3` which is tagged as `berry` in npm for the `yarn` package (https://www.npmjs.com/package/yarn/v/2.4.3).

Our mirroring automation expects yarn versions > 1.x to be distributed under the `@yarnpkg/cli-dist` but there is no published package for `@yarnpkg/cli-dist@2.4.3`.

This change should fix our Yarn mirroring which appears broken in GitHub Action runs due to version `2.4.3` belonging to the `yarn`, not `@yarnpkg/cli-dist`.