### PR TITLE
Skip `mirror-distribution` job if there are no versions

### DIFF
--- a/.github/workflows/_mirror-distribution.yml
+++ b/.github/workflows/_mirror-distribution.yml
@@ -43,6 +43,7 @@ jobs:
     name: Mirror v${{ matrix.version }} ${{ matrix.platform && format('({0})', matrix.platform) || '' }}
     needs: [get-unmirrored-versions]
     runs-on: ubuntu-22.04
+    if: needs.get-unmirrored-versions.outputs.versions != '[]'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Prevents the `mirror-distribution` from running when the versions output is an empty JSON array. Otherwise, the strategy evaluator will fail with:

```
Error when evaluating 'strategy' for job 'mirror-distribution'. heroku/buildpacks-nodejs/.github/workflows/_mirror-distribution.yml@d2b2e4b41bd74186941b08ae182261ac87ff5187 (Line: 49, Col: 18): 
Matrix vector 'version' does not contain any values
```