### PR TITLE
Update default Node version to 20.x

### DIFF
--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update default node version to 20.x
+
 ## [2.2.0] - 2023-10-26
 
 - No changes.

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update default node version to 20.x
+- Updated default node version to 20.x
 
 ## [2.2.0] - 2023-10-26
 

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -30,6 +30,8 @@ mod layers;
 
 const INVENTORY: &str = include_str!("../inventory.toml");
 
+const LTS_VERSION: &str = "20.x";
+
 pub struct NodeJsEngineBuildpack;
 
 impl Buildpack for NodeJsEngineBuildpack {
@@ -70,13 +72,16 @@ impl Buildpack for NodeJsEngineBuildpack {
         let inv: Inventory =
             toml::from_str(INVENTORY).map_err(NodeJsEngineBuildpackError::InventoryParseError)?;
 
+        let default_version =
+            Requirement::parse(LTS_VERSION).expect("The default Node.js version should be valid");
+
         let version_range = PackageJson::read(context.app_dir.join("package.json"))
             .map_err(NodeJsEngineBuildpackError::PackageJsonError)
             .map(|package_json| {
                 package_json
                     .engines
                     .and_then(|e| e.node)
-                    .unwrap_or_else(Requirement::any)
+                    .unwrap_or(default_version)
             })?;
         let version_range_string = version_range.to_string();
 

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -10,10 +10,7 @@ use test_support::{
 #[ignore]
 fn simple_indexjs() {
     nodejs_integration_test("./fixtures/node-with-indexjs", |ctx| {
-        assert_contains!(
-            ctx.pack_stdout,
-            "Detected Node.js version range: >=20.0.0 <21.0.0-0"
-        );
+        assert_contains!(ctx.pack_stdout, "Node.js version not specified, using 20.x");
         assert_contains!(ctx.pack_stdout, "Installing Node.js");
         assert_web_response(&ctx, "node-with-indexjs");
     });
@@ -23,6 +20,7 @@ fn simple_indexjs() {
 #[ignore]
 fn simple_serverjs() {
     nodejs_integration_test("./fixtures/node-with-serverjs", |ctx| {
+        assert_contains!(ctx.pack_stdout, "Detected Node.js version range: 16.0.0");
         assert_contains!(ctx.pack_stdout, "Installing Node.js 16.0.0");
         assert_web_response(&ctx, "node-with-serverjs");
     });

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -10,7 +10,10 @@ use test_support::{
 #[ignore]
 fn simple_indexjs() {
     nodejs_integration_test("./fixtures/node-with-indexjs", |ctx| {
-        assert_contains!(ctx.pack_stdout, "Detected Node.js version range: *");
+        assert_contains!(
+            ctx.pack_stdout,
+            "Detected Node.js version range: >=20.0.0 <21.0.0-0"
+        );
         assert_contains!(ctx.pack_stdout, "Installing Node.js");
         assert_web_response(&ctx, "node-with-indexjs");
     });


### PR DESCRIPTION
As of [2023-10-24](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-10-24-version-2090-iron-lts-richardlau), Node.js 20.x is now the LTS version.  Previously, this buildpack would default to the latest known Node.js release if one was not provided. Now it will default to the latest Active LTS version.

[W-14390764](https://gus.lightning.force.com/lightning/r/a07EE00001dS3sgYAC/view)