### PR TITLE
Update to Buildpack API 0.10, libcnb.rs 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.4",
+ "windows-targets",
 ]
 
 [[package]]
@@ -211,8 +211,8 @@ dependencies = [
  "glob",
  "indoc",
  "lazy_static",
- "libcnb",
- "libherokubuildpack",
+ "libcnb 0.17.0",
+ "libherokubuildpack 0.17.0",
  "regex",
  "serde",
  "sha2",
@@ -338,7 +338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -377,7 +377,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -553,9 +553,9 @@ version = "0.0.0"
 dependencies = [
  "heroku-nodejs-utils",
  "indoc",
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.19.0",
  "opentelemetry 0.22.0",
  "serde",
  "test_support",
@@ -568,9 +568,9 @@ name = "heroku-nodejs-engine-buildpack"
 version = "0.0.0"
 dependencies = [
  "heroku-nodejs-utils",
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.19.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -587,9 +587,9 @@ dependencies = [
  "base64",
  "heroku-nodejs-utils",
  "hex",
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.19.0",
  "rand",
  "serde",
  "serde_json",
@@ -606,9 +606,9 @@ version = "0.0.0"
 dependencies = [
  "heroku-nodejs-utils",
  "indoc",
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.19.0",
  "serde",
  "test_support",
  "toml",
@@ -643,9 +643,9 @@ name = "heroku-nodejs-yarn-buildpack"
 version = "0.0.0"
 dependencies = [
  "heroku-nodejs-utils",
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.19.0",
  "serde",
  "tempfile",
  "test_support",
@@ -662,9 +662,9 @@ dependencies = [
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.19.0",
  "serde",
  "serde_json",
  "test_support",
@@ -679,7 +679,7 @@ dependencies = [
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
  "serde",
  "serde_json",
@@ -692,7 +692,7 @@ version = "0.0.0"
 dependencies = [
  "commons",
  "indoc",
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
  "test_support",
 ]
@@ -709,7 +709,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -810,9 +810,23 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c385c618fa8afebe2d1b499b74bc0a3682507b0d91aa4aad09708b81681e2ca"
 dependencies = [
- "libcnb-common",
- "libcnb-data",
- "libcnb-proc-macros",
+ "libcnb-common 0.17.0",
+ "libcnb-data 0.17.0",
+ "libcnb-proc-macros 0.17.0",
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "libcnb"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db217651ab45597152c94ad849defb079fc7ced7d72de2fcc2e9c3dec6e990e"
+dependencies = [
+ "libcnb-common 0.19.0",
+ "libcnb-data 0.19.0",
+ "libcnb-proc-macros 0.19.0",
  "opentelemetry 0.21.0",
  "opentelemetry-stdout 0.2.0",
  "opentelemetry_sdk 0.21.2",
@@ -833,13 +847,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "libcnb-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3abf2056162dd76ade12884e002ba88f068a26594b2eb9579ef8af40cfbca1b"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "libcnb-data"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c0c825002ee57279d0c9e23309863804536f0c45687436d574dd3e8c7420fb"
 dependencies = [
  "fancy-regex 0.12.0",
- "libcnb-proc-macros",
+ "libcnb-proc-macros 0.17.0",
+ "serde",
+ "thiserror",
+ "toml",
+ "uriparse",
+]
+
+[[package]]
+name = "libcnb-data"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc6b01af8b624193ca6b247667ef82f36dd85d62b90f5a7e8d047b46642ce7c"
+dependencies = [
+ "fancy-regex 0.13.0",
+ "libcnb-proc-macros 0.19.0",
  "serde",
  "thiserror",
  "toml",
@@ -848,14 +887,15 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934ec4398991f7e926889a6e5046d83935e39de5c047feb591ed0333b83abf75"
+checksum = "2678c2e0882c622a01d415e64625258849e533aeba8531110a5b3db9593d97d5"
 dependencies = [
  "cargo_metadata",
  "ignore",
- "libcnb-common",
- "libcnb-data",
+ "indoc",
+ "libcnb-common 0.19.0",
+ "libcnb-data 0.19.0",
  "petgraph",
  "thiserror",
  "uriparse",
@@ -875,15 +915,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "libcnb-test"
-version = "0.17.0"
+name = "libcnb-proc-macros"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2471f098af746db385e0e254dd423de21db3347ea26cfd4c758a37cccaa1674a"
+checksum = "b0308e3b554dd8b0b969ab42d19b50b02bdb712dc72652849fa1e33bd1d16709"
+dependencies = [
+ "cargo_metadata",
+ "fancy-regex 0.13.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libcnb-test"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f094d9c229c481fb868d36231dcc4b7596491503d0a297eb239b08e942eb483c"
 dependencies = [
  "fastrand",
  "fs_extra",
- "libcnb-common",
- "libcnb-data",
+ "libcnb-common 0.19.0",
+ "libcnb-data 0.19.0",
  "libcnb-package",
  "tempfile",
  "thiserror",
@@ -896,8 +948,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e800ca80376b707d57d55ea95f48c88d2621864a0250cc41f54eab8e9481887"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "libherokubuildpack"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410f8f0e8cfcaffd92423211b5e280d2bebe3a5508d543fdcd451459d14debca"
+dependencies = [
  "flate2",
- "libcnb",
+ "libcnb 0.19.0",
  "pathdiff",
  "tar",
  "termcolor",
@@ -1263,7 +1323,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1276,7 +1336,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1448,7 +1508,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1464,7 +1524,7 @@ dependencies = [
 name = "test_support"
 version = "0.0.0"
 dependencies = [
- "libcnb",
+ "libcnb 0.19.0",
  "libcnb-test",
  "serde_json",
  "ureq",
@@ -1729,15 +1789,15 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1777,16 +1837,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1795,22 +1846,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1819,20 +1855,14 @@ version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1842,21 +1872,9 @@ checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1866,21 +1884,9 @@ checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1890,21 +1896,9 @@ checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/buildpacks/nodejs-corepack/CHANGELOG.md
+++ b/buildpacks/nodejs-corepack/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 - No changes.

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -9,13 +9,13 @@ workspace = true
 [dependencies]
 heroku-nodejs-utils.workspace = true
 indoc = "2"
-libcnb = { version = "=0.17.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["log"] }
+libcnb = { version = "=0.19.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.19.0", default-features = false, features = ["log"] }
 opentelemetry = "0.22"
 serde = "1"
 thiserror = "1"
 
 [dev-dependencies]
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.19.0"
 test_support.workspace = true
 ureq = "2"

--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-corepack"

--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -14,5 +14,9 @@ type = "MIT"
 [[stacks]]
 id = "*"
 
+[[targets]]
+os = "linux"
+arch = "amd64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-corepack" }

--- a/buildpacks/nodejs-corepack/src/layers/manager.rs
+++ b/buildpacks/nodejs-corepack/src/layers/manager.rs
@@ -41,7 +41,7 @@ impl Layer for ManagerLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, CorepackBuildpackError> {
@@ -58,7 +58,7 @@ impl Layer for ManagerLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/nodejs-corepack/src/layers/shim.rs
+++ b/buildpacks/nodejs-corepack/src/layers/shim.rs
@@ -38,7 +38,7 @@ impl Layer for ShimLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, CorepackBuildpackError> {
@@ -47,7 +47,7 @@ impl Layer for ShimLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 - Added Node.js version 21.6.2.
@@ -15,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.6.5] - 2024-02-01
 
-### Added 
+### Added
 
 - Added Node.js version 21.6.1.
 

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -8,15 +8,15 @@ workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb = { version = "=0.17.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["download", "fs", "log", "tar"] }
+libcnb = { version = "=0.19.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.19.0", default-features = false, features = ["download", "fs", "log", "tar"] }
 serde = "1"
 tempfile = "3"
 thiserror = "1"
 toml = "0.8"
 
 [dev-dependencies]
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.19.0"
 serde_json = "1"
 test_support.workspace = true
 ureq = "2"

--- a/buildpacks/nodejs-engine/buildpack.toml
+++ b/buildpacks/nodejs-engine/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-engine"

--- a/buildpacks/nodejs-engine/buildpack.toml
+++ b/buildpacks/nodejs-engine/buildpack.toml
@@ -12,10 +12,11 @@ keywords = ["node.js", "nodejs", "heroku"]
 type = "MIT"
 
 [[stacks]]
-id = "heroku-20"
+id = "*"
 
-[[stacks]]
-id = "heroku-22"
+[[targets]]
+os = "linux"
+arch = "amd64"
 
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-engine" }

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -1,7 +1,6 @@
 use crate::{NodeJsEngineBuildpack, NodeJsEngineBuildpackError};
 use heroku_nodejs_utils::inv::Release;
 use libcnb::build::BuildContext;
-use libcnb::data::buildpack::StackId;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
@@ -23,7 +22,8 @@ pub(crate) struct DistLayer {
 pub(crate) struct DistLayerMetadata {
     layer_version: String,
     nodejs_version: String,
-    stack_id: StackId,
+    arch: String,
+    os: String,
 }
 
 #[derive(Error, Debug)]
@@ -53,7 +53,7 @@ impl Layer for DistLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, NodeJsEngineBuildpackError> {
@@ -74,7 +74,7 @@ impl Layer for DistLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
@@ -91,8 +91,9 @@ impl DistLayerMetadata {
     fn current(layer: &DistLayer, context: &BuildContext<NodeJsEngineBuildpack>) -> Self {
         DistLayerMetadata {
             nodejs_version: layer.release.version.to_string(),
-            stack_id: context.stack_id.clone(),
             layer_version: String::from(LAYER_VERSION),
+            arch: context.target.arch.clone(),
+            os: context.target.os.clone(),
         }
     }
 }

--- a/buildpacks/nodejs-engine/src/layers/node_runtime_metrics.rs
+++ b/buildpacks/nodejs-engine/src/layers/node_runtime_metrics.rs
@@ -23,7 +23,7 @@ impl Layer for NodeRuntimeMetricsLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, NodeJsEngineBuildpackError> {

--- a/buildpacks/nodejs-engine/src/layers/web_env.rs
+++ b/buildpacks/nodejs-engine/src/layers/web_env.rs
@@ -23,7 +23,7 @@ impl Layer for WebEnvLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         _layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, NodeJsEngineBuildpackError> {

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 - No changes.

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -8,8 +8,8 @@ workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb = "=0.17.0"
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["error", "log", "toml"] }
+libcnb = "=0.19.0"
+libherokubuildpack = { version = "=0.19.0", default-features = false, features = ["error", "log", "toml"] }
 serde = "1"
 thiserror = "1"
 toml = "0.8"
@@ -17,7 +17,7 @@ toml = "0.8"
 [dev-dependencies]
 base64 = "0.21"
 hex = "0.4"
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.19.0"
 rand = "0.8"
 serde_json = "1"
 tempfile = "3"

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -13,6 +13,10 @@ type = "MIT"
 [[stacks]]
 id = "heroku-22"
 
+[[targets]]
+os = "linux"
+arch = "amd64"
+
 [metadata.runtime]
 package_name = "@heroku/sf-fx-runtime-nodejs"
 package_version = "0.14.4"

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-function-invoker"

--- a/buildpacks/nodejs-function-invoker/src/layers/runtime.rs
+++ b/buildpacks/nodejs-function-invoker/src/layers/runtime.rs
@@ -1,6 +1,5 @@
 use crate::{NodeJsInvokerBuildpack, NodeJsInvokerBuildpackError};
 use libcnb::build::BuildContext;
-use libcnb::data::buildpack::StackId;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
@@ -20,7 +19,8 @@ pub(crate) struct RuntimeLayer {
 pub(crate) struct RuntimeLayerMetadata {
     layer_version: String,
     package: String,
-    stack_id: StackId,
+    arch: String,
+    os: String,
 }
 
 #[derive(Error, Debug)]
@@ -46,7 +46,7 @@ impl Layer for RuntimeLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, NodeJsInvokerBuildpackError> {
@@ -78,7 +78,7 @@ impl Layer for RuntimeLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
@@ -98,8 +98,9 @@ impl RuntimeLayerMetadata {
     fn current(layer: &RuntimeLayer, context: &BuildContext<NodeJsInvokerBuildpack>) -> Self {
         RuntimeLayerMetadata {
             package: layer.package.clone(),
-            stack_id: context.stack_id.clone(),
             layer_version: String::from(LAYER_VERSION),
+            arch: context.target.arch.clone(),
+            os: context.target.os.clone(),
         }
     }
 }

--- a/buildpacks/nodejs-function-invoker/src/layers/script.rs
+++ b/buildpacks/nodejs-function-invoker/src/layers/script.rs
@@ -27,7 +27,7 @@ impl Layer for ScriptLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, NodeJsInvokerBuildpackError> {

--- a/buildpacks/nodejs-npm-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-engine/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
 - Added npm version 10.5.0.
 - Added npm version 9.9.3.
+
 ## [2.6.6] - 2024-02-15
 
 - No changes.

--- a/buildpacks/nodejs-npm-engine/Cargo.toml
+++ b/buildpacks/nodejs-npm-engine/Cargo.toml
@@ -11,12 +11,12 @@ commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 fun_run = "0.1"
 heroku-nodejs-utils.workspace = true
 indoc = "2"
-libcnb = { version = "=0.17.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["download", "tar"] }
+libcnb = { version = "=0.19.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.19.0", default-features = false, features = ["download", "tar"] }
 serde = "1"
 toml = "0.8"
 
 [dev-dependencies]
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.19.0"
 serde_json = "1"
 test_support.workspace = true

--- a/buildpacks/nodejs-npm-engine/buildpack.toml
+++ b/buildpacks/nodejs-npm-engine/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-npm-engine"

--- a/buildpacks/nodejs-npm-engine/buildpack.toml
+++ b/buildpacks/nodejs-npm-engine/buildpack.toml
@@ -14,5 +14,9 @@ type = "MIT"
 [[stacks]]
 id = "*"
 
+[[targets]]
+os = "linux"
+arch = "amd64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-npm-engine" }

--- a/buildpacks/nodejs-npm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-install/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 - No changes.

--- a/buildpacks/nodejs-npm-install/Cargo.toml
+++ b/buildpacks/nodejs-npm-install/Cargo.toml
@@ -11,10 +11,10 @@ commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 fun_run = "0.1"
 heroku-nodejs-utils.workspace = true
 indoc = "2"
-libcnb = { version = "=0.17.0", features = ["trace"] }
+libcnb = { version = "=0.19.0", features = ["trace"] }
 serde = "1"
 
 [dev-dependencies]
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.19.0"
 serde_json = "1"
 test_support.workspace = true

--- a/buildpacks/nodejs-npm-install/buildpack.toml
+++ b/buildpacks/nodejs-npm-install/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-npm-install"

--- a/buildpacks/nodejs-npm-install/src/layers/npm_cache.rs
+++ b/buildpacks/nodejs-npm-install/src/layers/npm_cache.rs
@@ -25,7 +25,7 @@ impl<'a> Layer for NpmCacheLayer<'a> {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         _layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
@@ -34,7 +34,7 @@ impl<'a> Layer for NpmCacheLayer<'a> {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/nodejs-pnpm-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-engine/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 - No changes.

--- a/buildpacks/nodejs-pnpm-engine/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-engine/Cargo.toml
@@ -9,8 +9,8 @@ workspace = true
 [dependencies]
 commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 indoc = "2"
-libcnb = { version = "=0.17.0", features = ["trace"] }
+libcnb = { version = "=0.19.0", features = ["trace"] }
 
 [dev-dependencies]
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.19.0"
 test_support.workspace = true

--- a/buildpacks/nodejs-pnpm-engine/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-engine/buildpack.toml
@@ -14,5 +14,9 @@ type = "MIT"
 [[stacks]]
 id = "*"
 
+[[targets]]
+os = "linux"
+arch = "amd64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-pnpm-engine" }

--- a/buildpacks/nodejs-pnpm-engine/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-engine/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-pnpm-engine"

--- a/buildpacks/nodejs-pnpm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-install/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 - No changes.

--- a/buildpacks/nodejs-pnpm-install/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-install/Cargo.toml
@@ -9,12 +9,12 @@ workspace = true
 [dependencies]
 heroku-nodejs-utils.workspace = true
 indoc = "2"
-libcnb = { version = "=0.17.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["log"] }
+libcnb = { version = "=0.19.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.19.0", default-features = false, features = ["log"] }
 serde = "1"
 toml = "0.8"
 
 [dev-dependencies]
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.19.0"
 test_support.workspace = true
 ureq = "2"

--- a/buildpacks/nodejs-pnpm-install/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-install/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-pnpm-install"

--- a/buildpacks/nodejs-pnpm-install/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-install/buildpack.toml
@@ -14,5 +14,9 @@ type = "MIT"
 [[stacks]]
 id = "*"
 
+[[targets]]
+os = "linux"
+arch = "amd64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-pnpm-install" }

--- a/buildpacks/nodejs-pnpm-install/src/layers/addressable_store.rs
+++ b/buildpacks/nodejs-pnpm-install/src/layers/addressable_store.rs
@@ -32,7 +32,7 @@ impl Layer for AddressableStoreLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         _layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, PnpmInstallBuildpackError> {
@@ -41,7 +41,7 @@ impl Layer for AddressableStoreLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/nodejs-pnpm-install/src/layers/virtual_store.rs
+++ b/buildpacks/nodejs-pnpm-install/src/layers/virtual_store.rs
@@ -27,7 +27,7 @@ impl Layer for VirtualStoreLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, PnpmInstallBuildpackError> {

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 - Added Yarn version 3.8.0.

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -8,14 +8,14 @@ workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb = { version = "=0.17.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["download", "fs", "log", "tar"] }
+libcnb = { version = "=0.19.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.19.0", default-features = false, features = ["download", "fs", "log", "tar"] }
 serde = "1"
 tempfile = "3"
 thiserror = "1"
 toml = "0.8"
 
 [dev-dependencies]
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.19.0"
 test_support.workspace = true
 ureq = "2"

--- a/buildpacks/nodejs-yarn/buildpack.toml
+++ b/buildpacks/nodejs-yarn/buildpack.toml
@@ -14,5 +14,9 @@ type = "MIT"
 [[stacks]]
 id = "*"
 
+[[targets]]
+os = "linux"
+arch = "amd64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-yarn" }

--- a/buildpacks/nodejs-yarn/buildpack.toml
+++ b/buildpacks/nodejs-yarn/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-yarn"

--- a/buildpacks/nodejs-yarn/src/layers/cli.rs
+++ b/buildpacks/nodejs-yarn/src/layers/cli.rs
@@ -1,7 +1,6 @@
 use crate::{YarnBuildpack, YarnBuildpackError};
 use heroku_nodejs_utils::inv::Release;
 use libcnb::build::BuildContext;
-use libcnb::data::buildpack::StackId;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
@@ -25,7 +24,8 @@ pub(crate) struct CliLayer {
 pub(crate) struct CliLayerMetadata {
     layer_version: String,
     yarn_version: String,
-    stack_id: StackId,
+    arch: String,
+    os: String,
 }
 
 #[derive(Error, Debug)]
@@ -57,7 +57,7 @@ impl Layer for CliLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, YarnBuildpackError> {
@@ -90,7 +90,7 @@ impl Layer for CliLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
@@ -107,8 +107,9 @@ impl CliLayerMetadata {
     fn current(layer: &CliLayer, context: &BuildContext<YarnBuildpack>) -> Self {
         CliLayerMetadata {
             yarn_version: layer.release.version.to_string(),
-            stack_id: context.stack_id.clone(),
             layer_version: String::from(LAYER_VERSION),
+            arch: context.target.arch.clone(),
+            os: context.target.os.clone(),
         }
     }
 }

--- a/buildpacks/nodejs-yarn/src/layers/deps.rs
+++ b/buildpacks/nodejs-yarn/src/layers/deps.rs
@@ -48,7 +48,7 @@ impl Layer for DepsLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, YarnBuildpackError> {
@@ -57,7 +57,7 @@ impl Layer for DepsLayer {
     }
 
     fn update(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer: &LayerData<Self::Metadata>,
     ) -> Result<LayerResult<Self::Metadata>, YarnBuildpackError> {
@@ -69,7 +69,7 @@ impl Layer for DepsLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/meta-buildpacks/nodejs-function/CHANGELOG.md
+++ b/meta-buildpacks/nodejs-function/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 ### Changed

--- a/meta-buildpacks/nodejs-function/buildpack.toml
+++ b/meta-buildpacks/nodejs-function/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs-function"

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump to Buildpack API 0.10.
+  ([#789](https://github.com/heroku/buildpacks-nodejs/pull/789))
+
 ## [2.6.6] - 2024-02-15
 
 ### Changed

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/nodejs"

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-libcnb = "=0.17.0"
-libcnb-test = "=0.17.0"
+libcnb = "=0.19.0"
+libcnb-test = "=0.19.0"
 serde_json = "1"
 ureq = "2"


### PR DESCRIPTION
This updates the libcnb family of dependencies and makes the following changes to support that change:

- [`StackId` has been removed from `libcnb`](https://github.com/heroku/libcnb.rs/pull/773) and the [Cloud Native Buildpacks Buildpack API 0.10 API](https://github.com/buildpacks/spec/blob/buildpack/0.10/buildpack.md?plain=1#L750-L760) in favor of `Target.os` and `Target.arch`. This buildpack now uses `os` + `arch` to determine cache validity instead of `StackId`.
- Bumps the Buildpack API version to 0.10 for libcnb buildpacks
- Includes `[[targets]]` for all libcnb buildpacks
  - Using `linux/amd64`, since these are all compiled only for that platform.
- A bunch of layer method signatures have changed so that the layer is mutable.

Due to previous issues with Buildpack API 0.10 and lifecycle (https://github.com/buildpacks/lifecycle/issues/1308), we should probably wait until `heroku/builder` is updated with lifecycle 0.19 or greater to ship this.