### PR TITLE
Added missing changelog entries for npm buildpacks

### DIFF
--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `heroku/nodejs-npm-engine` to the buildpack group for npm support ([#623](https://github.com/heroku/buildpacks-nodejs/pull/623))
+- Added `heroku/nodejs-npm-install` to the buildpack group for npm support ([#625](https://github.com/heroku/buildpacks-nodejs/pull/625))
+- Added `heroku/nodejs-corepack` to the buildpack group for npm support ([#685](https://github.com/heroku/buildpacks-nodejs/pull/685))
+
 ### Changed
 
 - Updated buildpack display name, description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+- 
+### Removed
+
+- Removed the deprecated `heroku/nodejs-npm` from the buildpack group for npm support ([#625](https://github.com/heroku/buildpacks-nodejs/pull/625))
 
 ## [1.1.7] - 2023-10-17
 

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated buildpack display name, description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
-- 
 ### Removed
 
 - Removed the deprecated `heroku/nodejs-npm` from the buildpack group for npm support ([#625](https://github.com/heroku/buildpacks-nodejs/pull/625))

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -16,12 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated buildpack display name, description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))
+
 ### Removed
 
 - Removed the deprecated `heroku/nodejs-npm` from the buildpack group for npm support ([#625](https://github.com/heroku/buildpacks-nodejs/pull/625))
-
-### Removed
-
 - Removed `heroku/procfile`, since it's being added directly to the Heroku builder images instead. If you override the Heroku builder images' default buildpack detection order (or use this buildpack with a non-Heroku builder image), you will need to append `heroku/procfile` to your buildpacks list. ([#696](https://github.com/heroku/buildpacks-node/pull/696))
 
 ## [1.1.7] - 2023-10-17


### PR DESCRIPTION
The composite buildpack `heroku/nodejs` should have had entries added for the new npm buildpacks merged in PRs:
- #623
- #625
- #685