### PR TITLE
Update metrics scripts to be compatible with Node v14.10.+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ latest, lts/*, lts/-1 ]
+        # check the minimum node version supported by the metrics script and the latest node version
+        # (assumes the versions between have backwards-compatible APIs)
+        version: [14.10.0, latest]
     name: Test Metrics (${{ matrix.version }})
     runs-on: ubuntu-latest
     steps:
@@ -130,4 +132,4 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
-      - run: node --test buildpacks/nodejs-engine/node_runtime_metrics/test/metrics.spec.cjs
+      - run: npx mocha buildpacks/nodejs-engine/node_runtime_metrics/test/metrics.spec.cjs

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Collect Node.js Runtime Metrics for v14.10.0 and up if the application has opted-in. ([#767](https://github.com/heroku/buildpacks-nodejs/pull/767))
+
 ## [2.6.4] - 2024-01-17
 
 - Added Node.js version 21.6.0.

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
 - Added Node.js version 21.6.1.
-- 
+
 ### Changed
 
 - Collect Node.js Runtime Metrics for v14.10.0 and up if the application has opted-in. ([#767](https://github.com/heroku/buildpacks-nodejs/pull/767))

--- a/buildpacks/nodejs-engine/node_runtime_metrics/test/fixtures/clustered_app.cjs
+++ b/buildpacks/nodejs-engine/node_runtime_metrics/test/fixtures/clustered_app.cjs
@@ -1,10 +1,13 @@
-const { isPrimary, fork } = require('node:cluster')
+const cluster = require('cluster')
 
 require('./_cpu_and_memory_simulator.cjs')
 
-if (isPrimary) {
+if (
+    cluster.isPrimary ||
+    cluster.isMaster // deprecated in Node v16
+) {
     console.log(`Starting primary cluster ${process.pid} running with NODE_OPTIONS="${process.env.NODE_OPTIONS || ''}"`)
-    fork()
+    cluster.fork()
     process.on('SIGINT', () => {
         process.exit(0)
     })

--- a/buildpacks/nodejs-engine/node_runtime_metrics/test/fixtures/worker_threads_app.cjs
+++ b/buildpacks/nodejs-engine/node_runtime_metrics/test/fixtures/worker_threads_app.cjs
@@ -1,4 +1,4 @@
-const { Worker, isMainThread} = require('node:worker_threads')
+const { Worker, isMainThread} = require('worker_threads')
 
 require('./_cpu_and_memory_simulator.cjs')
 

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -29,6 +29,8 @@ const INVENTORY: &str = include_str!("../inventory.toml");
 
 const LTS_VERSION: &str = "20.x";
 
+const MINIMUM_NODE_VERSION_FOR_METRICS: &str = ">=14.10";
+
 struct NodeJsEngineBuildpack;
 
 impl Buildpack for NodeJsEngineBuildpack {
@@ -103,7 +105,13 @@ impl Buildpack for NodeJsEngineBuildpack {
         )?;
 
         context.handle_layer(layer_name!("web_env"), WebEnvLayer)?;
-        context.handle_layer(layer_name!("node_runtime_metrics"), NodeRuntimeMetricsLayer)?;
+
+        if Requirement::parse(MINIMUM_NODE_VERSION_FOR_METRICS)
+            .expect("should be a valid version range")
+            .satisfies(&target_release.version)
+        {
+            context.handle_layer(layer_name!("node_runtime_metrics"), NodeRuntimeMetricsLayer)?;
+        }
 
         let launchjs = ["server.js", "index.js"]
             .map(|name| context.app_dir.join(name))

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -120,6 +120,7 @@ fn runtime_metrics_script_is_activated_when_node_version_is_at_least_v14_10_0() 
                 .env("HEROKU_METRICS_URL", "http://localhost:3000");
 
             ctx.start_container(container_config, |container| {
+                std::thread::sleep(Duration::from_secs(1));
                 let output = container.logs_now();
                 assert_contains!(output.stderr, "Registering metrics instrumentation");
             });

--- a/common/nodejs-utils/src/vrs.rs
+++ b/common/nodejs-utils/src/vrs.rs
@@ -104,7 +104,7 @@ impl Requirement {
     }
 
     #[must_use]
-    pub(crate) fn satisfies(&self, ver: &Version) -> bool {
+    pub fn satisfies(&self, ver: &Version) -> bool {
         self.0.satisfies(&ver.0)
     }
 }


### PR DESCRIPTION
To support earlier Node.js version several adjustments needed to be made to the metrics script. These include:
- dropping the `node:` protocol from required core modules
- using `http` instead of `fetch`
- using API signatures compatible across all versions:
  - `PerformanceObserver.observe`
  - `PerformanceEntry.kind` vs. `PerformanceEntry.detail.kind`
  - `cluster.isPrimary` vs. `cluster.isMaster`

This PR also includes changes to the CNB to restrict the layer containing the metrics script to only versions of Node `>=14.10`.

[W-14838686](https://gus.lightning.force.com/lightning/r/a07EE00001iPnjsYAC/view)

Fixes #754 