### PR TITLE
Write telemetry files in append mode

### DIFF
--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -38,29 +38,32 @@ impl Buildpack for CorepackBuildpack {
     type Error = CorepackBuildpackError;
 
     fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
-        // Corepack requires the `packageManager` key from `package.json`.
-        // This buildpack won't be detected without it.
-        let pkg_json_path = context.app_dir.join("package.json");
-        if pkg_json_path.exists() {
-            let pkg_json = PackageJson::read(pkg_json_path)
-                .map_err(CorepackBuildpackError::PackageJson)?;
-            cfg::get_supported_package_manager(&pkg_json).map_or_else(
-                || DetectResultBuilder::fail().build(),
-                |pkg_mgr| {
-                    DetectResultBuilder::pass()
-                        .build_plan(
-                            BuildPlanBuilder::new()
-                                .requires("node")
-                                .requires(&pkg_mgr)
-                                .provides(pkg_mgr)
-                                .build(),
-                        )
-                        .build()
-                },
-            )
-        } else {
-            DetectResultBuilder::fail().build()
-        }
+        let tracer = init_tracer(context.buildpack_descriptor.buildpack.id.to_string());
+        tracer.in_span("nodejs-corepack-detect", |_cx| {
+            // Corepack requires the `packageManager` key from `package.json`.
+            // This buildpack won't be detected without it.
+            let pkg_json_path = context.app_dir.join("package.json");
+            if pkg_json_path.exists() {
+                let pkg_json = PackageJson::read(pkg_json_path)
+                    .map_err(CorepackBuildpackError::PackageJson)?;
+                cfg::get_supported_package_manager(&pkg_json).map_or_else(
+                    || DetectResultBuilder::fail().build(),
+                    |pkg_mgr| {
+                        DetectResultBuilder::pass()
+                            .build_plan(
+                                BuildPlanBuilder::new()
+                                    .requires("node")
+                                    .requires(&pkg_mgr)
+                                    .provides(pkg_mgr)
+                                    .build(),
+                            )
+                            .build()
+                    },
+                )
+            } else {
+                DetectResultBuilder::fail().build()
+            }
+        })
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {

--- a/common/nodejs-utils/src/telemetry.rs
+++ b/common/nodejs-utils/src/telemetry.rs
@@ -20,8 +20,10 @@ pub fn init_tracer(buildpack_name: impl Into<String>) -> BoxedTracer {
     if let Some(parent_dir) = telem_file_path.parent() {
         let _ = create_dir_all(parent_dir);
     }
+
     let exporter = match File::options()
-        .read(false)
+        .read(true)
+        .write(true)
         .create(true)
         .append(true)
         .truncate(false)

--- a/common/nodejs-utils/src/telemetry.rs
+++ b/common/nodejs-utils/src/telemetry.rs
@@ -30,9 +30,12 @@ pub fn init_tracer(buildpack_name: impl Into<String>) -> BoxedTracer {
         Ok(f) => opentelemetry_stdout::SpanExporter::builder()
             .with_writer(f)
             .build(),
-        Err(_) => opentelemetry_stdout::SpanExporter::builder()
-            .with_writer(std::io::sink())
-            .build(),
+        Err(err) => {
+            println!("Error creating telemetry pipeline: {err:?}");
+            opentelemetry_stdout::SpanExporter::builder()
+                .with_writer(std::io::sink())
+                .build()
+        }
     };
     let provider = TracerProvider::builder()
         .with_config(

--- a/common/nodejs-utils/src/telemetry.rs
+++ b/common/nodejs-utils/src/telemetry.rs
@@ -20,20 +20,18 @@ pub fn init_tracing(buildpack_name: impl Into<String>) -> TracerProvider {
         let _ = create_dir_all(parent_dir);
     }
 
-    // Create the telemetry file if it doesn't exist
-    let _ = File::options()
-        .create(true)
-        .write(true)
-        .open(&telem_file_path);
-
     // Create a telemetry exporter that writes to the telemetry file
     // (or /dev/null in case of file issues)
-    let exporter = match File::options().append(true).open(telem_file_path) {
+    let exporter = match File::options()
+        .create(true)
+        .append(true)
+        .open(&telem_file_path)
+    {
         Ok(f) => opentelemetry_stdout::SpanExporter::builder()
             .with_writer(std::io::BufWriter::new(NoisyFileWriter(f)))
             .build(),
         Err(err) => {
-            println!("Error creating telemetry pipeline: {err:?}");
+            println!("Error writing to file {telem_file_path:?}: {err}");
             opentelemetry_stdout::SpanExporter::builder()
                 .with_writer(std::io::sink())
                 .build()

--- a/common/nodejs-utils/src/telemetry.rs
+++ b/common/nodejs-utils/src/telemetry.rs
@@ -22,8 +22,9 @@ pub fn init_tracer(buildpack_name: impl Into<String>) -> BoxedTracer {
     }
     let exporter = match File::options()
         .read(false)
-        .append(true)
         .create(true)
+        .append(true)
+        .truncate(false)
         .open(telem_file_path)
     {
         Ok(f) => opentelemetry_stdout::SpanExporter::builder()

--- a/common/nodejs-utils/src/telemetry.rs
+++ b/common/nodejs-utils/src/telemetry.rs
@@ -81,13 +81,6 @@ mod tests {
         });
         global::shutdown_tracer_provider();
 
-        init_tracer(buildpack_name.to_string());
-        let tracer = global::tracer("");
-        tracer.in_span(test_span_name, |cx| {
-            cx.span().add_event(test_event_name, Vec::new());
-        });
-        global::shutdown_tracer_provider();
-
         let contents = fs::read_to_string(telemetry_file_path)
             .expect("expected to read existing telemetry file");
         println!("Contents: {contents}");

--- a/common/nodejs-utils/src/telemetry.rs
+++ b/common/nodejs-utils/src/telemetry.rs
@@ -28,7 +28,7 @@ pub fn init_tracing(buildpack_name: impl Into<String>) -> TracerProvider {
         .open(&telem_file_path)
     {
         Ok(f) => opentelemetry_stdout::SpanExporter::builder()
-            .with_writer(std::io::BufWriter::new(NoisyFileWriter(f)))
+            .with_writer(std::io::BufWriter::new(f))
             .build(),
         Err(err) => {
             println!("Error writing to file {telem_file_path:?}: {err}");
@@ -92,18 +92,5 @@ mod tests {
         }
 
         Ok(())
-    }
-}
-
-#[derive(Debug)]
-struct NoisyFileWriter(File);
-impl std::io::Write for NoisyFileWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        println!("Writing to {self:?}! {}", String::from_utf8_lossy(buf));
-        self.0.write(buf)
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        println!("Flushing {self:?}!");
-        self.0.flush()
     }
 }


### PR DESCRIPTION
The existing telemetry setup was mistakenly replacing all contents on each write, due to the defaults that come with `File::create`. This should correct the file writer so that contents are appended to the file, rather than replacing the file.

This also changes the writer to essentially`/dev/null` when the telemetry file couldn't be created, previously, it would stream telemetry to stdout when there were file issues, which we don't want.