### PR TITLE
Fix for yarn 2.4.3

### DIFF
--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added Yarn version 2.4.3.
+
 ## [1.1.4] - 2023-08-10
 
 - No changes.

--- a/buildpacks/nodejs-yarn/inventory.toml
+++ b/buildpacks/nodejs-yarn/inventory.toml
@@ -697,6 +697,12 @@ url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v2.4.
 etag = "5ac10334c0ab3fd48c38a61255af427b"
 
 [[releases]]
+version = "2.4.3"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v2.4.3.tar.gz"
+etag = "1b85c06c52fd9fba14f267ecc58758f8"
+
+[[releases]]
 version = "3.0.0-rc.1"
 channel = "release"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v3.0.0-rc.1.tar.gz"
@@ -911,4 +917,3 @@ version = "4.0.0-rc.48"
 channel = "release"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0-rc.48.tar.gz"
 etag = "c202595e39bec0030ea6b2b091a0b6a3"
-

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -78,7 +78,7 @@ impl Buildpack for YarnBuildpack {
 
                 let requested_yarn_cli_range = match cfg::requested_yarn_range(&pkg_json) {
                     None => {
-                        log_info("No yarn engine range detected in package.json, using default ({DEFAULT_YARN_REQUIREMENT})");
+                        log_info(format!("No yarn engine range detected in package.json, using default ({DEFAULT_YARN_REQUIREMENT})"));
                         Requirement::parse(DEFAULT_YARN_REQUIREMENT)
                             .map_err(YarnBuildpackError::YarnDefaultParse)?
                     }


### PR DESCRIPTION
After [#617](https://github.com/heroku/buildpacks-nodejs/pull/617) was merged our inventory automation ran and the PR to update the `yarn` inventory with `2.4.3` ([#620](https://github.com/heroku/buildpacks-nodejs/pull/620)) had failing tests that showed that the layout for this version did not match our other distributions.

This PR handles this edge case by renaming the `bin/yarn.js` script to `bin/yarn` which matches the binary we expect to find. This is slightly different the `@yarnpkg/cli-dist` layout which uses a portable shell script at `yarn/bin` that calls `node /path/to/yarn.js`.