### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,6 @@ dependencies = [
  "libherokubuildpack",
  "serde",
  "serde_json",
- "tempfile",
  "test_support",
  "toml",
 ]
@@ -661,12 +660,9 @@ dependencies = [
  "indoc",
  "libcnb",
  "libcnb-test",
- "libherokubuildpack",
  "serde",
  "serde_json",
  "test_support",
- "toml",
- "ureq",
 ]
 
 [[package]]
@@ -1393,7 +1389,6 @@ dependencies = [
  "libcnb",
  "libcnb-test",
  "serde_json",
- "tempfile",
  "ureq",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,18 @@ members = [
 
 [workspace.package]
 version = "0.0.0"
-rust-version = "1.67"
+rust-version = "1.74"
 edition = "2021"
 publish = false
+
+[workspace.lints.rust]
+unused_crate_dependencies = "warn"
+
+[workspace.lints.clippy]
+pedantic = "warn"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
 
 [workspace.dependencies]
 heroku-nodejs-utils = { path = "./common/nodejs-utils" }

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 heroku-nodejs-utils.workspace = true
 indoc = "2"

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -1,8 +1,3 @@
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::module_name_repetitions)]
-
 use heroku_nodejs_utils::package_json::{PackageJson, PackageJsonError};
 use heroku_nodejs_utils::telemetry::init_tracer;
 use layers::{ManagerLayer, ShimLayer};

--- a/buildpacks/nodejs-corepack/tests/integration_test.rs
+++ b/buildpacks/nodejs-corepack/tests/integration_test.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb_test::assert_contains;
 use test_support::{nodejs_integration_test_with_config, set_package_manager};

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 heroku-nodejs-utils.workspace = true
 libcnb = "=0.16.0"

--- a/buildpacks/nodejs-engine/src/bin/web_env.rs
+++ b/buildpacks/nodejs-engine/src/bin/web_env.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb::data::exec_d::ExecDProgramOutputKey;
 use libcnb::data::exec_d_program_output_key;

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -1,8 +1,3 @@
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::module_name_repetitions)]
-
 use crate::layers::{DistLayer, DistLayerError, WebEnvLayer};
 use heroku_nodejs_utils::inv::Inventory;
 use heroku_nodejs_utils::package_json::{PackageJson, PackageJsonError};

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb_test::assert_contains;
 use test_support::{

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 heroku-nodejs-utils.workspace = true
 libcnb = "=0.16.0"

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -1,8 +1,3 @@
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::module_name_repetitions)]
-
 use crate::function::{
     get_declared_runtime_package_version, get_main, is_function, ExplicitRuntimeDependencyError,
     MainError,

--- a/buildpacks/nodejs-function-invoker/tests/integration_test.rs
+++ b/buildpacks/nodejs-function-invoker/tests/integration_test.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use base64::Engine;
 use libcnb_test::{assert_contains, assert_not_contains, TestContext};

--- a/buildpacks/nodejs-npm-engine/Cargo.toml
+++ b/buildpacks/nodejs-npm-engine/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 fun_run = "0.1"
@@ -14,7 +17,6 @@ indoc = "2"
 libcnb = "=0.16.0"
 libherokubuildpack = "=0.16.0"
 serde = "1"
-tempfile = "3"
 toml = "0.8"
 
 [dev-dependencies]

--- a/buildpacks/nodejs-npm-engine/src/layers/npm_engine.rs
+++ b/buildpacks/nodejs-npm-engine/src/layers/npm_engine.rs
@@ -2,7 +2,7 @@ use crate::errors::NpmEngineBuildpackError;
 use crate::NpmEngineBuildpack;
 use commons::output::fmt;
 use commons::output::section_log::{log_step, log_step_timed, SectionLogger};
-use fun_run::CommandWithName;
+use fun_run::{CommandWithName, NamedOutput};
 use heroku_nodejs_utils::inv::Release;
 use heroku_nodejs_utils::vrs::Version;
 use libcnb::build::BuildContext;
@@ -84,7 +84,7 @@ fn download_and_unpack_release(
     log_step_timed(format!("Downloading {}", fmt::value(download_from)), || {
         download_file(download_from, download_to)
             .map_err(NpmEngineLayerError::Download)
-            .and_then(|_| File::open(download_to).map_err(NpmEngineLayerError::OpenTarball))
+            .and_then(|()| File::open(download_to).map_err(NpmEngineLayerError::OpenTarball))
             .and_then(|mut npm_tgz_file| {
                 decompress_tarball(&mut npm_tgz_file, unpack_into)
                     .map_err(NpmEngineLayerError::DecompressTarball)
@@ -103,7 +103,7 @@ fn remove_existing_npm_installation(npm_cli_script: &Path) -> Result<(), NpmEngi
             "--loglevel=silent",
         ])
         .named_output()
-        .and_then(|cmd| cmd.nonzero_captured())
+        .and_then(NamedOutput::nonzero_captured)
         .map_err(NpmEngineLayerError::RemoveExistingNpmInstall)
         .map(|_| ())
 }
@@ -118,7 +118,7 @@ fn install_npm_package(npm_cli_script: &Path, package: &Path) -> Result<(), NpmE
             &package.to_string_lossy(),
         ])
         .named_output()
-        .and_then(|cmd| cmd.nonzero_captured())
+        .and_then(NamedOutput::nonzero_captured)
         .map_err(NpmEngineLayerError::InstallNpm)
         .map(|_| ())
 }

--- a/buildpacks/nodejs-npm-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-npm-engine/tests/integration_test.rs
@@ -1,3 +1,6 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use libcnb_test::assert_contains;
 use std::fs;
 use std::path::Path;
@@ -30,7 +33,7 @@ fn test_npm_engine_caching() {
         ctx.rebuild(config, |ctx| {
             assert_contains!(ctx.pack_stdout, "Using cached npm");
             assert_contains!(ctx.pack_stdout, "Successfully installed `npm@9.6.6`");
-        })
+        });
     });
 }
 

--- a/buildpacks/nodejs-npm-install/Cargo.toml
+++ b/buildpacks/nodejs-npm-install/Cargo.toml
@@ -6,18 +6,18 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 fun_run = "0.1"
 heroku-nodejs-utils.workspace = true
 indoc = "2"
 libcnb = "=0.16.0"
-libherokubuildpack = "=0.16.0"
 serde = "1"
-toml = "0.8"
 
 [dev-dependencies]
 libcnb-test = "=0.16.0"
 serde_json = "1"
 test_support.workspace = true
-ureq = "2"

--- a/buildpacks/nodejs-npm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-npm-install/tests/integration_test.rs
@@ -1,3 +1,6 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use libcnb_test::{assert_contains, assert_not_contains, PackResult};
 use serde_json::json;
 use std::path::Path;
@@ -37,7 +40,7 @@ fn test_npm_install_caching() {
         ctx.rebuild(config, |ctx| {
             assert_contains!(ctx.pack_stdout, "- Restoring npm cache");
             assert_contains!(ctx.pack_stdout, "added 4 packages");
-        })
+        });
     });
 }
 

--- a/buildpacks/nodejs-pnpm-install/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-install/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 heroku-nodejs-utils.workspace = true
 indoc = "2"

--- a/buildpacks/nodejs-pnpm-install/src/main.rs
+++ b/buildpacks/nodejs-pnpm-install/src/main.rs
@@ -1,6 +1,3 @@
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
 use heroku_nodejs_utils::package_json::{PackageJson, PackageJsonError};
 use layers::{AddressableStoreLayer, VirtualStoreLayer};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};

--- a/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use indoc::formatdoc;
 use libcnb_test::{assert_contains, assert_empty};

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 heroku-nodejs-utils.workspace = true
 libcnb = "=0.16.0"

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -1,8 +1,3 @@
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::module_name_repetitions)]
-
 use crate::layers::{CliLayer, CliLayerError, DepsLayer, DepsLayerError};
 use crate::yarn::Yarn;
 use heroku_nodejs_utils::inv::Inventory;

--- a/buildpacks/nodejs-yarn/tests/integration_test.rs
+++ b/buildpacks/nodejs-yarn/tests/integration_test.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb_test::{assert_contains, assert_not_contains};
 use test_support::{assert_web_response, nodejs_integration_test};

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/common/nodejs-utils/src/bin/diff_versions.rs
+++ b/common/nodejs-utils/src/bin/diff_versions.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use heroku_nodejs_utils::vrs::Version;
 use heroku_nodejs_utils::{

--- a/common/nodejs-utils/src/bin/generate_inventory.rs
+++ b/common/nodejs-utils/src/bin/generate_inventory.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use heroku_nodejs_utils::{distribution::Distribution, distribution::DEFAULT_BUCKET};
 

--- a/common/nodejs-utils/src/bin/list_unmirrored_versions.rs
+++ b/common/nodejs-utils/src/bin/list_unmirrored_versions.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use heroku_nodejs_utils::{
     distribution::{Distribution, DEFAULT_BUCKET},

--- a/common/nodejs-utils/src/bin/resolve_version.rs
+++ b/common/nodejs-utils/src/bin/resolve_version.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use heroku_nodejs_utils::{inv::Inventory, vrs::Requirement};
 

--- a/common/nodejs-utils/src/lib.rs
+++ b/common/nodejs-utils/src/lib.rs
@@ -1,8 +1,3 @@
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::module_name_repetitions)]
-
 pub mod application;
 pub mod distribution;
 pub mod inv;

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -6,9 +6,11 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 libcnb = "=0.16.0"
 libcnb-test = "=0.16.0"
 serde_json = "1"
-tempfile = "3"
 ureq = "2"

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -12,6 +12,7 @@ pub const PORT: u16 = 8080;
 pub const DEFAULT_RETRIES: u32 = 10;
 pub const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 
+#[must_use]
 pub fn get_integration_test_builder() -> String {
     std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap_or(DEFAULT_BUILDER.to_string())
 }
@@ -166,7 +167,7 @@ pub fn update_package_json(
         update(
             json.as_object_mut()
                 .expect("Deserialized package.json value should be an object"),
-        )
+        );
     });
 }
 


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in `Cargo.toml` across whole crates/workspaces:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section
https://doc.rust-lang.org/stable/cargo/reference/workspaces.html#the-lints-table

This reduces the boilerplate, and the chance that we forget to enable lints in some targets. The only thing we need to remember is to add the `[lints] workspace = true` to any new crates in the future.

Making this switch exposed a few places where lints weren't enabled and issues had been missed, which have been fixed now.

Since this feature requires Rust 1.74, the MSRV has also been bumped (however, libcnb 0.16.0 already requires Rust 1.74, so in practice this is a no-op).

GUS-W-14523836.