### PR TITLE
Update buildpack metadata in buildpack.toml

### DIFF
--- a/buildpacks/nodejs-corepack/CHANGELOG.md
+++ b/buildpacks/nodejs-corepack/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add support for using corepack to install npm ([#685](https://github.com/heroku/buildpacks-nodejs/pull/685))
+### Added
+
+- Added support for using corepack to install npm. ([#685](https://github.com/heroku/buildpacks-nodejs/pull/685))
+
+### Changed
+
+- Updated buildpack description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
 
 ## [1.1.7] - 2023-10-17
 

--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -5,7 +5,8 @@ id = "heroku/nodejs-corepack"
 version = "1.1.7"
 name = "Heroku Node.js Corepack"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
-keywords = ["corepack", "node", "node.js", "nodejs", "javascript", "js"]
+description = "Heroku's Node.js Corepack buildpack. A component of the 'heroku/nodejs' buildpack."
+keywords = ["corepack", "heroku"]
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -19,7 +20,5 @@ id = "heroku-22"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs-corepack"
+image = { repository = "docker.io/heroku/buildpack-nodejs-corepack" }

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Added Node.js version 21.0.0.
+
+### Changed
+
+- Updated buildpack description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+
 ## [1.1.7] - 2023-10-17
 
 - Added Node.js version 20.8.1.

--- a/buildpacks/nodejs-engine/buildpack.toml
+++ b/buildpacks/nodejs-engine/buildpack.toml
@@ -5,7 +5,8 @@ id = "heroku/nodejs-engine"
 version = "1.1.7"
 name = "Heroku Node.js Engine"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
-keywords = ["node", "node.js", "nodejs", "javascript", "js"]
+description = "Heroku's Node.js engine buildpack. A component of the 'heroku/nodejs' buildpack."
+keywords = ["node.js", "nodejs", "heroku"]
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -19,7 +20,5 @@ id = "heroku-22"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs-engine"
+image = { repository = "docker.io/heroku/buildpack-nodejs-engine" }

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+
 ## [1.1.7] - 2023-10-17
 
 - No changes.

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -3,9 +3,9 @@ api = "0.9"
 [buildpack]
 id = "heroku/nodejs-function-invoker"
 version = "1.1.7"
-name = "Heroku Node.js Function Invoker"
+name = "Salesforce Node.js Function Invoker"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
-keywords = ["nodejs", "node", "node.js", "javascript", "js", "function"]
+description = "Salesforce's Node.js function invoker buildpack. A component of the 'heroku/nodejs-function' buildpack."
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -13,11 +13,9 @@ type = "MIT"
 [[stacks]]
 id = "heroku-22"
 
-[metadata]
 [metadata.runtime]
 package_name = "@heroku/sf-fx-runtime-nodejs"
 package_version = "0.14.1"
 
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs-function-invoker"
+image = { repository = "docker.io/heroku/buildpack-nodejs-function-invoker" }

--- a/buildpacks/nodejs-npm-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-engine/CHANGELOG.md
@@ -7,5 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added npm version 10.2.1.
+### Added
+
 - Initial release

--- a/buildpacks/nodejs-npm-engine/buildpack.toml
+++ b/buildpacks/nodejs-npm-engine/buildpack.toml
@@ -3,9 +3,10 @@ api = "0.9"
 [buildpack]
 id = "heroku/nodejs-npm-engine"
 version = "1.1.7"
-name = "Heroku Node.js npm Engine Buildpack"
+name = "Heroku Node.js npm Engine"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
-keywords = ["node", "node.js", "nodejs", "javascript", "js", "npm", "engine"]
+description = "Heroku's Node.js npm engine buildpack. A component of the 'heroku/nodejs' buildpack."
+keywords = ["npm", "heroku"]
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -22,7 +23,5 @@ id = "heroku-22"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
 [metadata.release]
-[metadata.release.docker]
-repository = "docker.io/heroku/buildpack-nodejs-npm-engine"
+image = { repository = "docker.io/heroku/buildpack-nodejs-npm-engine" }

--- a/buildpacks/nodejs-npm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-install/CHANGELOG.md
@@ -10,4 +10,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
- 

--- a/buildpacks/nodejs-npm-install/buildpack.toml
+++ b/buildpacks/nodejs-npm-install/buildpack.toml
@@ -3,9 +3,10 @@ api = "0.9"
 [buildpack]
 id = "heroku/nodejs-npm-install"
 version = "1.1.7"
-name = "Heroku Node.js npm Install Buildpack"
+name = "Heroku Node.js npm Install"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
-keywords = ["node", "node.js", "nodejs", "javascript", "js", "npm", "install"]
+description = "Heroku's Node.js npm install buildpack. A component of the 'heroku/nodejs' buildpack."
+keywords = ["npm", "heroku"]
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -13,7 +14,5 @@ type = "MIT"
 [[stacks]]
 id = "*"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs-npm-install"
+image = { repository = "docker.io/heroku/buildpack-nodejs-npm-install" }

--- a/buildpacks/nodejs-pnpm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-install/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+
 ## [1.1.7] - 2023-10-17
 
 - No changes.

--- a/buildpacks/nodejs-pnpm-install/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-install/buildpack.toml
@@ -5,7 +5,8 @@ id = "heroku/nodejs-pnpm-install"
 version = "1.1.7"
 name = "Heroku Node.js pnpm install"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
-keywords = ["node", "node.js", "nodejs", "javascript", "js", "pnpm"]
+description = "Heroku's Node.js pnpm install buildpack. A component of the 'heroku/nodejs' buildpack."
+keywords = ["pnpm", "heroku"]
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -22,7 +23,5 @@ id = "heroku-22"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs-pnpm-install"
+image = { repository = "docker.io/heroku/buildpack-nodejs-pnpm-install" }

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+
 ## [1.1.7] - 2023-10-17
 
 - Added Yarn version 4.0.0-rc.53.

--- a/buildpacks/nodejs-yarn/buildpack.toml
+++ b/buildpacks/nodejs-yarn/buildpack.toml
@@ -5,7 +5,8 @@ id = "heroku/nodejs-yarn"
 version = "1.1.7"
 name = "Heroku Node.js Yarn"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
-keywords = ["node", "node.js", "nodejs", "javascript", "js", "yarn", "yarnpkg"]
+description = "Heroku's Node.js Yarn buildpack. A component of the 'heroku/nodejs' buildpack."
+keywords = ["yarn", "heroku"]
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -22,7 +23,5 @@ id = "heroku-22"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs-yarn"
+image = { repository = "docker.io/heroku/buildpack-nodejs-yarn" }

--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+
 ## [1.1.7] - 2023-10-17
 
 - No changes.

--- a/buildpacks/npm/buildpack.toml
+++ b/buildpacks/npm/buildpack.toml
@@ -3,9 +3,9 @@ api = "0.6"
 [buildpack]
 id = "heroku/nodejs-npm"
 version = "1.1.7"
-name = "NPM Buildpack"
+name = "Heroku Node.js npm (DEPRECATED)"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
-keywords = ["nodejs", "node", "npm"]
+description = "[DEPRECATED] Heroku's Node.js npm buildpack. Replaced by the 'heroku/nodejs-npm-engine' and 'heroku/nodejs-npm-install' buildpacks."
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -22,7 +22,5 @@ id = "heroku-22"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs-npm"
+image = { repository = "docker.io/heroku/buildpack-nodejs-npm" }

--- a/meta-buildpacks/nodejs-function/CHANGELOG.md
+++ b/meta-buildpacks/nodejs-function/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name and description. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+
 ## [1.1.7] - 2023-10-17
 
 ### Changed

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -3,8 +3,9 @@ api = "0.9"
 [buildpack]
 id = "heroku/nodejs-function"
 version = "1.1.7"
-name = "Node.js Function"
+name = "Salesforce Node.js Function"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
+description = "Salesforce's buildpack for Node.js Functions."
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -23,7 +24,5 @@ version = "1.1.7"
 id = "heroku/nodejs-function-invoker"
 version = "1.1.7"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs-function"
+image = { repository = "docker.io/heroku/buildpack-nodejs-function" }

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+
 ## [1.1.7] - 2023-10-17
 
 ### Changed

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -3,8 +3,10 @@ api = "0.9"
 [buildpack]
 id = "heroku/nodejs"
 version = "1.1.7"
-name = "Node.js"
+name = "Heroku Node.js"
 homepage = "https://github.com/heroku/buildpacks-nodejs"
+description = "Heroku's buildpack for Node.js applications."
+keywords = ["node.js", "nodejs", "javascript", "npm", "yarn", "pnpm", "heroku"]
 
 [[buildpack.licenses]]
 type = "MIT"
@@ -73,7 +75,5 @@ id = "heroku/procfile"
 version = "2.0.1"
 optional = true
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-nodejs"
+image = { repository = "docker.io/heroku/buildpack-nodejs" }


### PR DESCRIPTION
Adjusts the buildpack `name`, `description` and `keywords` in the `buildpack.toml` of all buildpacks to match the style discussed in:
https://github.com/heroku/cnb-builder-images/issues/408

These fields are used by the CNB registry and can also be seen in the output of `pack builder inspect`. They are not used by `pack build` or Kodon. In addition to standardising the metadata, one of the objectives here is to ensure users don't accidentally use component buildpacks when they really wanted the composite buildpack.

The `keywords` field has intentionally been omitted from the functions buildpacks since they are EOL and so don't want to be made more discoverable. (The CNB registry doesn't currently ingest/display the keywords currently, but may in the future.)

In addition, I've marked the older Bash based npm buildpack as deprecated, to try and ensure users don't pick that over the newer buildpacks when browsing the CNB registry (we'll need to publish it one more time before it's deleted from this repo).

Lastly, I've cleaned up the `[metadata]` table/subtables to match the concise style used by the Procfile and Python CNBs.

GUS-W-14121598.