### PR TITLE
Remove `heroku/procfile` from `heroku/nodejs`

### DIFF
--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated buildpack display name, description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
 
+### Removed
+
+- Removed `heroku/procfile`, since it's being added directly to the Heroku builder images instead. If you override the Heroku builder images' default buildpack detection order (or use this buildpack with a non-Heroku builder image), you will need to append `heroku/procfile` to your buildpacks list. ([#696](https://github.com/heroku/buildpacks-node/pull/696))
+
 ## [1.1.7] - 2023-10-17
 
 ### Changed

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -25,11 +25,6 @@ version = "1.1.7"
 id = "heroku/nodejs-pnpm-install"
 version = "1.1.7"
 
-[[order.group]]
-id = "heroku/procfile"
-version = "2.0.1"
-optional = true
-
 [[order]]
 
 [[order.group]]
@@ -44,11 +39,6 @@ optional = true
 [[order.group]]
 id = "heroku/nodejs-yarn"
 version = "1.1.7"
-
-[[order.group]]
-id = "heroku/procfile"
-version = "2.0.1"
-optional = true
 
 [[order]]
 
@@ -69,11 +59,6 @@ optional = true
 [[order.group]]
 id = "heroku/nodejs-npm-install"
 version = "1.1.7"
-
-[[order.group]]
-id = "heroku/procfile"
-version = "2.0.1"
-optional = true
 
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs" }

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -18,6 +18,3 @@ uri = "libcnb:heroku/nodejs-yarn"
 
 [[dependencies]]
 uri = "libcnb:heroku/nodejs-corepack"
-
-[[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"


### PR DESCRIPTION
Previously the `heroku/procfile` buildpack was included within the `heroku/nodejs` composite buildpack.

Whilst this is convenient (it saves having to add the Procfile CNB manually), this approach has a number of issues:
- If an app uses multiple languages (eg `heroku/nodejs` and `heroku/java`), the Procfile CNB will end up being run multiple times, and potentially with different versions of the Procfile buildpack.
- It means multiple places need updating after Procfile CNB releases, and means the builder image can end up containing several different versions of the Procfile buildpack.

After this change, the `heroku/procfile` CNB is no longer included in the `heroku/nodejs` composite buildpack, and instead will be included in the Heroku builder image order grouping (added in the PR that releases this change into the builder).

This matches the approach already used by the Go, Python, PHP and Ruby buildpacks (and shortly, the Java + Scala buildpacks).

Any app that sets a custom buildpack order in their `project.toml` (rather than relying on the default buildpack order in the Heroku builder image), or uses a non-Heroku builder (that does not similarly choose to add the Procfile to the builder) will need to explicitly add the `heroku/procfile` buildpack to the end of the buildpacks list in their `project.toml`.

**Since this is a breaking change, the buildpack major version number should be bumped for release.**

GUS-W-14356138.