### PR TITLE
Prepare integration tests to run under a single builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     name: Find libcnb buildpacks
     runs-on: ubuntu-22.04
     outputs:
-      buildpack_dirs: ${{ steps.find-buildpack-dirs.outputs.buildpack_dirs }}
+      libcnb-buildpacks: ${{ steps.find-buildpack-dirs.outputs.buildpacks }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,16 +61,22 @@ jobs:
           submodules: true
       - id: find-buildpack-dirs
         name: Find libcnb buildpack directories
-        run: echo "buildpack_dirs=$(find . -type d -execdir test -e "{}/buildpack.toml" -a -e "{}/Cargo.toml" \; -print | sort | uniq | jq -nRc '[inputs]')" >> $GITHUB_OUTPUT
+        run: |
+          echo "buildpacks=$( \
+            find . -type d -execdir test -e "{}/buildpack.toml" -a -e "{}/Cargo.toml" \; -print \
+            | sort \
+            | uniq \
+            | jq -nRc '[inputs] | map({ dir: ., name: split("/") | last } | [. + { builder_tag: 20 }, . + { builder_tag: 22 }]) | flatten' \
+          )" >> $GITHUB_OUTPUT
 
   rust-integration-test:
-    name: libcnb.rs integration tests (${{ matrix.buildpack-directory }})
+    name: Test (${{ matrix.builder_tag }}, ${{ matrix.name }})
     runs-on: pub-hk-ubuntu-22.04-large
     needs: find-libcnb-buildpacks
     strategy:
       fail-fast: false
       matrix:
-        buildpack-directory: ${{ fromJson(needs.find-libcnb-buildpacks.outputs.buildpack_dirs) }}
+        include: ${{ fromJson(needs.find-libcnb-buildpacks.outputs.libcnb-buildpacks) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -85,7 +91,9 @@ jobs:
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.4.0
       - name: Run integration tests
-        working-directory: ${{ matrix.buildpack-directory }}
+        working-directory: ${{ matrix.dir }}
+        env:
+          INTEGRATION_TEST_CNB_BUILDER: heroku/builder:${{ matrix.builder_tag }}
         run: cargo test --locked -- --ignored --test-threads 16
 
   shpec:
@@ -95,10 +103,10 @@ jobs:
     strategy:
       matrix:
         stack-version:
-        - '20'
-        - '22'
+          - '20'
+          - '22'
         buildpack-dir:
-        - buildpacks/npm
+          - buildpacks/npm
     defaults:
       run:
         shell: bash
@@ -115,8 +123,8 @@ jobs:
     strategy:
       matrix:
         test-dir:
-        - test/specs/node-function
-        - test/specs/node
+          - test/specs/node-function
+          - test/specs/node
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,9 @@ dependencies = [
  "libcnb-test",
  "libherokubuildpack",
  "serde",
+ "serde_json",
  "tempfile",
+ "test_support",
  "thiserror",
  "toml",
  "ureq",
@@ -498,6 +500,7 @@ dependencies = [
  "test_support",
  "thiserror",
  "toml",
+ "ureq",
 ]
 
 [[package]]
@@ -1287,7 +1290,9 @@ dependencies = [
 name = "test_support"
 version = "0.0.0"
 dependencies = [
+ "libcnb",
  "libcnb-test",
+ "serde_json",
  "tempfile",
  "ureq",
 ]

--- a/buildpacks/nodejs-corepack/tests/integration_test.rs
+++ b/buildpacks/nodejs-corepack/tests/integration_test.rs
@@ -1,13 +1,12 @@
 #![warn(clippy::pedantic)]
 
 use libcnb_test::assert_contains;
-use test_support::test_corepack_app;
-use test_support::Builder::{Heroku20, Heroku22};
+use test_support::nodejs_integration_test;
 
 #[test]
 #[ignore = "integration test"]
-fn corepack_yarn_2_heroku_20() {
-    test_corepack_app("yarn-2-pnp-zero", Heroku20, |ctx| {
+fn corepack_yarn_2() {
+    nodejs_integration_test("../../../test/fixtures/yarn-2-pnp-zero", |ctx| {
         assert_contains!(ctx.pack_stdout, "Preparing yarn@2.4.1");
         let output = ctx.run_shell_command("yarn --version");
         assert_contains!(output.stdout, "2.4.1");
@@ -16,8 +15,8 @@ fn corepack_yarn_2_heroku_20() {
 
 #[test]
 #[ignore = "integration test"]
-fn corepack_yarn_3_heroku_22() {
-    test_corepack_app("yarn-3-pnp-nonzero", Heroku22, |ctx| {
+fn corepack_yarn_3() {
+    nodejs_integration_test("../../../test/fixtures/yarn-3-pnp-nonzero", |ctx| {
         assert_contains!(ctx.pack_stdout, "Preparing yarn@3.2.0");
         let output = ctx.run_shell_command("yarn --version");
         assert_contains!(output.stdout, "3.2.0");
@@ -27,7 +26,7 @@ fn corepack_yarn_3_heroku_22() {
 #[test]
 #[ignore = "integration test"]
 fn corepack_pnpm_7() {
-    test_corepack_app("pnpm-7-pnp", Heroku20, |ctx| {
+    nodejs_integration_test("../../../test/fixtures/pnpm-7-pnp", |ctx| {
         assert_contains!(ctx.pack_stdout, "Preparing pnpm@7.32.3");
         let output = ctx.run_shell_command("pnpm --version");
         assert_contains!(output.stdout, "7.32.3");
@@ -37,7 +36,7 @@ fn corepack_pnpm_7() {
 #[test]
 #[ignore = "integration test"]
 fn corepack_pnpm_8() {
-    test_corepack_app("pnpm-8-hoist", Heroku22, |ctx| {
+    nodejs_integration_test("../../../test/fixtures/pnpm-8-hoist", |ctx| {
         assert_contains!(ctx.pack_stdout, "Preparing pnpm@8.4.0");
         let output = ctx.run_shell_command("pnpm --version");
         assert_contains!(output.stdout, "8.4.0");

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -17,4 +17,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 libcnb-test.workspace = true
+test_support.workspace = true
+serde_json.workspace = true
 ureq.workspace = true

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -15,16 +15,18 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericMetadata;
 use libcnb::generic::GenericPlatform;
 use libcnb::{buildpack_main, Buildpack};
-use libherokubuildpack::log::{log_error, log_header, log_info};
-use thiserror::Error;
-
-mod layers;
-
 #[cfg(test)]
 use libcnb_test as _;
-
+use libherokubuildpack::log::{log_error, log_header, log_info};
+#[cfg(test)]
+use serde_json as _;
+#[cfg(test)]
+use test_support as _;
+use thiserror::Error;
 #[cfg(test)]
 use ureq as _;
+
+mod layers;
 
 const INVENTORY: &str = include_str!("../inventory.toml");
 

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -1,96 +1,49 @@
 #![warn(clippy::pedantic)]
 
-use libcnb_test::{assert_contains, BuildConfig, ContainerConfig, ContainerContext, TestRunner};
-use std::time::Duration;
+use libcnb_test::assert_contains;
+use test_support::{
+    assert_web_response, nodejs_integration_test, nodejs_integration_test_with_config,
+    set_node_engine,
+};
 
-const PORT: u16 = 8080;
+#[test]
+#[ignore]
+fn simple_indexjs() {
+    nodejs_integration_test("../../../test/fixtures/node-with-indexjs", |ctx| {
+        assert_contains!(ctx.pack_stdout, "Detected Node.js version range: *");
+        assert_contains!(ctx.pack_stdout, "Installing Node.js");
+        assert_web_response(&ctx, "node-with-indexjs");
+    });
+}
 
-fn test_node(fixture: &str, builder: &str, expect_lines: &[&str]) {
-    TestRunner::default().build(
-        BuildConfig::new(builder, format!("../../test/fixtures/{fixture}")),
-        |ctx| {
-            for expect_line in expect_lines {
-                assert_contains!(ctx.pack_stdout, expect_line);
-            }
-            ctx.start_container(ContainerConfig::new().expose_port(PORT), |container| {
-                test_response(&container, fixture);
+#[test]
+#[ignore]
+fn simple_serverjs() {
+    nodejs_integration_test("../../../test/fixtures/node-with-serverjs", |ctx| {
+        assert_contains!(ctx.pack_stdout, "Installing Node.js 16.0.0");
+        assert_web_response(&ctx, "node-with-serverjs");
+    });
+}
+
+#[test]
+#[ignore]
+fn reinstalls_node_if_version_changes() {
+    nodejs_integration_test_with_config(
+        "../../../test/fixtures/node-with-indexjs",
+        |config| {
+            config.app_dir_preprocessor(|app_dir| {
+                set_node_engine(&app_dir, "^14.0");
             });
         },
-    );
-}
-
-fn test_response(container: &ContainerContext, text: &str) {
-    std::thread::sleep(Duration::from_secs(5));
-    let addr = container.address_for_port(PORT);
-    let resp = ureq::get(&format!("http://{addr}"))
-        .call()
-        .expect("request to container failed")
-        .into_string()
-        .expect("response read error");
-
-    assert_contains!(resp, text);
-}
-
-#[test]
-#[ignore]
-fn simple_indexjs_heroku20() {
-    test_node(
-        "node-with-indexjs",
-        "heroku/builder:20",
-        &["Detected Node.js version range: *", "Installing Node.js"],
-    );
-}
-
-#[test]
-#[ignore]
-fn simple_indexjs_heroku22() {
-    test_node(
-        "node-with-indexjs",
-        "heroku/builder:22",
-        &["Detected Node.js version range: *", "Installing Node.js"],
-    );
-}
-
-#[test]
-#[ignore]
-fn simple_serverjs_heroku20() {
-    test_node(
-        "node-with-serverjs",
-        "heroku/builder:20",
-        &["Installing Node.js 16.0.0"],
-    );
-}
-
-#[test]
-#[ignore]
-fn simple_serverjs_heroku22() {
-    test_node(
-        "node-with-serverjs",
-        "heroku/builder:22",
-        &["Installing Node.js 16.0.0"],
-    );
-}
-
-#[test]
-#[ignore]
-fn upgrade_simple_indexjs_from_heroku20_to_heroku22() {
-    TestRunner::default().build(
-        BuildConfig::new("heroku/builder:20", "../../test/fixtures/node-with-indexjs"),
-        |initial_ctx| {
-            assert_contains!(initial_ctx.pack_stdout, "Installing Node.js");
-            initial_ctx.rebuild(
-                BuildConfig::new("heroku/builder:22", "../../test/fixtures/node-with-indexjs"),
-                |upgrade_ctx| {
-                    assert_contains!(upgrade_ctx.pack_stdout, "Installing Node.js");
-                    let port = 8080;
-                    upgrade_ctx.start_container(
-                        ContainerConfig::new().expose_port(port),
-                        |container| {
-                            test_response(&container, "node-with-index");
-                        },
-                    );
-                },
-            );
+        |ctx| {
+            assert_contains!(ctx.pack_stdout, "Installing Node.js 14");
+            let mut config = ctx.config.clone();
+            config.app_dir_preprocessor(|app_dir| {
+                set_node_engine(&app_dir, "^16.0");
+            });
+            ctx.rebuild(config, |ctx| {
+                assert_contains!(ctx.pack_stdout, "Installing Node.js 16");
+            });
         },
     );
 }

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -19,3 +19,4 @@ libcnb-test.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 test_support.workspace = true
+ureq.workspace = true

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -25,6 +25,8 @@ use serde::Deserialize;
 #[cfg(test)]
 use test_support as _;
 use thiserror::Error;
+#[cfg(test)]
+use ureq as _;
 
 mod function;
 mod layers;

--- a/buildpacks/nodejs-function-invoker/tests/integration_test.rs
+++ b/buildpacks/nodejs-function-invoker/tests/integration_test.rs
@@ -1,89 +1,113 @@
 #![warn(clippy::pedantic)]
 
-use libcnb_test::{assert_contains, assert_not_contains};
-use test_support::Builder::Heroku22;
-use test_support::{assert_health_check_responds, test_node_function};
+use libcnb_test::{assert_contains, assert_not_contains, TestContext};
+use std::net::SocketAddr;
+use test_support::{
+    function_integration_test, retry, start_container, DEFAULT_RETRIES,
+    DEFAULT_RETRY_DELAY_IN_SECONDS,
+};
 
 #[test]
 #[ignore]
-fn simple_javascript_function_heroku_22() {
-    test_node_function("simple-function", Heroku22, |ctx| {
-        assert_health_check_responds(&ctx);
+fn simple_javascript_function() {
+    function_integration_test("../../../test/fixtures/simple-function", |ctx| {
+        assert_contains!(ctx.pack_stdout, "Installing Node.js Function Invoker");
+        start_container_and_assert_health_check_responds(&ctx);
     });
 }
 
 #[test]
 #[ignore]
-fn simple_typescript_function_heroku_22() {
-    test_node_function("simple-typescript-function", Heroku22, |ctx| {
-        assert_health_check_responds(&ctx);
+fn simple_typescript_function() {
+    function_integration_test("../../../test/fixtures/simple-typescript-function", |ctx| {
+        assert_contains!(ctx.pack_stdout, "Installing Node.js Function Invoker");
+        start_container_and_assert_health_check_responds(&ctx);
     });
 }
 
 #[test]
 #[ignore]
-fn test_function_with_explicit_runtime_dependency_js_heroku_22() {
-    test_node_function(
-        "functions/with-explicit-runtime-dependency-js",
-        Heroku22,
+fn test_function_with_explicit_runtime_dependency_js() {
+    function_integration_test(
+        "../../../test/fixtures/functions/with-explicit-runtime-dependency-js",
         |ctx| {
             assert_contains!(
                 ctx.pack_stdout,
                 "Node.js function runtime declared in package.json"
             );
             assert_not_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
-            assert_health_check_responds(&ctx);
+            start_container_and_assert_health_check_responds(&ctx);
         },
     );
 }
 
 #[test]
 #[ignore]
-fn test_function_with_explicit_runtime_dependency_ts_heroku_22() {
-    test_node_function(
-        "functions/with-explicit-runtime-dependency-ts",
-        Heroku22,
+fn test_function_with_explicit_runtime_dependency_ts() {
+    function_integration_test(
+        "../../../test/fixtures/functions/with-explicit-runtime-dependency-ts",
         |ctx| {
             assert_contains!(
                 ctx.pack_stdout,
                 "Node.js function runtime declared in package.json"
             );
             assert_not_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
-            assert_health_check_responds(&ctx);
+            start_container_and_assert_health_check_responds(&ctx);
         },
     );
 }
 
 #[test]
 #[ignore]
-fn test_function_with_implicit_runtime_dependency_js_heroku_22() {
-    test_node_function(
-        "functions/with-implicit-runtime-dependency-js",
-        Heroku22,
+fn test_function_with_implicit_runtime_dependency_js() {
+    function_integration_test(
+        "../../../test/fixtures/functions/with-implicit-runtime-dependency-js",
         |ctx| {
             assert_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
             assert_not_contains!(
                 ctx.pack_stdout,
                 "Node.js function runtime declared in package.json"
             );
-            assert_health_check_responds(&ctx);
+            start_container_and_assert_health_check_responds(&ctx);
         },
     );
 }
 
 #[test]
 #[ignore]
-fn test_function_with_implicit_runtime_dependency_ts_heroku_22() {
-    test_node_function(
-        "functions/with-implicit-runtime-dependency-ts",
-        Heroku22,
+fn test_function_with_implicit_runtime_dependency_ts() {
+    function_integration_test(
+        "../../../test/fixtures/functions/with-implicit-runtime-dependency-ts",
         |ctx| {
             assert_contains!(ctx.pack_stderr, "Future versions of the Functions Runtime for Node.js (@heroku/sf-fx-runtime-nodejs) will not be auto-detected and must be added as a dependency in package.json");
             assert_not_contains!(
                 ctx.pack_stdout,
                 "Node.js function runtime declared in package.json"
             );
-            assert_health_check_responds(&ctx);
+            start_container_and_assert_health_check_responds(&ctx);
         },
     );
+}
+
+fn assert_health_check_responds(socket_addr: &SocketAddr) {
+    retry(
+        DEFAULT_RETRIES,
+        DEFAULT_RETRY_DELAY_IN_SECONDS,
+        || {
+            ureq::post(&format!("http://{socket_addr}"))
+                .set("x-health-check", "true")
+                .call()
+        },
+        |res| {
+            let response_body = res.into_string().unwrap();
+            assert_contains!(response_body, "OK");
+        },
+        |error| panic!("request to assert function health check response failed: {error}"),
+    );
+}
+
+fn start_container_and_assert_health_check_responds(ctx: &TestContext) {
+    start_container(ctx, |_container, socket_addr| {
+        assert_health_check_responds(socket_addr);
+    });
 }

--- a/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
@@ -2,13 +2,12 @@
 
 use indoc::formatdoc;
 use libcnb_test::{assert_contains, assert_empty};
-use test_support::Builder::{Heroku20, Heroku22};
-use test_support::{assert_web_response, test_pnpm_app};
+use test_support::{assert_web_response, nodejs_integration_test};
 
 #[test]
 #[ignore = "integration test"]
-fn pnpm_7_pnp_heroku_20() {
-    test_pnpm_app("pnpm-7-pnp", Heroku20, |ctx| {
+fn pnpm_7_pnp() {
+    nodejs_integration_test("../../../test/fixtures/pnpm-7-pnp", |ctx| {
         assert_empty!(ctx.pack_stderr);
         assert_contains!(
             ctx.pack_stdout,
@@ -58,8 +57,8 @@ fn pnpm_7_pnp_heroku_20() {
 
 #[test]
 #[ignore = "integration test"]
-fn pnpm_8_hoist_heroku_22() {
-    test_pnpm_app("pnpm-8-hoist", Heroku22, |ctx| {
+fn pnpm_8_hoist() {
+    nodejs_integration_test("../../../test/fixtures/pnpm-8-hoist", |ctx| {
         assert_empty!(ctx.pack_stderr);
         assert_contains!(
             ctx.pack_stdout,

--- a/buildpacks/nodejs-yarn/tests/integration_test.rs
+++ b/buildpacks/nodejs-yarn/tests/integration_test.rs
@@ -1,13 +1,12 @@
 #![warn(clippy::pedantic)]
 
 use libcnb_test::{assert_contains, assert_not_contains};
-use test_support::Builder::{Heroku20, Heroku22};
-use test_support::{assert_web_response, test_yarn_app};
+use test_support::{assert_web_response, nodejs_integration_test};
 
 #[test]
 #[ignore = "integration test"]
-fn yarn_1_typescript_heroku_20() {
-    test_yarn_app("yarn-1-typescript", Heroku20, |ctx| {
+fn yarn_1_typescript() {
+    nodejs_integration_test("../../../test/fixtures/yarn-1-typescript", |ctx| {
         assert_contains!(ctx.pack_stdout, "Installing yarn");
         assert_contains!(ctx.pack_stdout, "Installing dependencies");
         assert_contains!(ctx.pack_stdout, "Running `build` script");
@@ -17,20 +16,9 @@ fn yarn_1_typescript_heroku_20() {
 
 #[test]
 #[ignore = "integration test"]
-fn yarn_1_typescript_heroku_22() {
-    test_yarn_app("yarn-1-typescript", Heroku22, |ctx| {
-        assert_contains!(ctx.pack_stdout, "Installing yarn");
-        assert_contains!(ctx.pack_stdout, "Installing dependencies");
-        assert_contains!(ctx.pack_stdout, "Running `build` script");
-        assert_web_response(&ctx, "yarn-1-typescript");
-    });
-}
-
-#[test]
-#[ignore = "integration test"]
-fn yarn_2_pnp_zero_heroku_20() {
-    test_yarn_app("yarn-2-pnp-zero", Heroku20, |ctx| {
-        assert_contains!(ctx.pack_stdout, "Installing yarn");
+fn yarn_2_pnp_zero() {
+    nodejs_integration_test("../../../test/fixtures/yarn-2-pnp-zero", |ctx| {
+        assert_not_contains!(ctx.pack_stdout, "Installing yarn");
         assert_contains!(ctx.pack_stdout, "Yarn zero-install detected");
         assert_contains!(ctx.pack_stdout, "Installing dependencies");
         assert_not_contains!(
@@ -47,27 +35,8 @@ fn yarn_2_pnp_zero_heroku_20() {
 
 #[test]
 #[ignore = "integration test"]
-fn yarn_2_pnp_zero_heroku_22() {
-    test_yarn_app("yarn-2-pnp-zero", Heroku22, |ctx| {
-        assert_contains!(ctx.pack_stdout, "Installing yarn");
-        assert_contains!(ctx.pack_stdout, "Yarn zero-install detected");
-        assert_contains!(ctx.pack_stdout, "Installing dependencies");
-        assert_not_contains!(
-            ctx.pack_stdout,
-            "can't be found in the cache and will be fetched from the remote registry"
-        );
-        assert_contains!(ctx.pack_stdout, "Resolution step");
-        assert_contains!(ctx.pack_stdout, "Fetch step");
-        assert_contains!(ctx.pack_stdout, "Link step");
-        assert_contains!(ctx.pack_stdout, "Completed");
-        assert_web_response(&ctx, "yarn-2-pnp-zero");
-    });
-}
-
-#[test]
-#[ignore = "integration test"]
-fn yarn_2_modules_nonzero_heroku_20() {
-    test_yarn_app("yarn-2-modules-nonzero", Heroku20, |ctx| {
+fn yarn_2_modules_nonzero() {
+    nodejs_integration_test("../../../test/fixtures/yarn-2-modules-nonzero", |ctx| {
         assert_contains!(ctx.pack_stdout, "Installing yarn");
         assert_contains!(ctx.pack_stdout, "Successfully set cacheFolder");
         assert_contains!(ctx.pack_stdout, "Installing dependencies");
@@ -85,27 +54,8 @@ fn yarn_2_modules_nonzero_heroku_20() {
 
 #[test]
 #[ignore = "integration test"]
-fn yarn_2_modules_nonzero_heroku_22() {
-    test_yarn_app("yarn-2-modules-nonzero", Heroku22, |ctx| {
-        assert_contains!(ctx.pack_stdout, "Installing yarn");
-        assert_contains!(ctx.pack_stdout, "Successfully set cacheFolder");
-        assert_contains!(ctx.pack_stdout, "Installing dependencies");
-        assert_contains!(
-            ctx.pack_stdout,
-            "can't be found in the cache and will be fetched from the remote registry"
-        );
-        assert_contains!(ctx.pack_stdout, "Resolution step");
-        assert_contains!(ctx.pack_stdout, "Fetch step");
-        assert_contains!(ctx.pack_stdout, "Link step");
-        assert_contains!(ctx.pack_stdout, "Completed");
-        assert_web_response(&ctx, "yarn-2-modules-nonzero");
-    });
-}
-
-#[test]
-#[ignore = "integration test"]
-fn yarn_3_pnp_nonzero_heroku_20() {
-    test_yarn_app("yarn-3-pnp-nonzero", Heroku20, |ctx| {
+fn yarn_3_pnp_nonzero() {
+    nodejs_integration_test("../../../test/fixtures/yarn-3-pnp-nonzero", |ctx| {
         assert_contains!(ctx.pack_stdout, "Installing yarn");
         assert_contains!(ctx.pack_stdout, "Installing dependencies");
         assert_contains!(ctx.pack_stdout, "Successfully set cacheFolder");
@@ -123,46 +73,8 @@ fn yarn_3_pnp_nonzero_heroku_20() {
 
 #[test]
 #[ignore = "integration test"]
-fn yarn_3_pnp_nonzero_heroku_22() {
-    test_yarn_app("yarn-3-pnp-nonzero", Heroku22, |ctx| {
-        assert_contains!(ctx.pack_stdout, "Installing yarn");
-        assert_contains!(ctx.pack_stdout, "Successfully set cacheFolder");
-        assert_contains!(ctx.pack_stdout, "Installing dependencies");
-        assert_contains!(
-            ctx.pack_stdout,
-            "can't be found in the cache and will be fetched from the remote registry"
-        );
-        assert_contains!(ctx.pack_stdout, "Resolution step");
-        assert_contains!(ctx.pack_stdout, "Fetch step");
-        assert_contains!(ctx.pack_stdout, "Link step");
-        assert_contains!(ctx.pack_stdout, "Completed");
-        assert_web_response(&ctx, "yarn-3-pnp-nonzero");
-    });
-}
-
-#[test]
-#[ignore = "integration test"]
-fn yarn_3_modules_zero_heroku_20() {
-    test_yarn_app("yarn-3-modules-zero", Heroku20, |ctx| {
-        assert_contains!(ctx.pack_stdout, "Installing yarn");
-        assert_contains!(ctx.pack_stdout, "Yarn zero-install detected");
-        assert_contains!(ctx.pack_stdout, "Installing dependencies");
-        assert_not_contains!(
-            ctx.pack_stdout,
-            "can't be found in the cache and will be fetched from the remote registry"
-        );
-        assert_contains!(ctx.pack_stdout, "Resolution step");
-        assert_contains!(ctx.pack_stdout, "Fetch step");
-        assert_contains!(ctx.pack_stdout, "Link step");
-        assert_contains!(ctx.pack_stdout, "Completed");
-        assert_web_response(&ctx, "yarn-3-modules-zero");
-    });
-}
-
-#[test]
-#[ignore = "integration test"]
-fn yarn_3_modules_zero_heroku_22() {
-    test_yarn_app("yarn-3-modules-zero", Heroku22, |ctx| {
+fn yarn_3_modules_zero() {
+    nodejs_integration_test("../../../test/fixtures/yarn-3-modules-zero", |ctx| {
         assert_contains!(ctx.pack_stdout, "Installing yarn");
         assert_contains!(ctx.pack_stdout, "Yarn zero-install detected");
         assert_contains!(ctx.pack_stdout, "Installing dependencies");

--- a/buildpacks/nodejs-yarn/tests/integration_test.rs
+++ b/buildpacks/nodejs-yarn/tests/integration_test.rs
@@ -18,7 +18,7 @@ fn yarn_1_typescript() {
 #[ignore = "integration test"]
 fn yarn_2_pnp_zero() {
     nodejs_integration_test("../../../test/fixtures/yarn-2-pnp-zero", |ctx| {
-        assert_not_contains!(ctx.pack_stdout, "Installing yarn");
+        assert_contains!(ctx.pack_stdout, "Installing yarn");
         assert_contains!(ctx.pack_stdout, "Yarn zero-install detected");
         assert_contains!(ctx.pack_stdout, "Installing dependencies");
         assert_not_contains!(

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -7,6 +7,8 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+libcnb.workspace = true
 libcnb-test.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
 ureq.workspace = true

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -1,144 +1,173 @@
+use libcnb::data::buildpack_id;
 use libcnb_test::{
-    assert_contains, BuildConfig, BuildpackReference, ContainerConfig, TestContext, TestRunner,
+    assert_contains, BuildConfig, BuildpackReference, ContainerConfig, ContainerContext,
+    TestContext, TestRunner,
 };
-use std::fmt;
-use std::fmt::Formatter;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-const PORT: u16 = 8080;
-const TIMEOUT: u64 = 10;
+const DEFAULT_BUILDER: &str = "heroku/builder:22";
+pub const PORT: u16 = 8080;
+pub const DEFAULT_RETRIES: u32 = 10;
+pub const DEFAULT_RETRY_DELAY_IN_SECONDS: u64 = 1;
 
-pub enum Builder {
-    Heroku20,
-    Heroku22,
+pub fn get_integration_test_builder() -> String {
+    std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap_or(DEFAULT_BUILDER.to_string())
 }
 
-impl fmt::Display for Builder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            Builder::Heroku20 => write!(f, "heroku/builder:20"),
-            Builder::Heroku22 => write!(f, "heroku/builder:22"),
+pub fn nodejs_integration_test(fixture: &str, test_body: fn(TestContext)) {
+    nodejs_integration_test_with_config(fixture, |_| {}, test_body);
+}
+
+pub fn nodejs_integration_test_with_config(
+    fixture: &str,
+    with_config: fn(&mut BuildConfig),
+    test_body: fn(TestContext),
+) {
+    integration_test_with_config(
+        fixture,
+        with_config,
+        test_body,
+        &[BuildpackReference::WorkspaceBuildpack(buildpack_id!(
+            "heroku/nodejs"
+        ))],
+    );
+}
+
+pub fn function_integration_test(fixture: &str, test_body: fn(TestContext)) {
+    function_integration_test_with_config(fixture, |_| {}, test_body);
+}
+
+pub fn function_integration_test_with_config(
+    fixture: &str,
+    with_config: fn(&mut BuildConfig),
+    test_body: fn(TestContext),
+) {
+    if get_integration_test_builder() == "heroku/builder:20" {
+        // builder:20 doesn't ship with functions
+        return;
+    }
+    integration_test_with_config(
+        fixture,
+        with_config,
+        test_body,
+        &[BuildpackReference::WorkspaceBuildpack(buildpack_id!(
+            "heroku/nodejs-function"
+        ))],
+    );
+}
+
+fn integration_test_with_config(
+    fixture: &str,
+    with_config: fn(&mut BuildConfig),
+    test_body: fn(TestContext),
+    buildpacks: &[BuildpackReference],
+) {
+    let cargo_manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .expect("The CARGO_MANIFEST_DIR should be automatically set by Cargo when running tests but it was not");
+
+    let builder = get_integration_test_builder();
+    let app_dir = cargo_manifest_dir.join("tests").join(fixture);
+
+    let mut build_config = BuildConfig::new(builder, app_dir);
+    build_config.buildpacks(buildpacks);
+    with_config(&mut build_config);
+
+    TestRunner::default().build(build_config, test_body);
+}
+
+pub fn retry<T, E>(
+    attempts: u32,
+    retry_delay_in_secs: u64,
+    retryable_action: impl Fn() -> Result<T, E>,
+    on_success: impl FnOnce(T),
+    on_fail: impl FnOnce(E),
+) {
+    for attempt in 0..attempts {
+        match retryable_action() {
+            Ok(result) => {
+                on_success(result);
+                break;
+            }
+            Err(error) => {
+                if attempt == attempts - 1 {
+                    on_fail(error);
+                    break;
+                }
+            }
         }
+        std::thread::sleep(Duration::from_secs(retry_delay_in_secs));
     }
 }
 
-pub fn get_function_invoker_buildpacks() -> Vec<BuildpackReference> {
-    vec![
-        BuildpackReference::Other(String::from("heroku/nodejs-engine")),
-        BuildpackReference::Other(String::from("heroku/nodejs-npm")),
-        BuildpackReference::CurrentCrate,
-    ]
-}
-
-pub fn get_yarn_buildpacks() -> Vec<BuildpackReference> {
-    vec![
-        BuildpackReference::Other(String::from("heroku/nodejs-engine")),
-        BuildpackReference::CurrentCrate,
-    ]
-}
-
-pub fn get_corepack_buildpacks() -> Vec<BuildpackReference> {
-    vec![
-        BuildpackReference::Other(String::from("heroku/nodejs-engine")),
-        BuildpackReference::CurrentCrate,
-    ]
-}
-
-pub fn get_pnpm_buildpacks() -> Vec<BuildpackReference> {
-    vec![
-        BuildpackReference::Other(String::from("heroku/nodejs-engine")),
-        BuildpackReference::Other(String::from("heroku/nodejs-corepack")),
-        BuildpackReference::CurrentCrate,
-    ]
-}
-
-pub fn get_function_invoker_build_config(fixture: &str, builder: Builder) -> BuildConfig {
-    BuildConfig::new(
-        builder.to_string(),
-        format!("../../test/fixtures/{fixture}"),
-    )
-    .buildpacks(get_function_invoker_buildpacks())
-    .to_owned()
-}
-
-pub fn get_yarn_build_config(fixture: &str, builder: Builder) -> BuildConfig {
-    BuildConfig::new(
-        builder.to_string(),
-        format!("../../test/fixtures/{fixture}"),
-    )
-    .buildpacks(get_yarn_buildpacks())
-    .to_owned()
-}
-
-pub fn get_corepack_build_config(fixture: &str, builder: Builder) -> BuildConfig {
-    BuildConfig::new(
-        builder.to_string(),
-        format!("../../test/fixtures/{fixture}"),
-    )
-    .buildpacks(get_corepack_buildpacks())
-    .to_owned()
-}
-
-pub fn get_pnpm_build_config(fixture: &str, builder: Builder) -> BuildConfig {
-    BuildConfig::new(
-        builder.to_string(),
-        format!("../../test/fixtures/{fixture}"),
-    )
-    .buildpacks(get_pnpm_buildpacks())
-    .to_owned()
-}
-
-pub fn test_node_function(fixture: &str, builder: Builder, test_body: fn(TestContext)) {
-    TestRunner::default().build(get_function_invoker_build_config(fixture, builder), |ctx| {
-        test_body(ctx)
-    });
-}
-
-pub fn test_yarn_app(fixture: &str, builder: Builder, test_body: fn(TestContext)) {
-    TestRunner::default().build(get_yarn_build_config(fixture, builder), |ctx| {
-        test_body(ctx)
-    });
-}
-
-pub fn test_corepack_app(fixture: &str, builder: Builder, test_body: fn(TestContext)) {
-    TestRunner::default().build(get_corepack_build_config(fixture, builder), |ctx| {
-        test_body(ctx)
-    });
-}
-
-pub fn test_pnpm_app(fixture: &str, builder: Builder, test_body: fn(TestContext)) {
-    TestRunner::default().build(get_pnpm_build_config(fixture, builder), |ctx| {
-        test_body(ctx)
-    });
-}
-
-pub fn assert_health_check_responds(ctx: &TestContext) {
+pub fn start_container(ctx: &TestContext, in_container: impl Fn(&ContainerContext, &SocketAddr)) {
     ctx.start_container(ContainerConfig::new().expose_port(PORT), |container| {
-        std::thread::sleep(Duration::from_secs(TIMEOUT));
-
-        let addr = container.address_for_port(PORT);
-        let resp = ureq::post(&format!("http://{addr}"))
-            .set("x-health-check", "true")
-            .call()
-            .expect("request to container failed")
-            .into_string()
-            .expect("response read error");
-
-        assert_contains!(resp, "OK")
-    })
+        retry(
+            DEFAULT_RETRIES,
+            DEFAULT_RETRY_DELAY_IN_SECONDS,
+            || std::panic::catch_unwind(|| container.address_for_port(PORT)),
+            |socket_addr| in_container(&container, &socket_addr),
+            |error| std::panic::resume_unwind(error),
+        );
+    });
 }
 
-pub fn assert_web_response(ctx: &TestContext, text: &'static str) {
-    ctx.start_container(ContainerConfig::new().expose_port(PORT), |container| {
-        std::thread::sleep(Duration::from_secs(5));
+pub fn assert_web_response(ctx: &TestContext, expected_response_body: &'static str) {
+    start_container(ctx, |_container, socket_addr| {
+        retry(
+            DEFAULT_RETRIES,
+            DEFAULT_RETRY_DELAY_IN_SECONDS,
+            || ureq::get(&format!("http://{socket_addr}/")).call(),
+            |res| {
+                let response_body = res.into_string().unwrap();
+                assert_contains!(response_body, expected_response_body)
+            },
+            |error| panic!("request to assert web response failed: {error}"),
+        );
+    });
+}
 
-        let addr = container.address_for_port(PORT);
-        let resp = ureq::get(&format!("http://{addr}/"))
-            .call()
-            .expect("request to container failed")
-            .into_string()
-            .expect("response read error");
+pub fn set_node_engine(app_dir: &Path, version_range: &str) {
+    update_package_json(app_dir, |package_json| {
+        package_json
+            .entry("engines")
+            .or_insert(serde_json::Value::Object(serde_json::Map::new()))
+            .as_object_mut()
+            .unwrap()
+            .insert(
+                "node".to_string(),
+                serde_json::Value::String(version_range.to_string()),
+            );
+    });
+}
 
-        assert_contains!(resp, text);
-    })
+pub fn set_package_manager(app_dir: &Path, package_manager: &str) {
+    update_package_json(app_dir, |package_json| {
+        package_json.insert(
+            "packageManager".to_string(),
+            serde_json::Value::String(package_manager.to_string()),
+        );
+    });
+}
+
+pub fn update_package_json(
+    app_dir: &Path,
+    update: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>),
+) {
+    update_json_file(&app_dir.join("package.json"), |json| {
+        update(
+            json.as_object_mut()
+                .expect("Deserialized package.json value should be an object"),
+        )
+    });
+}
+
+pub fn update_json_file(path: &Path, update: impl FnOnce(&mut serde_json::Value)) {
+    let json_file = std::fs::read_to_string(path).unwrap();
+    let mut json: serde_json::Value = serde_json::from_str(&json_file).unwrap();
+    update(&mut json);
+    let new_contents = serde_json::to_string(&json).unwrap();
+    std::fs::write(path, new_contents).unwrap();
 }


### PR DESCRIPTION
Removes the double tests that were added in several integration suites that would explicitly run against the `20` and `22` stacks and updates the CI workflow to control this.

This also leverages `libcnb@0.15.0` to run our integration tests against the composite buildpacks (`heroku/nodejs` and `heroku/nodejs-function`) so the build order/grouping matches what the user would see instead of manually defining individual buildpacks in tests.