### PR TITLE
Update CODEOWNERS to reduce review notification noise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,13 @@
+# The Languages team should be the default requested reviewer on all PRs
 * @heroku/languages
+
+# Expect for automation that:
+# - updates binary inventories
+# - updates project dependencies
+# - prepares releases
+# Only Node.js language owners should be the requested reviewers here
+CHANGELOG.md @joshwlewis @colincasey
+inventory.toml @joshwlewis @colincasey
+Cargo.toml @joshwlewis @colincasey
+Cargo.lock @joshwlewis @colincasey
+buildpack.toml @joshwlewis @colincasey

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # The Languages team should be the default requested reviewer on all PRs
 * @heroku/languages
 
-# Expect for automation that:
+# Except for automation that:
 # - updates binary inventories
 # - updates project dependencies
 # - prepares releases


### PR DESCRIPTION
This modification to the `CODEOWNERS` file is based off suggestions from @edmorley to help reduce review notification overload for the team.

For most PRs, the Languages team will be requested for review except for automation-based changes which are assigned to specific language owners since they often require further action such as performing a release, etc.