### PR TITLE
Simplify Cargo metadata for `publish = false` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,8 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.0"
-rust-version = "1.74"
+rust-version = "1.75"
 edition = "2021"
-publish = false
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-nodejs-corepack-buildpack"
-description = "Heroku Node.js Corepack Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-nodejs-engine-buildpack"
-description = "Heroku Node.js Engine Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-nodejs-function-invoker-buildpack"
-description = "Heroku Node.js Function Invoker Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/nodejs-npm-engine/Cargo.toml
+++ b/buildpacks/nodejs-npm-engine/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-npm-engine-buildpack"
-description = "Heroku Node.js npm Engine Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/nodejs-npm-install/Cargo.toml
+++ b/buildpacks/nodejs-npm-install/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-npm-install-buildpack"
-description = "Heroku Node.js npm Install Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/nodejs-pnpm-engine/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-engine/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-pnpm-engine-buildpack"
-description = "Heroku Node.js pnpm Engine Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/nodejs-pnpm-install/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-install/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-nodejs-pnpm-install-buildpack"
-description = "Heroku Node.js pnpm install Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-nodejs-yarn-buildpack"
-description = "Heroku Node.js Yarn Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-nodejs-utils"
-description = "Libs and bins for Heroku Node.js Buildpacks"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "test_support"
-description = "Test support functions for integration tests"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28
https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

In addition, the `Cargo.toml` `description` property has been removed, since:
- it's unused unless the crate is published
- it duplicates the description in `buildpack.toml` / the README etc

GUS-W-14821120.