### PR TITLE
Switch tests from `heroku/buildpacks:20` to `heroku/builder:20`

### DIFF
--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -36,7 +36,7 @@ fn test_response(container: &ContainerContext, text: &str) {
 fn simple_indexjs_heroku20() {
     test_node(
         "node-with-indexjs",
-        "heroku/buildpacks:20",
+        "heroku/builder:20",
         &["Detected Node.js version range: *", "Installing Node.js"],
     );
 }
@@ -56,7 +56,7 @@ fn simple_indexjs_heroku22() {
 fn simple_serverjs_heroku20() {
     test_node(
         "node-with-serverjs",
-        "heroku/buildpacks:20",
+        "heroku/builder:20",
         &["Installing Node.js 16.0.0"],
     );
 }
@@ -75,10 +75,7 @@ fn simple_serverjs_heroku22() {
 #[ignore]
 fn upgrade_simple_indexjs_from_heroku20_to_heroku22() {
     TestRunner::default().build(
-        BuildConfig::new(
-            "heroku/buildpacks:20",
-            "../../test/fixtures/node-with-indexjs",
-        ),
+        BuildConfig::new("heroku/builder:20", "../../test/fixtures/node-with-indexjs"),
         |initial_ctx| {
             assert_contains!(initial_ctx.pack_stdout, "Installing Node.js");
             initial_ctx.rebuild(

--- a/test/specs/node-function/spec_helper.rb
+++ b/test/specs/node-function/spec_helper.rb
@@ -12,7 +12,7 @@ end
 NODEJS_FUNCTION_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("../meta-buildpacks/nodejs-function"))
 Cutlass.config do |config|
   config.default_buildpack_paths = [NODEJS_FUNCTION_BUILDPACK]
-  config.default_builder = "heroku/buildpacks:20"
+  config.default_builder = "heroku/builder:20"
   config.default_repo_dirs = [test_dir.join("fixtures")]
 end
 

--- a/test/specs/node/cutlass/basic_spec.rb
+++ b/test/specs/node/cutlass/basic_spec.rb
@@ -4,7 +4,7 @@ require_relative "../spec_helper"
 
 
 describe "Heroku's Nodejs CNB" do
-  ["heroku/buildpacks:20", "heroku/builder:22"].each do |builder|
+  ["heroku/builder:20", "heroku/builder:22"].each do |builder|
     describe "with #{builder}" do
       it "handles a downgrade of node engine" do
         Cutlass::App.new("simple-function", builder: builder).transaction do |app|

--- a/test/specs/node/spec_helper.rb
+++ b/test/specs/node/spec_helper.rb
@@ -13,7 +13,7 @@ NODEJS_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("../meta
 
 Cutlass.config do |config|
   config.default_buildpack_paths = [NODEJS_BUILDPACK]
-  config.default_builder = "heroku/buildpacks:20"
+  config.default_builder = "heroku/builder:22"
   config.default_repo_dirs = [test_dir.join("fixtures")]
 end
 

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -16,7 +16,7 @@ pub enum Builder {
 impl fmt::Display for Builder {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
-            Builder::Heroku20 => write!(f, "heroku/buildpacks:20"),
+            Builder::Heroku20 => write!(f, "heroku/builder:20"),
             Builder::Heroku22 => write!(f, "heroku/builder:22"),
         }
     }


### PR DESCRIPTION
Since the `heroku/buildpacks:20` image is about to be deprecated, and has been replaced by the newly added `heroku/builder:20` for those that need to use a Heroku-20 based builder.

The build and run images used by `heroku/builder:20` are the same as those used by `heroku/buildpacks:20` - the only differences between the builders are the included buildpacks (which is somewhat irrelevant for these integration tests, since the buildpack under test will be injected instead).

The smoke tests in the `heroku/builder` GitHub repo are still testing against all image variants (until such time as we make the legacy images error with an EOL message), so we still have test coverage against them.

See:
https://github.com/heroku/builder/pull/394
https://salesforce.quip.com/0JtbAYiWZYk6

GUS-W-14186015.