### PR TITLE
Fix non-existent builder Docker image name

### DIFF
--- a/buildpacks/nodejs-pnpm-install/README.md
+++ b/buildpacks/nodejs-pnpm-install/README.md
@@ -99,11 +99,11 @@ command from Cloud Native Buildpacks using
 pack build example-app-image --buildpack heroku/nodejs-engine --buildpack heroku/nodejs-corepack --buildpack heroku/nodejs-pnpm-install --path /some/example-app
 ```
 
-Alternatively, use the `heroku/buildpacks:22` builder, which includes the above
+Alternatively, use the `heroku/builder:22` builder, which includes the above
 buildpacks:
 
 ```
-pack build example-app-image --builder heroku/buildpacks:22 --path /some/example-app
+pack build example-app-image --builder heroku/builder:22 --path /some/example-app
 ```
 
 ## Additional Info


### PR DESCRIPTION
There is no such builder `heroku/buildpacks:22` - the correct Docker image name is `heroku/builder:22`.

See:
https://github.com/heroku/cnb-builder-images/blob/main/README.md
https://hub.docker.com/r/heroku/builder/tags