### PR TITLE
Enable additional rustc and Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,15 @@ edition = "2021"
 publish = false
 
 [workspace.lints.rust]
+unreachable_pub = "warn"
+unsafe_code = "warn"
 unused_crate_dependencies = "warn"
 
 [workspace.lints.clippy]
+panic_in_result_fn = "warn"
 pedantic = "warn"
+unwrap_used = "warn"
+enum_variant_names = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -25,7 +25,7 @@ mod cmd;
 mod errors;
 mod layers;
 
-pub(crate) struct CorepackBuildpack;
+struct CorepackBuildpack;
 
 impl Buildpack for CorepackBuildpack {
     type Platform = GenericPlatform;
@@ -113,7 +113,7 @@ impl Buildpack for CorepackBuildpack {
 }
 
 #[derive(Debug)]
-pub(crate) enum CorepackBuildpackError {
+enum CorepackBuildpackError {
     PackageManagerMissing,
     PackageJson(PackageJsonError),
     ShimLayer(std::io::Error),

--- a/buildpacks/nodejs-engine/src/bin/web_env.rs
+++ b/buildpacks/nodejs-engine/src/bin/web_env.rs
@@ -13,7 +13,7 @@ const MAX_AVAILABLE_MEMORY_MB: usize = 14336;
 const DEFAULT_AVAILABLE_MEMORY_MB: usize = 512;
 const DEFAULT_WEB_MEMORY_MB: usize = 512;
 
-pub fn main() {
+fn main() {
     write_exec_d_program_output(web_env(read_env("WEB_CONCURRENCY"), read_env("WEB_MEMORY")));
 }
 

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -15,19 +15,19 @@ use tempfile::NamedTempFile;
 use thiserror::Error;
 
 /// A layer that downloads the Node.js distribution artifacts
-pub struct DistLayer {
-    pub release: Release,
+pub(crate) struct DistLayer {
+    pub(crate) release: Release,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
-pub struct DistLayerMetadata {
+pub(crate) struct DistLayerMetadata {
     layer_version: String,
     nodejs_version: String,
     stack_id: StackId,
 }
 
 #[derive(Error, Debug)]
-pub enum DistLayerError {
+pub(crate) enum DistLayerError {
     #[error("Couldn't create tempfile for Node.js distribution: {0}")]
     TempFile(std::io::Error),
     #[error("Couldn't download Node.js distribution: {0}")]

--- a/buildpacks/nodejs-engine/src/layers/mod.rs
+++ b/buildpacks/nodejs-engine/src/layers/mod.rs
@@ -1,5 +1,5 @@
 mod dist;
 mod web_env;
 
-pub use dist::*;
-pub use web_env::*;
+pub(crate) use dist::*;
+pub(crate) use web_env::*;

--- a/buildpacks/nodejs-engine/src/layers/web_env.rs
+++ b/buildpacks/nodejs-engine/src/layers/web_env.rs
@@ -8,7 +8,7 @@ use libcnb::generic::GenericMetadata;
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 
 /// A layer that sets `WEB_MEMORY` and `WEB_CONCURRENCY` via exec.d
-pub struct WebEnvLayer;
+pub(crate) struct WebEnvLayer;
 
 impl Layer for WebEnvLayer {
     type Buildpack = NodeJsEngineBuildpack;

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -27,7 +27,7 @@ const INVENTORY: &str = include_str!("../inventory.toml");
 
 const LTS_VERSION: &str = "20.x";
 
-pub struct NodeJsEngineBuildpack;
+struct NodeJsEngineBuildpack;
 
 impl Buildpack for NodeJsEngineBuildpack {
     type Platform = GenericPlatform;
@@ -153,7 +153,7 @@ impl Buildpack for NodeJsEngineBuildpack {
 }
 
 #[derive(Error, Debug)]
-pub enum NodeJsEngineBuildpackError {
+enum NodeJsEngineBuildpackError {
     #[error("Couldn't parse Node.js inventory: {0}")]
     InventoryParseError(toml::de::Error),
     #[error("Couldn't parse package.json: {0}")]

--- a/buildpacks/nodejs-function-invoker/src/function.rs
+++ b/buildpacks/nodejs-function-invoker/src/function.rs
@@ -4,7 +4,7 @@ use libherokubuildpack::toml::toml_select_value;
 use std::path::PathBuf;
 use thiserror::Error;
 
-pub fn is_function<P>(d: P) -> bool
+pub(crate) fn is_function<P>(d: P) -> bool
 where
     P: Into<PathBuf>,
 {
@@ -21,7 +21,7 @@ where
     }
 }
 
-pub fn get_main<P>(d: P) -> Result<PathBuf, MainError>
+pub(crate) fn get_main<P>(d: P) -> Result<PathBuf, MainError>
 where
     P: Into<PathBuf>,
 {
@@ -33,7 +33,7 @@ where
         .and_then(|path| path.exists().then_some(path).ok_or(MainError::MissingFile))
 }
 
-pub fn get_declared_runtime_package_version<P>(
+pub(crate) fn get_declared_runtime_package_version<P>(
     app_dir: P,
     package_name: &String,
 ) -> Result<Option<String>, ExplicitRuntimeDependencyError>
@@ -57,7 +57,7 @@ where
 }
 
 #[derive(Error, Debug)]
-pub enum MainError {
+pub(crate) enum MainError {
     #[error("Could not determine function file location from package.json. {0}")]
     PackageJson(#[from] PackageJsonError),
     #[error(
@@ -69,7 +69,7 @@ pub enum MainError {
 }
 
 #[derive(Error, Debug)]
-pub enum ExplicitRuntimeDependencyError {
+pub(crate) enum ExplicitRuntimeDependencyError {
     #[error("Failure while attempting to read from package.json. {0}")]
     PackageJson(#[from] PackageJsonError),
     #[error("The '{package_name}' package must be declared in the 'dependencies' field of your package.json but was found in 'devDependencies'.")]

--- a/buildpacks/nodejs-function-invoker/src/layers/runtime.rs
+++ b/buildpacks/nodejs-function-invoker/src/layers/runtime.rs
@@ -12,19 +12,19 @@ use std::process::Command;
 use thiserror::Error;
 
 /// A layer that installs the Node.js Invoker/Runtime package
-pub struct RuntimeLayer {
-    pub package: String,
+pub(crate) struct RuntimeLayer {
+    pub(crate) package: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
-pub struct RuntimeLayerMetadata {
+pub(crate) struct RuntimeLayerMetadata {
     layer_version: String,
     package: String,
     stack_id: StackId,
 }
 
 #[derive(Error, Debug)]
-pub enum RuntimeLayerError {
+pub(crate) enum RuntimeLayerError {
     #[error("Couldn't run `npm install` command: {0}")]
     NpmCommandError(std::io::Error),
     #[error("Couldn't install invoker runtime with `npm install`: #{0}")]

--- a/buildpacks/nodejs-function-invoker/src/layers/script.rs
+++ b/buildpacks/nodejs-function-invoker/src/layers/script.rs
@@ -47,7 +47,7 @@ impl Layer for ScriptLayer {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum ScriptLayerError {
+pub(crate) enum ScriptLayerError {
     #[error("Could not write runtime script to layer: {0}")]
     CouldNotWriteRuntimeScript(std::io::Error),
     #[error("Could not set executable bit on runtime script: {0}")]

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -32,17 +32,17 @@ use ureq as _;
 mod function;
 mod layers;
 
-pub struct NodeJsInvokerBuildpack;
+struct NodeJsInvokerBuildpack;
 
 #[derive(Deserialize, Debug)]
-pub struct NodeJsInvokerBuildpackMetadata {
-    pub runtime: NodeJsInvokerBuildpackRuntimeMetadata,
+struct NodeJsInvokerBuildpackMetadata {
+    runtime: NodeJsInvokerBuildpackRuntimeMetadata,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct NodeJsInvokerBuildpackRuntimeMetadata {
-    pub package_name: String,
-    pub package_version: String,
+struct NodeJsInvokerBuildpackRuntimeMetadata {
+    package_name: String,
+    package_version: String,
 }
 
 impl Buildpack for NodeJsInvokerBuildpack {
@@ -159,7 +159,7 @@ impl Buildpack for NodeJsInvokerBuildpack {
 }
 
 #[derive(Error, Debug)]
-pub enum NodeJsInvokerBuildpackError {
+enum NodeJsInvokerBuildpackError {
     #[error("{0}")]
     MainFunction(#[from] MainError),
     #[error("{0}")]

--- a/buildpacks/nodejs-function-invoker/tests/integration_test.rs
+++ b/buildpacks/nodejs-function-invoker/tests/integration_test.rs
@@ -1,5 +1,7 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
+// Required due to: https://github.com/rust-lang/rust-clippy/issues/11119
+#![allow(clippy::unwrap_used)]
 
 use base64::Engine;
 use libcnb_test::{assert_contains, assert_not_contains, TestContext};

--- a/buildpacks/nodejs-npm-engine/src/main.rs
+++ b/buildpacks/nodejs-npm-engine/src/main.rs
@@ -27,11 +27,11 @@ use std::process::Command;
 #[cfg(test)]
 use test_support as _;
 
-pub(crate) const BUILDPACK_NAME: &str = "Heroku Node.js npm Engine Buildpack";
+const BUILDPACK_NAME: &str = "Heroku Node.js npm Engine Buildpack";
 
 const INVENTORY: &str = include_str!("../inventory.toml");
 
-pub(crate) struct NpmEngineBuildpack;
+struct NpmEngineBuildpack;
 
 impl Buildpack for NpmEngineBuildpack {
     type Platform = GenericPlatform;

--- a/buildpacks/nodejs-npm-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-npm-engine/tests/integration_test.rs
@@ -1,5 +1,7 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
+// Required due to: https://github.com/rust-lang/rust-clippy/issues/11119
+#![allow(clippy::unwrap_used)]
 
 use libcnb_test::assert_contains;
 use std::fs;

--- a/buildpacks/nodejs-npm-install/src/errors.rs
+++ b/buildpacks/nodejs-npm-install/src/errors.rs
@@ -39,7 +39,7 @@ pub(crate) fn on_error(error: libcnb::Error<NpmInstallBuildpackError>) {
     }
 }
 
-pub(crate) fn on_buildpack_error(error: NpmInstallBuildpackError, logger: Box<dyn StartedLogger>) {
+fn on_buildpack_error(error: NpmInstallBuildpackError, logger: Box<dyn StartedLogger>) {
     match error {
         NpmInstallBuildpackError::Application(e) => on_application_error(&e, logger),
         NpmInstallBuildpackError::BuildScript(e) => on_build_script_error(&e, logger),

--- a/buildpacks/nodejs-npm-install/src/main.rs
+++ b/buildpacks/nodejs-npm-install/src/main.rs
@@ -30,9 +30,9 @@ use std::process::Command;
 #[cfg(test)]
 use test_support as _;
 
-pub(crate) const BUILDPACK_NAME: &str = "Heroku Node.js npm Install Buildpack";
+const BUILDPACK_NAME: &str = "Heroku Node.js npm Install Buildpack";
 
-pub(crate) struct NpmInstallBuildpack;
+struct NpmInstallBuildpack;
 
 impl Buildpack for NpmInstallBuildpack {
     type Platform = GenericPlatform;

--- a/buildpacks/nodejs-npm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-npm-install/tests/integration_test.rs
@@ -1,5 +1,7 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
+// Required due to: https://github.com/rust-lang/rust-clippy/issues/11119
+#![allow(clippy::unwrap_used)]
 
 use libcnb_test::{assert_contains, assert_not_contains, PackResult};
 use serde_json::json;

--- a/buildpacks/nodejs-pnpm-install/src/main.rs
+++ b/buildpacks/nodejs-pnpm-install/src/main.rs
@@ -22,7 +22,7 @@ mod errors;
 mod layers;
 mod store;
 
-pub(crate) struct PnpmInstallBuildpack;
+struct PnpmInstallBuildpack;
 
 impl Buildpack for PnpmInstallBuildpack {
     type Platform = GenericPlatform;
@@ -110,7 +110,7 @@ impl Buildpack for PnpmInstallBuildpack {
 }
 
 #[derive(Debug)]
-pub(crate) enum PnpmInstallBuildpackError {
+enum PnpmInstallBuildpackError {
     BuildScript(cmd::Error),
     PackageJson(PackageJsonError),
     PnpmDir(cmd::Error),

--- a/buildpacks/nodejs-yarn/src/layers/cli.rs
+++ b/buildpacks/nodejs-yarn/src/layers/cli.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 
 /// A layer that downloads and installs the yarn cli
 pub(crate) struct CliLayer {
-    pub release: Release,
+    pub(crate) release: Release,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -30,7 +30,7 @@ mod yarn;
 const INVENTORY: &str = include_str!("../inventory.toml");
 const DEFAULT_YARN_REQUIREMENT: &str = "1.22.x";
 
-pub(crate) struct YarnBuildpack;
+struct YarnBuildpack;
 
 impl Buildpack for YarnBuildpack {
     type Platform = GenericPlatform;
@@ -205,7 +205,7 @@ impl Buildpack for YarnBuildpack {
 }
 
 #[derive(Error, Debug)]
-pub(crate) enum YarnBuildpackError {
+enum YarnBuildpackError {
     #[error("Couldn't run build script: {0}")]
     BuildScript(cmd::Error),
     #[error("{0}")]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/common/nodejs-utils/src/application.rs
+++ b/common/nodejs-utils/src/application.rs
@@ -7,8 +7,6 @@ use std::fmt::{Display, Formatter};
 use std::io::Stdout;
 use std::path::Path;
 
-pub type Result<T> = std::result::Result<T, Error>;
-
 /// Checks for npm, Yarn, pnpm, and shrink-wrap lockfiles and raises an error if multiple are detected.
 ///
 /// # Errors
@@ -16,7 +14,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Will return an `Err` when:
 /// - More than one lockfile exists in the `app_dir`.
 /// - No lockfile exists in the `app_dir`.
-pub fn check_for_singular_lockfile(app_dir: &Path) -> Result<()> {
+pub fn check_for_singular_lockfile(app_dir: &Path) -> Result<(), Error> {
     let detected_lockfiles = [
         PackageManager::Npm,
         PackageManager::Pnpm,

--- a/common/nodejs-utils/src/distribution.rs
+++ b/common/nodejs-utils/src/distribution.rs
@@ -10,7 +10,7 @@ use std::{fmt, str::FromStr};
 /// Heroku nodebin AWS S3 Bucket name
 pub const DEFAULT_BUCKET: &str = "heroku-nodebin";
 /// Heroku nodebin AWS S3 Region
-pub const DEFAULT_REGION: &str = "us-east-1";
+pub(crate) const DEFAULT_REGION: &str = "us-east-1";
 
 #[derive(Debug, Clone, Copy)]
 pub enum Distribution {

--- a/common/nodejs-utils/src/inv.rs
+++ b/common/nodejs-utils/src/inv.rs
@@ -10,12 +10,12 @@ use thiserror::Error;
 
 /// Default/assumed operating system for node release lookups
 #[cfg(target_os = "macos")]
-pub const OS: &str = "darwin";
+const OS: &str = "darwin";
 #[cfg(target_os = "linux")]
-pub const OS: &str = "linux";
+const OS: &str = "linux";
 
 /// Default/assumed architecture for node release lookups
-pub const ARCH: &str = "x64";
+const ARCH: &str = "x64";
 
 /// Represents a software inventory with releases.
 #[derive(Debug, Deserialize, Serialize)]
@@ -47,7 +47,7 @@ impl Inventory {
     }
 
     #[must_use]
-    pub fn resolve_other(
+    fn resolve_other(
         &self,
         version_requirements: &Requirement,
         platform: &str,

--- a/common/nodejs-utils/src/package_manager.rs
+++ b/common/nodejs-utils/src/package_manager.rs
@@ -20,7 +20,7 @@ impl PackageManager {
         }
     }
 
-    pub fn iterator() -> impl Iterator<Item = PackageManager> {
+    pub(crate) fn iterator() -> impl Iterator<Item = PackageManager> {
         Self::VALUES.iter().copied()
     }
 }

--- a/common/nodejs-utils/src/s3.rs
+++ b/common/nodejs-utils/src/s3.rs
@@ -23,7 +23,7 @@ pub(crate) struct Content {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(dead_code)]
-pub(crate) struct ListBucketResult {
+struct ListBucketResult {
     name: String,
     pub(crate) prefix: String,
     max_keys: usize,

--- a/common/nodejs-utils/src/vrs.rs
+++ b/common/nodejs-utils/src/vrs.rs
@@ -104,12 +104,7 @@ impl Requirement {
     }
 
     #[must_use]
-    pub fn any() -> Self {
-        Requirement(Range::any())
-    }
-
-    #[must_use]
-    pub fn satisfies(&self, ver: &Version) -> bool {
+    pub(crate) fn satisfies(&self, ver: &Version) -> bool {
         self.0.satisfies(&ver.0)
     }
 }
@@ -127,7 +122,7 @@ impl fmt::Display for Requirement {
     }
 }
 
-pub type VersionSet = HashSet<Version>;
+pub(crate) type VersionSet = HashSet<Version>;
 
 impl TryFrom<s3::BucketContent> for VersionSet {
     type Error = anyhow::Error;

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -1,3 +1,6 @@
+// This module is only used for testing, where using unwrap() is acceptable.
+#![allow(clippy::unwrap_used)]
+
 use libcnb::data::buildpack_id;
 use libcnb_test::{
     assert_contains, BuildConfig, BuildpackReference, ContainerConfig, ContainerContext,
@@ -8,12 +11,12 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const DEFAULT_BUILDER: &str = "heroku/builder:22";
-pub const PORT: u16 = 8080;
+const PORT: u16 = 8080;
 pub const DEFAULT_RETRIES: u32 = 10;
 pub const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[must_use]
-pub fn get_integration_test_builder() -> String {
+fn get_integration_test_builder() -> String {
     std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap_or(DEFAULT_BUILDER.to_string())
 }
 
@@ -40,7 +43,7 @@ pub fn function_integration_test(fixture: &str, test_body: fn(TestContext)) {
     function_integration_test_with_config(fixture, |_| {}, test_body);
 }
 
-pub fn function_integration_test_with_config(
+fn function_integration_test_with_config(
     fixture: &str,
     with_config: fn(&mut BuildConfig),
     test_body: fn(TestContext),
@@ -159,7 +162,7 @@ pub fn add_build_script(app_dir: &Path, script: &str) {
     });
 }
 
-pub fn update_package_json(
+fn update_package_json(
     app_dir: &Path,
     update: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>),
 ) {


### PR DESCRIPTION
Enables some off-by-default lints that we already use in the `libcnb.rs` repository.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code
https://rust-lang.github.io/rust-clippy/master/index.html#/panic_in_result_fn
https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used

GUS-W-14523836.