### PR TITLE
Adjust WEB_CONCURRENCY calculations for memory heavy instances

### DIFF
--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Adjusted WEB_MEMORY and WEB_CONCURRENCY calculation to be more appropriate on
+  memory heavy instances.
 - Added Node.js version 21.6.0.
 ## [2.6.3] - 2024-01-11
 

--- a/buildpacks/nodejs-engine/src/bin/web_env.rs
+++ b/buildpacks/nodejs-engine/src/bin/web_env.rs
@@ -47,7 +47,7 @@ fn detect_available_memory() -> usize {
     .find_map(|path| fs::read_to_string(path).ok())
     .and_then(|contents| contents.trim().parse().ok())
     .map_or(512, |max_bytes: usize| {
-        cmp::min(129024, max_bytes / 1_048_576)
+        cmp::min(129_024, max_bytes / 1_048_576)
     })
 }
 
@@ -114,7 +114,7 @@ mod tests {
         // memory heavy instance
         assert_eq!(default_web_memory(30720), 2048);
         // extra large memory heavy instance
-        assert_eq!(default_web_memory(129025), 2048);
+        assert_eq!(default_web_memory(129_025), 2048);
     }
 
     #[test]


### PR DESCRIPTION
This allows the WEB_MEMORY / WEB_CONCURRENCY selection to be more appropriate on memory heavy instances. This mirrors the work in https://github.com/heroku/heroku-buildpack-nodejs/pull/1196.

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001g8anxYAA/view)