### PR TITLE
Remove yarn 4.0.0 from inventory

### DIFF
--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added Yarn version 4.0.0.
 ### Changed
 
 - Updated buildpack description and keywords. ([#692](https://github.com/heroku/buildpacks-nodejs/pull/692))

--- a/buildpacks/nodejs-yarn/inventory.toml
+++ b/buildpacks/nodejs-yarn/inventory.toml
@@ -960,9 +960,3 @@ channel = "release"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0-rc.53.tar.gz"
 etag = "c0d6abdde92df88fc17e0bf8ef57b9a3"
 
-[[releases]]
-version = "4.0.0"
-channel = "release"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0.tar.gz"
-etag = "4b6a1f8a77263f5abf02843147aed885"
-


### PR DESCRIPTION
This reverts commit 64ec7dbe296d21dc937e68d38b8b3f4e2cef7c7b (#691).

In my own testing, yarn 4 builds aren't working properly. Example failure: https://github.com/heroku/buildpacks-nodejs/actions/runs/6629679100/job/18009505103?pr=698. I think this is because yarn 4 defaults `enableGlobalCache` to `true`.