### PR TITLE
Fix CNB builder repo URL

### DIFF
--- a/buildpacks/nodejs-corepack/README.md
+++ b/buildpacks/nodejs-corepack/README.md
@@ -56,7 +56,7 @@ manager is installed.
 ## Usage
 
 For most users, it's simplest to build an app using [`pack`](https://buildpacks.io/docs/tools/pack/)
-and Heroku's [builder](https://github.com/builder), which includes this buildpack.
+and Heroku's [builder](https://github.com/heroku/cnb-builder-images), which includes this buildpack.
 
 ```
 pack build example-app-image --builder heroku/builder:22 --path /my/example-app


### PR DESCRIPTION
The previous link was missing the `heroku/` segment, so 404ed.

The repo has also just been renamed, in:
https://github.com/heroku/cnb-builder-images/issues/396

GUS-W-14201543.