### PR TITLE
Set explicit `resolver` version in workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "buildpacks/nodejs-engine",
   "buildpacks/nodejs-corepack",


### PR DESCRIPTION
To resolve (pun intended) this Cargo resolver version deprecation warning:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Fixes #701.