### PR TITLE
Update Procfile CNB to v2.0.1

### DIFF
--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated `heroku/procfile` to `2.0.1`. ([#639](https://github.com/heroku/buildpacks-node/pull/639))
+
 ## [1.1.4] - 2023-08-10
 
 - Updated `heroku/nodejs-corepack` to `1.1.4`.

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -25,7 +25,7 @@ version = "1.1.4"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "2.0.0"
+version = "2.0.1"
 optional = true
 
 [[order]]
@@ -45,7 +45,7 @@ version = "1.1.4"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "2.0.0"
+version = "2.0.1"
 optional = true
 
 [[order]]
@@ -60,7 +60,7 @@ version = "1.1.4"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "2.0.0"
+version = "2.0.1"
 optional = true
 
 [metadata]

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -17,4 +17,4 @@ uri = "libcnb:heroku/nodejs-yarn"
 uri = "libcnb:heroku/nodejs-corepack"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"


### PR DESCRIPTION
Since there has been a new Procfile CNB release:
https://github.com/heroku/procfile-cnb/releases/tag/v2.0.1
https://github.com/heroku/procfile-cnb/compare/v2.0.0...v2.0.1

Also switches the buildpack URI to using the image SHA256, for parity with the URI used in `heroku/builder`.

GUS-W-13982692.