### PR TITLE
Switch away from workspace-defined dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,22 +19,8 @@ edition = "2021"
 publish = false
 
 [workspace.dependencies]
-commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 heroku-nodejs-utils = { path = "./common/nodejs-utils" }
-indoc = "2"
-# libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
-# so it's pinned to an exact version to isolate it from lockfile refreshes.
-libcnb-test = "=0.15.0"
-libcnb = "=0.15.0"
-libherokubuildpack = "=0.15.0"
-opentelemetry = "0.20.0"
-serde = "1"
-serde_json = "1"
 test_support = { path = "./test_support" }
-tempfile = "3"
-thiserror = "1"
-toml = "0.8"
-ureq = "2"
 
 [profile.release]
 strip = true

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -8,14 +8,14 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb.workspace = true
-libherokubuildpack.workspace = true
-opentelemetry.workspace = true
-serde.workspace = true
-thiserror.workspace = true
-indoc.workspace = true
+indoc = "2"
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+opentelemetry = "0.20.0"
+serde = "1"
+thiserror = "1"
 
 [dev-dependencies]
-libcnb-test.workspace = true
+libcnb-test = "=0.15.0"
 test_support.workspace = true
-ureq.workspace = true
+ureq = "2"

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -8,15 +8,15 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb.workspace = true
-libherokubuildpack.workspace = true
-serde.workspace = true
-tempfile.workspace = true
-toml.workspace = true
-thiserror.workspace = true
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+serde = "1"
+tempfile = "3"
+thiserror = "1"
+toml = "0.8"
 
 [dev-dependencies]
-libcnb-test.workspace = true
+libcnb-test = "=0.15.0"
+serde_json = "1"
 test_support.workspace = true
-serde_json.workspace = true
-ureq.workspace = true
+ureq = "2"

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -8,18 +8,18 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb.workspace = true
-libherokubuildpack.workspace = true
-serde.workspace = true
-thiserror.workspace = true
-toml.workspace = true
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+serde = "1"
+thiserror = "1"
+toml = "0.8"
 
 [dev-dependencies]
 base64 = "0.21"
 hex = "0.4"
-libcnb-test.workspace = true
+libcnb-test = "=0.15.0"
 rand = "0.8"
-serde_json.workspace = true
-tempfile.workspace = true
+serde_json = "1"
+tempfile = "3"
 test_support.workspace = true
-ureq.workspace = true
+ureq = "2"

--- a/buildpacks/nodejs-npm-engine/Cargo.toml
+++ b/buildpacks/nodejs-npm-engine/Cargo.toml
@@ -7,17 +7,17 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-commons.workspace = true
+commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 fun_run = "0.1"
 heroku-nodejs-utils.workspace = true
-libcnb.workspace = true
-libherokubuildpack.workspace = true
-serde.workspace = true
-indoc.workspace = true
-tempfile.workspace = true
-toml.workspace = true
+indoc = "2"
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+serde = "1"
+tempfile = "3"
+toml = "0.8"
 
 [dev-dependencies]
-libcnb-test.workspace = true
-serde_json.workspace = true
+libcnb-test = "=0.15.0"
+serde_json = "1"
 test_support.workspace = true

--- a/buildpacks/nodejs-npm-install/Cargo.toml
+++ b/buildpacks/nodejs-npm-install/Cargo.toml
@@ -7,17 +7,17 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-commons.workspace = true
+commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 fun_run = "0.1"
 heroku-nodejs-utils.workspace = true
-libcnb.workspace = true
-libherokubuildpack.workspace = true
-serde.workspace = true
-indoc.workspace = true
-toml.workspace = true
+indoc = "2"
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+serde = "1"
+toml = "0.8"
 
 [dev-dependencies]
-libcnb-test.workspace = true
-serde_json.workspace = true
+libcnb-test = "=0.15.0"
+serde_json = "1"
 test_support.workspace = true
-ureq.workspace = true
+ureq = "2"

--- a/buildpacks/nodejs-pnpm-install/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-install/Cargo.toml
@@ -8,13 +8,13 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb.workspace = true
-libherokubuildpack.workspace = true
-serde.workspace = true
-indoc.workspace = true
-toml.workspace = true
+indoc = "2"
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+serde = "1"
+toml = "0.8"
 
 [dev-dependencies]
-libcnb-test.workspace = true
+libcnb-test = "=0.15.0"
 test_support.workspace = true
-ureq.workspace = true
+ureq = "2"

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -8,14 +8,14 @@ publish.workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb.workspace = true
-libherokubuildpack.workspace = true
-serde.workspace = true
-thiserror.workspace = true
-tempfile.workspace = true
-toml.workspace = true
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+serde = "1"
+tempfile = "3"
+thiserror = "1"
+toml = "0.8"
 
 [dev-dependencies]
-libcnb-test.workspace = true
+libcnb-test = "=0.15.0"
 test_support.workspace = true
-ureq.workspace = true
+ureq = "2"

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -9,20 +9,20 @@ publish.workspace = true
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
-commons.workspace = true
-indoc.workspace = true
+commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
+indoc = "2"
 node-semver = "2"
-regex = "1"
-serde = { workspace = true, features = ['derive'] }
-serde_json.workspace = true
-serde-xml-rs = "0.6"
-thiserror.workspace = true
-toml.workspace = true
-ureq = { workspace = true, features = ["json"] }
-url = "2"
-opentelemetry.workspace = true
-opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
+opentelemetry = "0.20.0"
 opentelemetry_sdk = { version = "0.20.0", features = ["trace"] }
+opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
+regex = "1"
+serde = { version = "1", features = ['derive'] }
+serde_json = "1"
+serde-xml-rs = "0.6"
+thiserror = "1"
+toml = "0.8"
+ureq = { version = "2", features = ["json"] }
+url = "2"
 
 [dev-dependencies]
-tempfile.workspace = true
+tempfile = "3"

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-libcnb.workspace = true
-libcnb-test.workspace = true
-serde_json.workspace = true
-tempfile.workspace = true
-ureq.workspace = true
+libcnb = "=0.15.0"
+libcnb-test = "=0.15.0"
+serde_json = "1"
+tempfile = "3"
+ureq = "2"


### PR DESCRIPTION
Both Dependabot and `cargo-edit`'s `cargo upgrade` don't seem to handle dependencies being specified in the Cargo workspace `Cargo.toml` and inherited by individual crates very well.

As such, this switches back to specifying those dependencies explicitly in each crate. Dependabot always updates dependencies across all crates, so they will still stay in sync.

This will unblock Dependabot being able to open a PR for libcnb 0.16.0.

See also:
https://github.com/heroku/buildpacks-jvm/pull/614

I've left the local shared crate dependencies as workspace-defined, since Dependabot or `cargo-edit` doesn't need to update those, since they are path-only dependencies.

Lastly, the lists of dependencies have been sorted alphabetically.

GUS-W-14513796.