### PR TITLE
Ignore yarn 2.4.3

### DIFF
--- a/common/bin/download-verify-npm-package
+++ b/common/bin/download-verify-npm-package
@@ -20,9 +20,9 @@ if [ -z "$package_version" ]; then
 fi
 
 if [ "yarn" = "${package_name}" ]; then
-	# Yarn 2+ (aka: "berry") is hosted under a different npm package (except for version 2.4.3).
+	# Yarn 2+ (aka: "berry") is hosted under a different npm package.
 	major_version=$(echo "$package_version" | cut -d "." -f 1)
-	package_name=$([ "$major_version" -ge 2 ] && [ "$package_version" != "2.4.3" ] && echo "@yarnpkg/cli-dist" || echo "yarn")
+	package_name=$([ "$major_version" -ge 2 ] && echo "@yarnpkg/cli-dist" || echo "yarn")
 fi
 
 npm_url="https://registry.npmjs.com/${package_name}/${package_version}"


### PR DESCRIPTION
After [#617](https://github.com/heroku/buildpacks-nodejs/pull/617) was merged our inventory automation ran and the PR to update the `yarn` inventory with `2.4.3` ([#620](https://github.com/heroku/buildpacks-nodejs/pull/620)) had failing tests that showed that the layout for this version did not match our other distributions.

This PR modifies the automation to ignore this version of `yarn` so that our mirroring jobs no longer report as failing and we will not get this distribution added to our inventory since it requires special handling in the buildpack to be usable.

This was the preferred alternative to #626.