### PR TITLE
Fix flaky integration tests

### DIFF
--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -7,8 +7,9 @@ use libcnb_test::{
     TestContext, TestRunner,
 };
 use std::net::SocketAddr;
+use std::panic;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 const DEFAULT_BUILDER: &str = "heroku/builder:22";
 pub const PORT: u16 = 8080;
@@ -117,6 +118,27 @@ pub fn assert_web_response(ctx: &TestContext, expected_response_body: &'static s
         let response_body = response.into_string().unwrap();
         assert_contains!(response_body, expected_response_body);
     });
+}
+
+pub fn wait_for<F>(condition: F, max_wait_time: Duration)
+where
+    F: Fn() + panic::RefUnwindSafe,
+{
+    let start_time = SystemTime::now();
+    while SystemTime::now()
+        .duration_since(start_time)
+        .expect("should not be an earlier time")
+        < max_wait_time
+    {
+        let result = panic::catch_unwind(|| {
+            condition();
+        });
+        if result.is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timeout exceeded");
 }
 
 pub fn set_node_engine(app_dir: &Path, version_range: &str) {

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -6,7 +6,6 @@ use libcnb_test::{
     assert_contains, BuildConfig, BuildpackReference, ContainerConfig, ContainerContext,
     TestContext, TestRunner,
 };
-use std::any::Any;
 use std::net::SocketAddr;
 use std::panic;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Several of the metrics tests are temporal-based and, while we can get decent reliability by tweaking the timeouts used, it's not a guarantee that the chosen timeouts will always be effective which can lead to unwanted flakiness during test runs or test runs that wait longer than necessary.

To balance the tradeoff between wait time and test execution time, this PR introduces `wait_for(condition, timeout)` which will continually poll the state of the given `condition` until it passes or the `timeout` is exceeded. This should help to minimize the wait time required to guarantee the expected outcome.