### PR TITLE
Update the legacy NPM buildpack to Buildpack API 0.7

### DIFF
--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- This buildpack now implements Buildpack API 0.7 instead of 0.6. ([#721](https://github.com/heroku/buildpacks-nodejs/pull/721))
+
 ## [2.3.0] - 2023-11-09
 
 - No changes.

--- a/buildpacks/npm/buildpack.toml
+++ b/buildpacks/npm/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.7"
 
 [buildpack]
 id = "heroku/nodejs-npm"


### PR DESCRIPTION
Since Buildpack API 0.6 has been deprecated for some time, and is no longer supported by newer versions  of `lifecycle`, which is causing CI to fail since the integration tests in this repo use `heroku/builder:22`, which has just had its lifecycle version upgraded:
https://github.com/heroku/cnb-builder-images/pull/431

These CI failures are not reflective of production (which is working fine), since Functions in production are actually run via the functions builder image (and not `heroku/builder:22`), which was intentionally left on the old lifecycle version. However, this functions builder image is not available on Docker Hub, so can't be used by the integration tests in this repo.

Improving parity of the integration tests here might be worth considering longer term, however, upgrading the Buildpack API version was a simpler (and arguably correct thing to do regardless) step for now.

There are no breaking changes that affect this buildpack in the new API version, so no buildpack changes were required:
https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.7

Fixes #720.
GUS-W-14493124.