### PR TITLE
Use artifact inventory

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -7,14 +7,54 @@ on:
 
 jobs:
   update-nodejs-inventory:
-    name: Node.js
-    uses: ./.github/workflows/_update-inventory.yml
-    with:
-      name: Node.js
-      distribution: node
-      buildpack_id: heroku/nodejs-engine
-      buildpack_path: buildpacks/nodejs-engine
-    secrets: inherit
+    name: Update Node.js Inventory
+    runs-on: pub-hk-ubuntu-22.04-small
+    steps:
+      - uses: heroku/use-app-token-action@main
+        id: generate-token
+        with:
+          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - id: install-rust-toolchain
+        name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Rebuild Inventory
+        id: rebuild-inventory
+        run: |
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "msg<<${delimiter}"
+            cargo run --bin update_node_inventory buildpacks/nodejs-engine/inventory.toml
+            echo "${delimiter}"
+          } >> $GITHUB_OUTPUT
+
+      - name: Update Changelog
+        run: echo "${{ steps.rebuild-inventory.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' buildpacks/nodejs-engine/CHANGELOG.md
+
+      - name: Create Pull Request
+        id: pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.generate-token.outputs.app_token }}
+          title: "Update Node.js Inventory"
+          commit-message: "Update Inventory for heroku/nodejs\n\n${{ steps.rebuild-inventory.outputs.msg }}"
+          committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          branch: update-nodejs-inventory
+          body: "Automated pull-request to update heroku/nodejs inventory:\n\n${{ steps.rebuild-inventory.outputs.msg }}"
+
+      - name: Configure PR
+        if: steps.pr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+        run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"
 
   update-yarn-inventory:
     name: Yarn

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Update Rust toolchain
         run: rustup update
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.7.3
+
       - name: Rebuild Inventory
         id: rebuild-inventory
         run: |

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -19,11 +19,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - id: install-rust-toolchain
-        name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Update Rust toolchain
+        run: rustup update
 
       - name: Rebuild Inventory
         id: rebuild-inventory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "heroku-inventory-utils"
+version = "0.0.0"
+source = "git+https://github.com/heroku/buildpacks-go/?rev=28d59e1935a6474f854d030a18e2a52ea5cd258d#28d59e1935a6474f854d030a18e2a52ea5cd258d"
+dependencies = [
+ "hex",
+ "semver",
+ "serde",
+ "sha2",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "heroku-nodejs-corepack-buildpack"
 version = "0.0.0"
 dependencies = [
@@ -567,12 +580,14 @@ dependencies = [
 name = "heroku-nodejs-engine-buildpack"
 version = "0.0.0"
 dependencies = [
+ "heroku-inventory-utils",
  "heroku-nodejs-utils",
  "libcnb 0.21.0",
  "libcnb-test",
  "libherokubuildpack 0.21.0",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "test_support",
  "thiserror",
@@ -622,6 +637,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "commons",
+ "heroku-inventory-utils",
  "indoc",
  "node-semver",
  "opentelemetry 0.22.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 [[package]]
 name = "heroku-inventory-utils"
 version = "0.0.0"
-source = "git+https://github.com/heroku/buildpacks-go/?rev=28d59e1935a6474f854d030a18e2a52ea5cd258d#28d59e1935a6474f854d030a18e2a52ea5cd258d"
+source = "git+https://github.com/heroku/buildpacks-go/?rev=2a86fae18332b9bd495eb29422c13ac3fcb2d0dc#2a86fae18332b9bd495eb29422c13ac3fcb2d0dc"
 dependencies = [
  "hex",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "toml",

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -12,6 +12,7 @@ heroku-nodejs-utils.workspace = true
 libcnb = { version = "=0.21.0", features = ["trace"] }
 libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["download", "fs", "log", "tar"] }
 serde = "1"
+sha2 = "0.10.8"
 tempfile = "3"
 thiserror = "1"
 toml = "0.8"

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "28d59e1935a6474f854d030a18e2a52ea5cd258d" }
+heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "2a86fae18332b9bd495eb29422c13ac3fcb2d0dc" }
 heroku-nodejs-utils.workspace = true
 libcnb = { version = "=0.21.0", features = ["trace"] }
 libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["download", "fs", "log", "tar"] }

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
+heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "28d59e1935a6474f854d030a18e2a52ea5cd258d" }
 heroku-nodejs-utils.workspace = true
 libcnb = { version = "=0.21.0", features = ["trace"] }
 libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["download", "fs", "log", "tar"] }

--- a/buildpacks/nodejs-engine/inventory.toml
+++ b/buildpacks/nodejs-engine/inventory.toml
@@ -1,9830 +1,7825 @@
-name = "Node.js"
-
-[[releases]]
-version = "0.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.0-darwin-x64.tar.gz"
-etag = "739c200ca266266ff150ad4d89b83205"
-
-[[releases]]
-version = "0.10.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.1-darwin-x64.tar.gz"
-etag = "add2c86408c51ca108e2014030dded1d"
-
-[[releases]]
-version = "0.10.10"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.10-darwin-x64.tar.gz"
-etag = "f6721ca79d7402ddc881ea8f4380b0c2"
-
-[[releases]]
-version = "0.10.11"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.11-darwin-x64.tar.gz"
-etag = "ce0674b2322d7c33664212d211aa4bb9"
-
-[[releases]]
-version = "0.10.12"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.12-darwin-x64.tar.gz"
-etag = "23804ca5de6d2a6139ead017faf1ed60"
-
-[[releases]]
-version = "0.10.13"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.13-darwin-x64.tar.gz"
-etag = "d5a63c84cdb39b470f7ad3dc45c2727a"
-
-[[releases]]
-version = "0.10.14"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.14-darwin-x64.tar.gz"
-etag = "4386f721ba4e862b946f163b62cf61db"
-
-[[releases]]
-version = "0.10.15"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.15-darwin-x64.tar.gz"
-etag = "996c64a09c2a36cddfbf3cdfce493a51"
-
-[[releases]]
-version = "0.10.16"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.16-darwin-x64.tar.gz"
-etag = "d53b6340de354eb048cc7703a44e9b33"
-
-[[releases]]
-version = "0.10.17"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.17-darwin-x64.tar.gz"
-etag = "f67479fe9e0524344a50407575f6c251"
-
-[[releases]]
-version = "0.10.18"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.18-darwin-x64.tar.gz"
-etag = "0aa4270c3c6b2907041ac0d4e1d06731"
-
-[[releases]]
-version = "0.10.19"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.19-darwin-x64.tar.gz"
-etag = "d84eaf1d2a4445ae99d55f0c3a3b5cb0"
-
-[[releases]]
-version = "0.10.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.2-darwin-x64.tar.gz"
-etag = "d7217ca7e7710e04d8f4071bf601874b"
-
-[[releases]]
-version = "0.10.20"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.20-darwin-x64.tar.gz"
-etag = "165eb79335dfa844823ed07eebd571ba"
-
-[[releases]]
-version = "0.10.21"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.21-darwin-x64.tar.gz"
-etag = "4cd170168374738bc0c1818c94592be5"
-
-[[releases]]
-version = "0.10.22"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.22-darwin-x64.tar.gz"
-etag = "3541e529c8be6ac367b388a68d32844f"
-
-[[releases]]
-version = "0.10.23"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.23-darwin-x64.tar.gz"
-etag = "8dc094d98bd38f521f84016d4a0ea6d4"
-
-[[releases]]
-version = "0.10.24"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.24-darwin-x64.tar.gz"
-etag = "6127fae6281e5e40dc353e05da190e93"
-
-[[releases]]
-version = "0.10.25"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.25-darwin-x64.tar.gz"
-etag = "9323f6b7987407b9eb8d1402c7741f1a"
-
-[[releases]]
-version = "0.10.26"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.26-darwin-x64.tar.gz"
-etag = "34520fbfd822d3899b49eeaafcdbf170"
-
-[[releases]]
-version = "0.10.27"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.27-darwin-x64.tar.gz"
-etag = "a799579a84476983eb6e387f5185ebf0"
-
-[[releases]]
-version = "0.10.28"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.28-darwin-x64.tar.gz"
-etag = "fffb965e05b2c6f0b7a7b22f33ffad34"
-
-[[releases]]
-version = "0.10.29"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.29-darwin-x64.tar.gz"
-etag = "beb1de9f25c28f417d493124f0e49e53"
-
-[[releases]]
-version = "0.10.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.3-darwin-x64.tar.gz"
-etag = "b7effabcbff4fe1dca4e8a5c6bc1fb5c"
-
-[[releases]]
-version = "0.10.30"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.30-darwin-x64.tar.gz"
-etag = "3973ca6d1367474ca02850fb5d7a9d57"
-
-[[releases]]
-version = "0.10.31"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.31-darwin-x64.tar.gz"
-etag = "7a833d417b76c305366b09102eda94d0"
-
-[[releases]]
-version = "0.10.32"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.32-darwin-x64.tar.gz"
-etag = "bd5a65196c2ebe33c0251f19c5321b52"
-
-[[releases]]
-version = "0.10.33"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.33-darwin-x64.tar.gz"
-etag = "6fba8115b885c622d06683d75c676f48"
-
-[[releases]]
-version = "0.10.34"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.34-darwin-x64.tar.gz"
-etag = "62a928fc2a73d860c460865cf123c575"
-
-[[releases]]
-version = "0.10.35"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.35-darwin-x64.tar.gz"
-etag = "7d8e8de66e727e9bc51dead89a7b14cc"
-
-[[releases]]
-version = "0.10.36"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.36-darwin-x64.tar.gz"
-etag = "215ab4fb1cf6e767650ef0d3cd606e17"
-
-[[releases]]
-version = "0.10.37"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.37-darwin-x64.tar.gz"
-etag = "0603dedf1d2026c2331b669f53dc26e1"
-
-[[releases]]
-version = "0.10.38"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.38-darwin-x64.tar.gz"
-etag = "03a18da46350772ecae75ed58908477c"
-
-[[releases]]
-version = "0.10.39"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.39-darwin-x64.tar.gz"
-etag = "e5f59d0ee5a09c81d78395c1dd993a46"
-
-[[releases]]
-version = "0.10.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.4-darwin-x64.tar.gz"
-etag = "9fbb0184a5df999712948124cf09dc05"
-
-[[releases]]
-version = "0.10.40"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.40-darwin-x64.tar.gz"
-etag = "76c54366530314da504a5007f15a5aec"
-
-[[releases]]
-version = "0.10.41"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.41-darwin-x64.tar.gz"
-etag = "c677ea00932040e381c23cbd44c0803c"
-
-[[releases]]
-version = "0.10.42"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.42-darwin-x64.tar.gz"
-etag = "a6ba39e90330d93157d57285a64ec452"
-
-[[releases]]
-version = "0.10.43"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.43-darwin-x64.tar.gz"
-etag = "9f780366c50e11d2568a8625a59daff7"
-
-[[releases]]
-version = "0.10.44"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.44-darwin-x64.tar.gz"
-etag = "d8d2ea8e88b0f2cd5ae7aed433fc311e"
-
-[[releases]]
-version = "0.10.45"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.45-darwin-x64.tar.gz"
-etag = "a17db31698018e08a476eedc5e598b6e"
-
-[[releases]]
-version = "0.10.46"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.46-darwin-x64.tar.gz"
-etag = "5f73583d287cf3914f07f787792b5d9c"
-
-[[releases]]
-version = "0.10.47"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.47-darwin-x64.tar.gz"
-etag = "d63dfd67feabdd2cbe45d4abec11d9e3"
-
-[[releases]]
-version = "0.10.48"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.48-darwin-x64.tar.gz"
-etag = "8f543018e5a064588c3bb702cadccafd"
-
-[[releases]]
-version = "0.10.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.5-darwin-x64.tar.gz"
-etag = "38fe9f773e5a5ff45c3fec18d1049985"
-
-[[releases]]
-version = "0.10.6"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.6-darwin-x64.tar.gz"
-etag = "7a5967f8f2c1ecf88e82d00e63171fb4"
-
-[[releases]]
-version = "0.10.7"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.7-darwin-x64.tar.gz"
-etag = "55bc3ff33a8f1f75a87e1833fddea26e"
-
-[[releases]]
-version = "0.10.8"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.8-darwin-x64.tar.gz"
-etag = "3a1cf754787f708b693ba306c4acf169"
-
-[[releases]]
-version = "0.10.9"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.10.9-darwin-x64.tar.gz"
-etag = "a7328931bb7bd251c7d41dbf927e0d41"
-
-[[releases]]
-version = "0.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.0-darwin-x64.tar.gz"
-etag = "38f7c4238b49e8c4073e754f7ffdb19c"
-
-[[releases]]
-version = "0.11.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.1-darwin-x64.tar.gz"
-etag = "32608390f1fe57f48c187f1c9d2b4e18"
-
-[[releases]]
-version = "0.11.10"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.10-darwin-x64.tar.gz"
-etag = "738f72c339d4071c8e61c793da2e52d1"
-
-[[releases]]
-version = "0.11.11"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.11-darwin-x64.tar.gz"
-etag = "982cc2b49d3e5babdf5bd562fe4c0926"
-
-[[releases]]
-version = "0.11.12"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.12-darwin-x64.tar.gz"
-etag = "afcf17c85420c2c73e45339ded62fa8d"
-
-[[releases]]
-version = "0.11.13"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.13-darwin-x64.tar.gz"
-etag = "21ad4ffb7818e0a417db9337259c396e"
-
-[[releases]]
-version = "0.11.14"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.14-darwin-x64.tar.gz"
-etag = "002ed72f0088c5dddbb1be01c2af0638"
-
-[[releases]]
-version = "0.11.15"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.15-darwin-x64.tar.gz"
-etag = "e3d0eb56dd809049e5702c73d4045a78"
-
-[[releases]]
-version = "0.11.16"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.16-darwin-x64.tar.gz"
-etag = "73634a80432dbbfacada263f6cec36cb"
-
-[[releases]]
-version = "0.11.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.2-darwin-x64.tar.gz"
-etag = "3feeee79ae46834e75572c625c0f0542"
-
-[[releases]]
-version = "0.11.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.3-darwin-x64.tar.gz"
-etag = "1e56e19afbd95bd795c20056eed4933a"
-
-[[releases]]
-version = "0.11.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.4-darwin-x64.tar.gz"
-etag = "ae5c57a9f852fbc9529423e65aa8b696"
-
-[[releases]]
-version = "0.11.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.5-darwin-x64.tar.gz"
-etag = "d50ee079ce3cbb49d3f41afef4fecb23"
-
-[[releases]]
-version = "0.11.6"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.6-darwin-x64.tar.gz"
-etag = "6b2ccf9eb054ee10d0673b9357c9a297"
-
-[[releases]]
-version = "0.11.7"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.7-darwin-x64.tar.gz"
-etag = "196d5b28789d1ee20e038193ef7a23de"
-
-[[releases]]
-version = "0.11.8"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.8-darwin-x64.tar.gz"
-etag = "d483c05cbb31924d3bdea30f26f49d23"
-
-[[releases]]
-version = "0.11.9"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.11.9-darwin-x64.tar.gz"
-etag = "f89e4994ab1c7277a78a0e6d4c0899c3"
-
-[[releases]]
-version = "0.12.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.0-darwin-x64.tar.gz"
-etag = "1d8d0e3c3c0ccfd45c055b42c26c1ca7"
-
-[[releases]]
-version = "0.12.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.1-darwin-x64.tar.gz"
-etag = "592ba6e0e99bd8fc58e448f5d9e500cc"
-
-[[releases]]
-version = "0.12.10"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.10-darwin-x64.tar.gz"
-etag = "d9ee01290fc87e63206fb30b5069bb11"
-
-[[releases]]
-version = "0.12.11"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.11-darwin-x64.tar.gz"
-etag = "416dac6ff5d849922bf1d3e0d724bae4"
-
-[[releases]]
-version = "0.12.12"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.12-darwin-x64.tar.gz"
-etag = "ef7e7ab15d21c2d2648293937d0ae44a"
-
-[[releases]]
-version = "0.12.13"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.13-darwin-x64.tar.gz"
-etag = "c6803787452700a9ec319ec2286ff8de"
-
-[[releases]]
-version = "0.12.14"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.14-darwin-x64.tar.gz"
-etag = "e3205a937b4540885f1063f797fce988"
-
-[[releases]]
-version = "0.12.15"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.15-darwin-x64.tar.gz"
-etag = "419ace8c46216989e12a741a44a7731a"
-
-[[releases]]
-version = "0.12.16"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.16-darwin-x64.tar.gz"
-etag = "ee30295fa1aefbfb225463a3b8456363"
-
-[[releases]]
-version = "0.12.17"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.17-darwin-x64.tar.gz"
-etag = "b0b4f1030e12d2b512bbcf90732baf0d"
-
-[[releases]]
-version = "0.12.18"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.18-darwin-x64.tar.gz"
-etag = "49c80986b9d5b1acbf6ad8a1999b6cea"
-
-[[releases]]
-version = "0.12.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.2-darwin-x64.tar.gz"
-etag = "fb2fd0e602bc4c0ee4daaff5dac200c6"
-
-[[releases]]
-version = "0.12.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.3-darwin-x64.tar.gz"
-etag = "e35219a458ddb2e9e6c24d119b02d1b3"
-
-[[releases]]
-version = "0.12.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.4-darwin-x64.tar.gz"
-etag = "b9f311cd43f3e51ac4123f7750989d95"
-
-[[releases]]
-version = "0.12.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.5-darwin-x64.tar.gz"
-etag = "0d7ed0f9aab35c791b8064f18b6e2745"
-
-[[releases]]
-version = "0.12.6"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.6-darwin-x64.tar.gz"
-etag = "f435cb7650ae7d4019b51e08c4d62d65"
-
-[[releases]]
-version = "0.12.7"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.7-darwin-x64.tar.gz"
-etag = "ca4897256e00f5b8523cb84e85ad83ea"
-
-[[releases]]
-version = "0.12.8"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.8-darwin-x64.tar.gz"
-etag = "5c25cb525ac6f97b5c0c2eec00111623"
-
-[[releases]]
-version = "0.12.9"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.12.9-darwin-x64.tar.gz"
-etag = "45b61d6b3c5cdaac0f4046db0565ecbc"
-
-[[releases]]
-version = "0.8.10"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.10-darwin-x64.tar.gz"
-etag = "56dab27cc904791dd324a29e30fe8ae7"
-
-[[releases]]
-version = "0.8.11"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.11-darwin-x64.tar.gz"
-etag = "a35e1376822d0fbad51daadde7cabad7"
-
-[[releases]]
-version = "0.8.12"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.12-darwin-x64.tar.gz"
-etag = "60547b643e4f0966a20cf42407466563"
-
-[[releases]]
-version = "0.8.13"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.13-darwin-x64.tar.gz"
-etag = "61337c8953075670391a8752bda13bda"
-
-[[releases]]
-version = "0.8.14"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.14-darwin-x64.tar.gz"
-etag = "a2c406dddc355c67a6d56fc54d8d39bd"
-
-[[releases]]
-version = "0.8.15"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.15-darwin-x64.tar.gz"
-etag = "b1bf7b088912361e46b5138b64475516"
-
-[[releases]]
-version = "0.8.16"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.16-darwin-x64.tar.gz"
-etag = "face3eaa75cd5aba019ee978813c1d17"
-
-[[releases]]
-version = "0.8.17"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.17-darwin-x64.tar.gz"
-etag = "57832104e0536cb63412197159fe77cf"
-
-[[releases]]
-version = "0.8.18"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.18-darwin-x64.tar.gz"
-etag = "02ee6073e6a87f7c9c00dd602db07163"
-
-[[releases]]
-version = "0.8.19"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.19-darwin-x64.tar.gz"
-etag = "e8b346a4f69ae83767424550af3dd4d0"
-
-[[releases]]
-version = "0.8.20"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.20-darwin-x64.tar.gz"
-etag = "cb0c253f4fcca6b91614e5e56854b311"
-
-[[releases]]
-version = "0.8.21"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.21-darwin-x64.tar.gz"
-etag = "38319ebdc4d2d85d60344f483de0283b"
-
-[[releases]]
-version = "0.8.22"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.22-darwin-x64.tar.gz"
-etag = "fbf42b4daf46c9e116ed01fff61b4c23"
-
-[[releases]]
-version = "0.8.23"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.23-darwin-x64.tar.gz"
-etag = "3f6a2cb26cdf7f350b5d2e2ccea98c77"
-
-[[releases]]
-version = "0.8.24"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.24-darwin-x64.tar.gz"
-etag = "a42122be1f420bdf57c251babf5d8070"
-
-[[releases]]
-version = "0.8.25"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.25-darwin-x64.tar.gz"
-etag = "e89e8300224a071d31ca80c507b9a1f1"
-
-[[releases]]
-version = "0.8.26"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.26-darwin-x64.tar.gz"
-etag = "d280e8b57089db7620373b7d398dc39a"
-
-[[releases]]
-version = "0.8.27"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.27-darwin-x64.tar.gz"
-etag = "3028f490e2e457d67aeb8d4f2835fd33"
-
-[[releases]]
-version = "0.8.28"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.28-darwin-x64.tar.gz"
-etag = "6ab1225ea01032b87d2a9a08adb3402e"
-
-[[releases]]
-version = "0.8.6"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.6-darwin-x64.tar.gz"
-etag = "b5ff6ae04cbf8fe84bc0cffca9fdff7b"
-
-[[releases]]
-version = "0.8.7"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.7-darwin-x64.tar.gz"
-etag = "324266fbf25ba05282209f5bbd60ff11"
-
-[[releases]]
-version = "0.8.8"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.8-darwin-x64.tar.gz"
-etag = "084e6edf8e73a97344cea02fa868e3b1"
-
-[[releases]]
-version = "0.8.9"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.8.9-darwin-x64.tar.gz"
-etag = "07fe9ebaf6b620cd6ba74370c4f35882"
-
-[[releases]]
-version = "0.9.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.1-darwin-x64.tar.gz"
-etag = "50be3aa0d3ee2cede7b4ab972e5175d5"
-
-[[releases]]
-version = "0.9.10"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.10-darwin-x64.tar.gz"
-etag = "88120d7fa1717334114e4a80d0cb0365"
-
-[[releases]]
-version = "0.9.11"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.11-darwin-x64.tar.gz"
-etag = "795a3c869bdb384b34b68e6406bf145f"
-
-[[releases]]
-version = "0.9.12"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.12-darwin-x64.tar.gz"
-etag = "8a56c23f7a5e3724e1bface4398f83ba"
-
-[[releases]]
-version = "0.9.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.2-darwin-x64.tar.gz"
-etag = "0c9a0e751ee1b069c835039cc1116f15"
-
-[[releases]]
-version = "0.9.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.3-darwin-x64.tar.gz"
-etag = "8141db63871daaaada2db8b8982a1429"
-
-[[releases]]
-version = "0.9.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.4-darwin-x64.tar.gz"
-etag = "e9062b989187f679e81070773d041ca5"
-
-[[releases]]
-version = "0.9.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.5-darwin-x64.tar.gz"
-etag = "43c36503c316aee0bd66ea360e0d26e0"
-
-[[releases]]
-version = "0.9.6"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.6-darwin-x64.tar.gz"
-etag = "f31a916da408a2c33e2902e9c393be97"
-
-[[releases]]
-version = "0.9.7"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.7-darwin-x64.tar.gz"
-etag = "acb9e55c00a49b1b5ef1226b3b66e327"
-
-[[releases]]
-version = "0.9.8"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.8-darwin-x64.tar.gz"
-etag = "077b15f7b31a1143e008f8ca3a2a747a"
-
-[[releases]]
-version = "0.9.9"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v0.9.9-darwin-x64.tar.gz"
-etag = "fda6cf91f58e44dfa9686915ba00b29f"
-
-[[releases]]
-version = "10.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.0.0-darwin-x64.tar.gz"
-etag = "489d0568ea937a3e5041fad18649b51e"
-
-[[releases]]
-version = "10.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.1.0-darwin-x64.tar.gz"
-etag = "075338fcbfb421d80b8b272167367149-2"
-
-[[releases]]
-version = "10.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.10.0-darwin-x64.tar.gz"
-etag = "c21bffff553546ac2776cdb28fb7363c-2"
-
-[[releases]]
-version = "10.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.11.0-darwin-x64.tar.gz"
-etag = "7c1f911d3b24c71f9f0718b93d9bb6b8-2"
-
-[[releases]]
-version = "10.12.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.12.0-darwin-x64.tar.gz"
-etag = "ffe227e5a6512104f9c2414fafb1b55a-2"
-
-[[releases]]
-version = "10.13.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.13.0-darwin-x64.tar.gz"
-etag = "d5f7998b145c354695fd17fae1b3f02b-2"
-
-[[releases]]
-version = "10.14.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.14.0-darwin-x64.tar.gz"
-etag = "c121ed62304a207ba5c7f6b49037fd1b-2"
-
-[[releases]]
-version = "10.14.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.14.1-darwin-x64.tar.gz"
-etag = "eed04220f203896d319837b77919dcff-2"
-
-[[releases]]
-version = "10.14.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.14.2-darwin-x64.tar.gz"
-etag = "b1d3e9268544048430ab8ff3e08b4483-2"
-
-[[releases]]
-version = "10.15.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.15.0-darwin-x64.tar.gz"
-etag = "7ff7b375d370a97fcd4746f2541fefa0-2"
-
-[[releases]]
-version = "10.15.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.15.1-darwin-x64.tar.gz"
-etag = "7ea7702617b20c5deb6416261782630a-2"
-
-[[releases]]
-version = "10.15.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.15.2-darwin-x64.tar.gz"
-etag = "963ffeecd266832a954db7724fcd86fe-2"
-
-[[releases]]
-version = "10.15.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.15.3-darwin-x64.tar.gz"
-etag = "6b7bb08f102bb5e4e8dee88b46548fb7-2"
-
-[[releases]]
-version = "10.16.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.16.0-darwin-x64.tar.gz"
-etag = "70b927cdc7bc9d0fd3bc558e5a205cca-3"
-
-[[releases]]
-version = "10.16.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.16.1-darwin-x64.tar.gz"
-etag = "782b24811bc14de243941e17e3e3603c-3"
-
-[[releases]]
-version = "10.16.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.16.2-darwin-x64.tar.gz"
-etag = "cbabef467c591e4d643ec6174f0ec122-3"
-
-[[releases]]
-version = "10.16.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.16.3-darwin-x64.tar.gz"
-etag = "8740ea019b634b1947bbbbfce372c8ee-3"
-
-[[releases]]
-version = "10.17.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.17.0-darwin-x64.tar.gz"
-etag = "c288126f9b163ae8f210d4be4e544be7-3"
-
-[[releases]]
-version = "10.18.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.18.0-darwin-x64.tar.gz"
-etag = "0c95534e9dac2cc99fac2f0ddc1bcd46-3"
-
-[[releases]]
-version = "10.18.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.18.1-darwin-x64.tar.gz"
-etag = "1beab3e621a27924a076f88bbd0180f8-3"
-
-[[releases]]
-version = "10.19.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.19.0-darwin-x64.tar.gz"
-etag = "06ce71192fd267dd866827edccda5996-3"
-
-[[releases]]
-version = "10.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.2.0-darwin-x64.tar.gz"
-etag = "0ea30daa604b1bd929ee178d40af8352-2"
-
-[[releases]]
-version = "10.2.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.2.1-darwin-x64.tar.gz"
-etag = "aa160c78897cd7245bee4412f3bc96e2-2"
-
-[[releases]]
-version = "10.20.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.20.0-darwin-x64.tar.gz"
-etag = "9333a777f0a74f5b7ea87550d74262c3-3"
-
-[[releases]]
-version = "10.20.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.20.1-darwin-x64.tar.gz"
-etag = "878c0c4323e31dd9106d756abb0b9002-3"
-
-[[releases]]
-version = "10.21.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.21.0-darwin-x64.tar.gz"
-etag = "3df5c0dec214c35f2d731726733b1c6a-3"
-
-[[releases]]
-version = "10.22.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.22.0-darwin-x64.tar.gz"
-etag = "0037544c07933ec1d5da9c33092f6831-3"
-
-[[releases]]
-version = "10.22.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.22.1-darwin-x64.tar.gz"
-etag = "d32be387d0f7f21abf2642e23d47b19c-3"
-
-[[releases]]
-version = "10.23.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.23.0-darwin-x64.tar.gz"
-etag = "7d35b632cb913bb0cee161b3f949932f-3"
-
-[[releases]]
-version = "10.23.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.23.1-darwin-x64.tar.gz"
-etag = "292b25a4474b5829b2ac34a1ecc32100-3"
-
-[[releases]]
-version = "10.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.3.0-darwin-x64.tar.gz"
-etag = "b60c4138233e6dbd81136991478d3ce8"
-
-[[releases]]
-version = "10.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.4.0-darwin-x64.tar.gz"
-etag = "fdfe32890237401b1074b76f4531d7af"
-
-[[releases]]
-version = "10.4.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.4.1-darwin-x64.tar.gz"
-etag = "a2f3db9e73ef1289b98fab580efd1829"
-
-[[releases]]
-version = "10.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.5.0-darwin-x64.tar.gz"
-etag = "ab1b49dcd29791ef0183c6aa4cb00885"
-
-[[releases]]
-version = "10.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.6.0-darwin-x64.tar.gz"
-etag = "48ae42cdab07fa348621cf5525847605"
-
-[[releases]]
-version = "10.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.7.0-darwin-x64.tar.gz"
-etag = "1339db7e1ce0b9a626f49451319ea4c5"
-
-[[releases]]
-version = "10.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.8.0-darwin-x64.tar.gz"
-etag = "cceaa14bbe1408de6a2b00c4b941205b"
-
-[[releases]]
-version = "10.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v10.9.0-darwin-x64.tar.gz"
-etag = "589b2b59735c2756fa3ab64cdfb1f1a9"
-
-[[releases]]
-version = "11.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.0.0-darwin-x64.tar.gz"
-etag = "ecc3e19ec147553f53a1d55cd7985054"
-
-[[releases]]
-version = "11.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.1.0-darwin-x64.tar.gz"
-etag = "58249d44f40a5a5299fa83f3fd1ee36c"
-
-[[releases]]
-version = "11.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.10.0-darwin-x64.tar.gz"
-etag = "bf5fd780114c9e7981146a4909e2ffde"
-
-[[releases]]
-version = "11.10.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.10.1-darwin-x64.tar.gz"
-etag = "80ac0921ffeca782eabae1e543cf5a1d"
-
-[[releases]]
-version = "11.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.11.0-darwin-x64.tar.gz"
-etag = "736858f23fb79479af941461817424a4"
-
-[[releases]]
-version = "11.12.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.12.0-darwin-x64.tar.gz"
-etag = "77636576d7ba54c52a984e9891413b16"
-
-[[releases]]
-version = "11.13.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.13.0-darwin-x64.tar.gz"
-etag = "56d811e1709ae0ba4b591ee2489003c3"
-
-[[releases]]
-version = "11.14.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.14.0-darwin-x64.tar.gz"
-etag = "59478d7f4976d5d4248b8e6d24b19270"
-
-[[releases]]
-version = "11.15.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.15.0-darwin-x64.tar.gz"
-etag = "3cc7ff95006b05b6d8cb7b727388c19b"
-
-[[releases]]
-version = "11.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.2.0-darwin-x64.tar.gz"
-etag = "3dbded714a5cebaf5ac447c4484e32fe"
-
-[[releases]]
-version = "11.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.3.0-darwin-x64.tar.gz"
-etag = "d15a0a760aeb7fcd4c0b6a25529759c0"
-
-[[releases]]
-version = "11.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.4.0-darwin-x64.tar.gz"
-etag = "0badf49f8d6aa6d8132916052547865d"
-
-[[releases]]
-version = "11.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.5.0-darwin-x64.tar.gz"
-etag = "f1968a180739aec5a35e7778b77d4bea"
-
-[[releases]]
-version = "11.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.6.0-darwin-x64.tar.gz"
-etag = "bc6044faecbd1a216d11ab8ac05f3a41"
-
-[[releases]]
-version = "11.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.7.0-darwin-x64.tar.gz"
-etag = "ccea4d6956bf66ce6af96cefb93d1f04"
-
-[[releases]]
-version = "11.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.8.0-darwin-x64.tar.gz"
-etag = "d7d522f5bf1e1821d258cdb3ebf87e7c"
-
-[[releases]]
-version = "11.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v11.9.0-darwin-x64.tar.gz"
-etag = "1dce07e744fd518a9d3bf1611c0e721a"
-
-[[releases]]
-version = "12.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.0.0-darwin-x64.tar.gz"
-etag = "9bd5425992b3e8b27542dd0017140feb"
-
-[[releases]]
-version = "12.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.1.0-darwin-x64.tar.gz"
-etag = "f6464cf5569dcd84a7930dd463636418"
-
-[[releases]]
-version = "12.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.10.0-darwin-x64.tar.gz"
-etag = "ae17569da0e787b77f7811b255c528cb"
-
-[[releases]]
-version = "12.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.11.0-darwin-x64.tar.gz"
-etag = "cfb6ddede26476faa95e4e445dee6254"
-
-[[releases]]
-version = "12.11.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.11.1-darwin-x64.tar.gz"
-etag = "870f6467a4e95f1d3b29f08f8158dde1"
-
-[[releases]]
-version = "12.12.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.12.0-darwin-x64.tar.gz"
-etag = "72b892d17a1de38b40cddd7fdb39e8e7"
-
-[[releases]]
-version = "12.13.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.13.0-darwin-x64.tar.gz"
-etag = "e5cb03e25d7996ae24a230a4512c5817"
-
-[[releases]]
-version = "12.13.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.13.1-darwin-x64.tar.gz"
-etag = "1df6f5862c67e5cf377ee8661ed730f4"
-
-[[releases]]
-version = "12.14.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.14.0-darwin-x64.tar.gz"
-etag = "1ec6c21238c6af4b8c2cb20ae6630df8"
-
-[[releases]]
-version = "12.14.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.14.1-darwin-x64.tar.gz"
-etag = "d98df77c47b0b83b3d0cb04d97374e90"
-
-[[releases]]
-version = "12.15.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.15.0-darwin-x64.tar.gz"
-etag = "8bf0ff87a9cd53de20f9905a4266b445"
-
-[[releases]]
-version = "12.16.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.16.0-darwin-x64.tar.gz"
-etag = "5504043d93837eeee1fb3dbfaa52eaa6"
-
-[[releases]]
-version = "12.16.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.16.1-darwin-x64.tar.gz"
-etag = "3bcfe9b7553b9836878c87394d585fbd"
-
-[[releases]]
-version = "12.16.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.16.2-darwin-x64.tar.gz"
-etag = "51645a099c321d971733a645e37847bc"
-
-[[releases]]
-version = "12.16.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.16.3-darwin-x64.tar.gz"
-etag = "db0e17a2dffe405e6077c817131a823d-3"
-
-[[releases]]
-version = "12.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.2.0-darwin-x64.tar.gz"
-etag = "d95b66b6c81e4bbddd94b7ddfa4a4a2f"
-
-[[releases]]
-version = "12.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.3.0-darwin-x64.tar.gz"
-etag = "3b55e52fc17ba959ce339c7fdcee0f56"
-
-[[releases]]
-version = "12.3.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.3.1-darwin-x64.tar.gz"
-etag = "67a1cf0fd7d2b623ff3503f5026b21d4"
-
-[[releases]]
-version = "12.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.4.0-darwin-x64.tar.gz"
-etag = "1327d9429ca77b14ce14b52b622031f2"
-
-[[releases]]
-version = "12.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.5.0-darwin-x64.tar.gz"
-etag = "ace7c880c8178bbdbdc2efae749a9ac7"
-
-[[releases]]
-version = "12.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.6.0-darwin-x64.tar.gz"
-etag = "383b60f419a752c565bfeb1b95a0e843-3"
-
-[[releases]]
-version = "12.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.7.0-darwin-x64.tar.gz"
-etag = "de537f6e5640466b44d7774b61616864-3"
-
-[[releases]]
-version = "12.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.8.0-darwin-x64.tar.gz"
-etag = "a6bf0fad73dd99a3eb92c8dffdf73a9e"
-
-[[releases]]
-version = "12.8.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.8.1-darwin-x64.tar.gz"
-etag = "4c89a11e9cf7c81fdccaaaa23243a52a-3"
-
-[[releases]]
-version = "12.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.9.0-darwin-x64.tar.gz"
-etag = "db54bea21ff05b1faf4515b62df166cc"
-
-[[releases]]
-version = "12.9.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v12.9.1-darwin-x64.tar.gz"
-etag = "b6c2184b83c94254b3267e485b9540c5-3"
-
-[[releases]]
-version = "13.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.0.0-darwin-x64.tar.gz"
-etag = "9c1d16f64f45ae8f041ede55f9ca3f27-4"
-
-[[releases]]
-version = "13.0.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.0.1-darwin-x64.tar.gz"
-etag = "2e9b0f36d6f58841817fc6eb178e8a09-4"
-
-[[releases]]
-version = "13.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.1.0-darwin-x64.tar.gz"
-etag = "60da832dd768d69cd01dbfccad8fc154-4"
-
-[[releases]]
-version = "13.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.10.0-darwin-x64.tar.gz"
-etag = "0908ebf0f16e61c25083f66bb37f115a-4"
-
-[[releases]]
-version = "13.10.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.10.1-darwin-x64.tar.gz"
-etag = "56e611f1cb321731eb1ef238991ef4da-4"
-
-[[releases]]
-version = "13.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.11.0-darwin-x64.tar.gz"
-etag = "4370def07b18d225755e4acca647593d-4"
-
-[[releases]]
-version = "13.12.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.12.0-darwin-x64.tar.gz"
-etag = "f014fcc400f09fc071ea300b7b68eed3-4"
-
-[[releases]]
-version = "13.13.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.13.0-darwin-x64.tar.gz"
-etag = "1503b4a33b739dffa30cb28609c3c882-4"
-
-[[releases]]
-version = "13.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.2.0-darwin-x64.tar.gz"
-etag = "6b7239eebb6bc344cc2e642014ea8402-4"
-
-[[releases]]
-version = "13.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.3.0-darwin-x64.tar.gz"
-etag = "a2090fb5b2388c6e3a970d66a982b267"
-
-[[releases]]
-version = "13.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.4.0-darwin-x64.tar.gz"
-etag = "22c2828a7db7547e4c5487b7cd18f2ce-4"
-
-[[releases]]
-version = "13.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.5.0-darwin-x64.tar.gz"
-etag = "7099d8d7eece8092aadf065201195309-4"
-
-[[releases]]
-version = "13.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.6.0-darwin-x64.tar.gz"
-etag = "4b02b6953ad7f299be3047e9337abbd9"
-
-[[releases]]
-version = "13.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.7.0-darwin-x64.tar.gz"
-etag = "86d6f2e39c4163584ba86e18abad26fb-4"
-
-[[releases]]
-version = "13.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.8.0-darwin-x64.tar.gz"
-etag = "363e99e2177ffbf685410148cb4cf701-4"
-
-[[releases]]
-version = "13.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v13.9.0-darwin-x64.tar.gz"
-etag = "25433a0b64a3b71b981656b01b3b0031"
-
-[[releases]]
-version = "16.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v16.2.0-darwin-x64.tar.gz"
-etag = "a5edf585cde418ce69f99eb1c99e4910-4"
-
-[[releases]]
-version = "4.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.0.0-darwin-x64.tar.gz"
-etag = "fd64ae33e7757293e6fe1acf660fd8fa"
-
-[[releases]]
-version = "4.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.1.0-darwin-x64.tar.gz"
-etag = "8ca7483120975d1510ab651d56630941"
-
-[[releases]]
-version = "4.1.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.1.1-darwin-x64.tar.gz"
-etag = "8a51c6314c0e43a911cd214bb34ca383"
-
-[[releases]]
-version = "4.1.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.1.2-darwin-x64.tar.gz"
-etag = "31a3ee2f51bb2018501048f543ea31c7"
-
-[[releases]]
-version = "4.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.0-darwin-x64.tar.gz"
-etag = "7372a81b1c6b8340c99421d55a0eda71"
-
-[[releases]]
-version = "4.2.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.1-darwin-x64.tar.gz"
-etag = "1570be16287504d7bd5410c6b047cf0c"
-
-[[releases]]
-version = "4.2.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.2-darwin-x64.tar.gz"
-etag = "7fa842ce2a6070b09e0dc774d5d9f81c"
-
-[[releases]]
-version = "4.2.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.3-darwin-x64.tar.gz"
-etag = "ba6c1db01e0fc29c94106d294959f63e"
-
-[[releases]]
-version = "4.2.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.4-darwin-x64.tar.gz"
-etag = "3a68493cd518e34f9cc913ea351b0d76"
-
-[[releases]]
-version = "4.2.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.5-darwin-x64.tar.gz"
-etag = "14934b5f60737cd3e2ee01fa5fad16e7"
-
-[[releases]]
-version = "4.2.6"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.2.6-darwin-x64.tar.gz"
-etag = "cab166afc09599e5b6946c2246aff0bf"
-
-[[releases]]
-version = "4.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.3.0-darwin-x64.tar.gz"
-etag = "e83bc0721bbd693d87e6d4a5739eff16"
-
-[[releases]]
-version = "4.3.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.3.1-darwin-x64.tar.gz"
-etag = "9a55c96b5c23e9d317cb7f5db2a8d9fc"
-
-[[releases]]
-version = "4.3.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.3.2-darwin-x64.tar.gz"
-etag = "1a621360147e89d351dd7262652d6f84"
-
-[[releases]]
-version = "4.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.0-darwin-x64.tar.gz"
-etag = "5392ac884a1e0acdf0011eb7fe6d10c3"
-
-[[releases]]
-version = "4.4.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.1-darwin-x64.tar.gz"
-etag = "b9ea0c459baa3ebea63cf59ae60373c0"
-
-[[releases]]
-version = "4.4.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.2-darwin-x64.tar.gz"
-etag = "b9acc9f1ff3bf474bc33e92b78a06fd3"
-
-[[releases]]
-version = "4.4.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.3-darwin-x64.tar.gz"
-etag = "32e4ce24aefbdd19e9b2306a8a0d6d3b"
-
-[[releases]]
-version = "4.4.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.4-darwin-x64.tar.gz"
-etag = "1f4c9fd5f68f7b626eb0d48c562d3250"
-
-[[releases]]
-version = "4.4.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.5-darwin-x64.tar.gz"
-etag = "553d2f47ade9312a3cb23192df927603"
-
-[[releases]]
-version = "4.4.6"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.6-darwin-x64.tar.gz"
-etag = "9db907435908ae769f0188605b4ce385"
-
-[[releases]]
-version = "4.4.7"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.4.7-darwin-x64.tar.gz"
-etag = "b2e25ef68900d66cca801bd149ad5fb4"
-
-[[releases]]
-version = "4.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.5.0-darwin-x64.tar.gz"
-etag = "5260810ee7c15d615552257a0d38a15d"
-
-[[releases]]
-version = "4.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.6.0-darwin-x64.tar.gz"
-etag = "89e85f848a731326a993a29cfe225db8"
-
-[[releases]]
-version = "4.6.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.6.1-darwin-x64.tar.gz"
-etag = "535ebadbee21b7a725143686bc662bcc"
-
-[[releases]]
-version = "4.6.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.6.2-darwin-x64.tar.gz"
-etag = "e20736b12e738b28c40e322bce66c399"
-
-[[releases]]
-version = "4.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.7.0-darwin-x64.tar.gz"
-etag = "d6f8e02a4a60e320e5cb7c8795a5a96f"
-
-[[releases]]
-version = "4.7.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.7.1-darwin-x64.tar.gz"
-etag = "0545346f38c803f039f8f63cbe9d8327"
-
-[[releases]]
-version = "4.7.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.7.2-darwin-x64.tar.gz"
-etag = "499521a44c1b2c174c70e0a903287179"
-
-[[releases]]
-version = "4.7.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.7.3-darwin-x64.tar.gz"
-etag = "36ec677543797d5d80cafc3e76cf788c"
-
-[[releases]]
-version = "4.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.0-darwin-x64.tar.gz"
-etag = "2160ab2fc4b3d97e30923c8ce73ff6e8"
-
-[[releases]]
-version = "4.8.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.1-darwin-x64.tar.gz"
-etag = "04aedde750aa1bf01f16f9d0ae5f0c9c"
-
-[[releases]]
-version = "4.8.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.2-darwin-x64.tar.gz"
-etag = "cd776a58cf3b1ba65f295094ab958087"
-
-[[releases]]
-version = "4.8.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.3-darwin-x64.tar.gz"
-etag = "d98c95d3735f911a836c6dca72416f00"
-
-[[releases]]
-version = "4.8.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.4-darwin-x64.tar.gz"
-etag = "591d6e6146d29ae62a1b9f885b72f652"
-
-[[releases]]
-version = "4.8.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.5-darwin-x64.tar.gz"
-etag = "9a8a87347201348b756baf733d88c3a1"
-
-[[releases]]
-version = "4.8.6"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.6-darwin-x64.tar.gz"
-etag = "9a270f3accb5c13ee9a7d238c6b630ec"
-
-[[releases]]
-version = "4.8.7"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.8.7-darwin-x64.tar.gz"
-etag = "3ec65a0ca5617bafad196f22487b4e92"
-
-[[releases]]
-version = "4.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.9.0-darwin-x64.tar.gz"
-etag = "ab0e0f28d3899e69bc8695ded2f78cda"
-
-[[releases]]
-version = "4.9.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v4.9.1-darwin-x64.tar.gz"
-etag = "45e1a8ac9e641a82acf976516f435842"
-
-[[releases]]
-version = "5.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.0.0-darwin-x64.tar.gz"
-etag = "b30997758fa2e89cca5434b06cbed440"
-
-[[releases]]
-version = "5.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.1.0-darwin-x64.tar.gz"
-etag = "d531d26ebec53b1ae00e99af25ae2a18"
-
-[[releases]]
-version = "5.1.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.1.1-darwin-x64.tar.gz"
-etag = "c52f962aeb14444c44c12280056f4cc3"
-
-[[releases]]
-version = "5.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.10.0-darwin-x64.tar.gz"
-etag = "9a8d8014841ffff463810b4d1c665f70"
-
-[[releases]]
-version = "5.10.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.10.1-darwin-x64.tar.gz"
-etag = "1dcc9d712dd2df5df88623c72309bf81"
-
-[[releases]]
-version = "5.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.11.0-darwin-x64.tar.gz"
-etag = "c4d12d0bd233b1674de585e2c50896d2"
-
-[[releases]]
-version = "5.11.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.11.1-darwin-x64.tar.gz"
-etag = "7106c928dabe9fde7159bc209e0115cc"
-
-[[releases]]
-version = "5.12.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.12.0-darwin-x64.tar.gz"
-etag = "46f848fd273ad87f5b9250d8312b7387"
-
-[[releases]]
-version = "5.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.2.0-darwin-x64.tar.gz"
-etag = "db1ae727932b933053862880fa6e5611"
-
-[[releases]]
-version = "5.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.3.0-darwin-x64.tar.gz"
-etag = "cd724378cf7f2c38934ef9361fdd3e9c"
-
-[[releases]]
-version = "5.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.4.0-darwin-x64.tar.gz"
-etag = "8e797a6e476e071fa09f59275f04cca3"
-
-[[releases]]
-version = "5.4.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.4.1-darwin-x64.tar.gz"
-etag = "4a8f9ebb26b5c6858799a32caf90a8ad"
-
-[[releases]]
-version = "5.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.5.0-darwin-x64.tar.gz"
-etag = "7f5c3e0cfc6866d99633c238139f1957"
-
-[[releases]]
-version = "5.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.6.0-darwin-x64.tar.gz"
-etag = "6644c279d0c9e178e87fe5c9b4ac3887"
-
-[[releases]]
-version = "5.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.7.0-darwin-x64.tar.gz"
-etag = "cbfa878e61eeedc29090e96e74783954"
-
-[[releases]]
-version = "5.7.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.7.1-darwin-x64.tar.gz"
-etag = "0db5fb88acd4ba2d65ba68459297c595"
-
-[[releases]]
-version = "5.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.8.0-darwin-x64.tar.gz"
-etag = "c939f95036066bd7f2629a2804c88e39"
-
-[[releases]]
-version = "5.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.9.0-darwin-x64.tar.gz"
-etag = "387926afe9499ffbe8c8417ed452936a"
-
-[[releases]]
-version = "5.9.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v5.9.1-darwin-x64.tar.gz"
-etag = "25ea4f9c9f6752e9464ebb876f588915"
-
-[[releases]]
-version = "6.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.0.0-darwin-x64.tar.gz"
-etag = "484a3058a2f75664f0c74cae4198ef99"
-
-[[releases]]
-version = "6.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.1.0-darwin-x64.tar.gz"
-etag = "97c09ca684eb6c3e8bf1a7dbbdf4394d"
-
-[[releases]]
-version = "6.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.10.0-darwin-x64.tar.gz"
-etag = "cdcd0f8f7bd8ba7665a3a645a32f9140"
-
-[[releases]]
-version = "6.10.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.10.1-darwin-x64.tar.gz"
-etag = "72d70fe5e6fe2c4123c9d313c8f852a1"
-
-[[releases]]
-version = "6.10.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.10.2-darwin-x64.tar.gz"
-etag = "df91310e47f2442b23e146cc02a6f825"
-
-[[releases]]
-version = "6.10.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.10.3-darwin-x64.tar.gz"
-etag = "c4cc8c509739f40960828aa9c87ef84a"
-
-[[releases]]
-version = "6.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.0-darwin-x64.tar.gz"
-etag = "af9fcf8ac3c2bd248c04f953488bce39"
-
-[[releases]]
-version = "6.11.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.1-darwin-x64.tar.gz"
-etag = "5250d8876d1d36fb31f08a149de6975b"
-
-[[releases]]
-version = "6.11.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.2-darwin-x64.tar.gz"
-etag = "1dc8b1cada5c2f0c651a5aa964dd8352"
-
-[[releases]]
-version = "6.11.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.3-darwin-x64.tar.gz"
-etag = "4ac55d1366cd86c93c25fdcd7cbf8e77"
-
-[[releases]]
-version = "6.11.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.4-darwin-x64.tar.gz"
-etag = "5ae64364557a952c05077c47bad7c0e4"
-
-[[releases]]
-version = "6.11.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.11.5-darwin-x64.tar.gz"
-etag = "2f2759d8b7a5d7827ec81ad38559f436"
-
-[[releases]]
-version = "6.12.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.12.0-darwin-x64.tar.gz"
-etag = "1ac3996e047fecba6a795720d910f254"
-
-[[releases]]
-version = "6.12.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.12.1-darwin-x64.tar.gz"
-etag = "01c3d1dcd37be7a64f89739300f75e6f"
-
-[[releases]]
-version = "6.12.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.12.2-darwin-x64.tar.gz"
-etag = "2647861a42f2052d31601b651cfd722b"
-
-[[releases]]
-version = "6.12.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.12.3-darwin-x64.tar.gz"
-etag = "1c5c373a464ed3b6d7de76b13f5dbc8a"
-
-[[releases]]
-version = "6.13.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.13.0-darwin-x64.tar.gz"
-etag = "8739711a000b22819add0f4a5c9ce90f"
-
-[[releases]]
-version = "6.13.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.13.1-darwin-x64.tar.gz"
-etag = "9a17508fc8573c92095fa7dfa9c20015"
-
-[[releases]]
-version = "6.14.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.0-darwin-x64.tar.gz"
-etag = "91b1b235028d51939f983d8682d2160a"
-
-[[releases]]
-version = "6.14.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.1-darwin-x64.tar.gz"
-etag = "8e28708fd099ccd09aee2c7bd4132b12"
-
-[[releases]]
-version = "6.14.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.2-darwin-x64.tar.gz"
-etag = "32708275cb56de819a9e8422b553e0ca"
-
-[[releases]]
-version = "6.14.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.3-darwin-x64.tar.gz"
-etag = "7351e1f2ae8bcc326c0898e25b71407f"
-
-[[releases]]
-version = "6.14.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.14.4-darwin-x64.tar.gz"
-etag = "0bb04f12c5041367429175a765e0f948"
-
-[[releases]]
-version = "6.15.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.15.0-darwin-x64.tar.gz"
-etag = "d8db6fa9ab2757996604a0b6e5af31d4"
-
-[[releases]]
-version = "6.15.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.15.1-darwin-x64.tar.gz"
-etag = "f4c860c829f4749ee9196f94239cd2ad"
-
-[[releases]]
-version = "6.16.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.16.0-darwin-x64.tar.gz"
-etag = "ece449be5f8b9a7a5acc6d7c75d2a97e"
-
-[[releases]]
-version = "6.17.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.17.0-darwin-x64.tar.gz"
-etag = "0a3afceae5144b47d497c01d40e57fed"
-
-[[releases]]
-version = "6.17.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.17.1-darwin-x64.tar.gz"
-etag = "55394ba4babf46ec8eeded045c1c8c56"
-
-[[releases]]
-version = "6.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.2.0-darwin-x64.tar.gz"
-etag = "26c088c39aa083ce07422ccc7af6d825"
-
-[[releases]]
-version = "6.2.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.2.1-darwin-x64.tar.gz"
-etag = "1bdc85854a27b84c5f9ed0132217b62f"
-
-[[releases]]
-version = "6.2.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.2.2-darwin-x64.tar.gz"
-etag = "6d2ea41938c4ccee53bde9423b1991fc"
-
-[[releases]]
-version = "6.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.3.0-darwin-x64.tar.gz"
-etag = "11ad99b9cf675ace0da8ca880369a338"
-
-[[releases]]
-version = "6.3.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.3.1-darwin-x64.tar.gz"
-etag = "7ad393945bf4b90e2e4c8737035a8167"
-
-[[releases]]
-version = "6.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.4.0-darwin-x64.tar.gz"
-etag = "a39aea666fef161df8e515189d318bbd"
-
-[[releases]]
-version = "6.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.5.0-darwin-x64.tar.gz"
-etag = "44080b266b0312ed1ebe054538be520a"
-
-[[releases]]
-version = "6.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.6.0-darwin-x64.tar.gz"
-etag = "aaf636350e51238f9ebba403741df2ea"
-
-[[releases]]
-version = "6.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.7.0-darwin-x64.tar.gz"
-etag = "cdb82558b770dd763cb7d2f3c9364287"
-
-[[releases]]
-version = "6.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.8.0-darwin-x64.tar.gz"
-etag = "3a0f016ee726588d0e01131b4f779bae"
-
-[[releases]]
-version = "6.8.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.8.1-darwin-x64.tar.gz"
-etag = "f2789ba98dd571b18c652b9cfb3dde0c"
-
-[[releases]]
-version = "6.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.0-darwin-x64.tar.gz"
-etag = "c1fab809f9d2e6e4593e726f4977327b"
-
-[[releases]]
-version = "6.9.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.1-darwin-x64.tar.gz"
-etag = "3e48d814a8bf69b2f42cea40daa3d252"
-
-[[releases]]
-version = "6.9.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.2-darwin-x64.tar.gz"
-etag = "8cdf2b717e404a37872bd3d4f0aee6f6"
-
-[[releases]]
-version = "6.9.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.3-darwin-x64.tar.gz"
-etag = "681d8aeff603aec817d3aa17ef88e34f"
-
-[[releases]]
-version = "6.9.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.4-darwin-x64.tar.gz"
-etag = "cfc3eff29e952b7f5c15ec0bf10ff877"
-
-[[releases]]
-version = "6.9.5"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v6.9.5-darwin-x64.tar.gz"
-etag = "1c4e82ed6c23c454bec36533581b48bd"
-
-[[releases]]
-version = "7.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.0.0-darwin-x64.tar.gz"
-etag = "e54f28c735c95991f3988c6ac0b8962f"
-
-[[releases]]
-version = "7.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.1.0-darwin-x64.tar.gz"
-etag = "46423bbe029458f5d495fa89b0e3ac8e"
-
-[[releases]]
-version = "7.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.10.0-darwin-x64.tar.gz"
-etag = "8d9bca96db9aa8b3c55dda544bb16ea8"
-
-[[releases]]
-version = "7.10.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.10.1-darwin-x64.tar.gz"
-etag = "17cc75617a63682f5c6cf51db5d08c23"
-
-[[releases]]
-version = "7.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.2.0-darwin-x64.tar.gz"
-etag = "9adf88beaad7bb1822ba65ad57e47df4"
-
-[[releases]]
-version = "7.2.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.2.1-darwin-x64.tar.gz"
-etag = "65c680fef9e82f03d720df5b4774af88"
-
-[[releases]]
-version = "7.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.3.0-darwin-x64.tar.gz"
-etag = "6ae4dd30d0470e2ac2ee181e78548d99"
-
-[[releases]]
-version = "7.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.4.0-darwin-x64.tar.gz"
-etag = "7daf628c7d2e8ac005dad53b35982930"
-
-[[releases]]
-version = "7.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.5.0-darwin-x64.tar.gz"
-etag = "0d885817d79da925d7da51f2144a1347"
-
-[[releases]]
-version = "7.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.6.0-darwin-x64.tar.gz"
-etag = "4f907c748933a9e6cce841239d708098"
-
-[[releases]]
-version = "7.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.0-darwin-x64.tar.gz"
-etag = "1040d8bcfca44e0fe80d8d6b76036b4b"
-
-[[releases]]
-version = "7.7.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.1-darwin-x64.tar.gz"
-etag = "8faf4f7704f956143a7b527f12dc656d"
-
-[[releases]]
-version = "7.7.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.2-darwin-x64.tar.gz"
-etag = "e8638adc89c219708629e0fdba15cfb4"
-
-[[releases]]
-version = "7.7.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.3-darwin-x64.tar.gz"
-etag = "0b62b1c7c4e0d7c4c1de458c6cbd2cec"
-
-[[releases]]
-version = "7.7.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.7.4-darwin-x64.tar.gz"
-etag = "7149579b4722d2026fc56e3df1dd2f84"
-
-[[releases]]
-version = "7.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.8.0-darwin-x64.tar.gz"
-etag = "95726bc5cb0207f65f47dffe0d6a320a"
-
-[[releases]]
-version = "7.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v7.9.0-darwin-x64.tar.gz"
-etag = "c4b1f398626b760f3e0ceb1c04d178f1"
-
-[[releases]]
-version = "8.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.0.0-darwin-x64.tar.gz"
-etag = "d1014f2aa625d100861367f7f93be1d6"
-
-[[releases]]
-version = "8.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.0-darwin-x64.tar.gz"
-etag = "e70963faa98945377a197c5f663c3cd8"
-
-[[releases]]
-version = "8.1.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.1-darwin-x64.tar.gz"
-etag = "f6fefeacd699294845fa4b255f9ad19a"
-
-[[releases]]
-version = "8.1.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.2-darwin-x64.tar.gz"
-etag = "0e218035c649612f1d1af2a9472b8e1b"
-
-[[releases]]
-version = "8.1.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.3-darwin-x64.tar.gz"
-etag = "7b66582e833f35e18de5914a35c5254c"
-
-[[releases]]
-version = "8.1.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.1.4-darwin-x64.tar.gz"
-etag = "0455fa02b87a530d86bcd2e790d4cf49"
-
-[[releases]]
-version = "8.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.10.0-darwin-x64.tar.gz"
-etag = "2f8c39ba3d09bbf9af648dce29608e2a"
-
-[[releases]]
-version = "8.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.0-darwin-x64.tar.gz"
-etag = "ed495410c5288975b251739954a65038"
-
-[[releases]]
-version = "8.11.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.1-darwin-x64.tar.gz"
-etag = "346c568c2f2ab7e0b804f2122a313d86"
-
-[[releases]]
-version = "8.11.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.2-darwin-x64.tar.gz"
-etag = "a7a4c8391bf5543c64658d7e5776c936"
-
-[[releases]]
-version = "8.11.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.3-darwin-x64.tar.gz"
-etag = "6211a102bd368c4f83a869c8b9b4b184"
-
-[[releases]]
-version = "8.11.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.11.4-darwin-x64.tar.gz"
-etag = "c30ef72d947f05a2a803f7bfd32d511b"
-
-[[releases]]
-version = "8.12.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.12.0-darwin-x64.tar.gz"
-etag = "f1489227237471edcbe1f02505b49ce4"
-
-[[releases]]
-version = "8.13.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.13.0-darwin-x64.tar.gz"
-etag = "77934dd4a77be45aab6069a2e2cc327c"
-
-[[releases]]
-version = "8.14.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.14.0-darwin-x64.tar.gz"
-etag = "cd6cfa062d4f62e7126ad653f8ed42aa"
-
-[[releases]]
-version = "8.14.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.14.1-darwin-x64.tar.gz"
-etag = "bf1e2d414c9b8b4ced0fb921536396fd"
-
-[[releases]]
-version = "8.15.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.15.0-darwin-x64.tar.gz"
-etag = "2b8d16fd1b804feb2534e5dc9d513e4f"
-
-[[releases]]
-version = "8.15.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.15.1-darwin-x64.tar.gz"
-etag = "bf05532c0ef3262c5a40a4af4ee8273a"
-
-[[releases]]
-version = "8.16.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.16.0-darwin-x64.tar.gz"
-etag = "765e9fb02e197f83d80f8afddf97438d"
-
-[[releases]]
-version = "8.16.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.16.1-darwin-x64.tar.gz"
-etag = "0d5148d32e59dafe82c772ede431290c"
-
-[[releases]]
-version = "8.16.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.16.2-darwin-x64.tar.gz"
-etag = "f5e20750bcc2d5b8642c1d0221f5ae71"
-
-[[releases]]
-version = "8.17.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.17.0-darwin-x64.tar.gz"
-etag = "794cf5d11fa08aab90c69e879f82a117"
-
-[[releases]]
-version = "8.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.2.0-darwin-x64.tar.gz"
-etag = "765fff5503c98f32d56c6a6554a3bae1"
-
-[[releases]]
-version = "8.2.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.2.1-darwin-x64.tar.gz"
-etag = "8dab18d4f2443c267367571c1cfb1e5f"
-
-[[releases]]
-version = "8.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.3.0-darwin-x64.tar.gz"
-etag = "6264f0d513f85377f95c96a0c6f6ab63"
-
-[[releases]]
-version = "8.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.4.0-darwin-x64.tar.gz"
-etag = "1be19a34c6159d40d96d603c14065752"
-
-[[releases]]
-version = "8.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.5.0-darwin-x64.tar.gz"
-etag = "e57d9b45d1deece35bf55c00b8c5ee92"
-
-[[releases]]
-version = "8.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.6.0-darwin-x64.tar.gz"
-etag = "628fe6b9683cf36ca808a998f5b6088b"
-
-[[releases]]
-version = "8.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.7.0-darwin-x64.tar.gz"
-etag = "87aa0c918a883f1a452a738dfb32a1de"
-
-[[releases]]
-version = "8.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.8.0-darwin-x64.tar.gz"
-etag = "5253bd34ddafc932d97d159492c810b6"
-
-[[releases]]
-version = "8.8.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.8.1-darwin-x64.tar.gz"
-etag = "0ebbd83692c7cde9c5de3cb3b188387f"
-
-[[releases]]
-version = "8.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.0-darwin-x64.tar.gz"
-etag = "8fc9f439dd896a56d546ceadb948c5b2"
-
-[[releases]]
-version = "8.9.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.1-darwin-x64.tar.gz"
-etag = "e7bfe8c32ce33f3a740538b12d4caa4e"
-
-[[releases]]
-version = "8.9.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.2-darwin-x64.tar.gz"
-etag = "db46704db0fd7d3f2cb40668c6dad63c"
-
-[[releases]]
-version = "8.9.3"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.3-darwin-x64.tar.gz"
-etag = "5827bb2a09c8979471030dae5c9f2943"
-
-[[releases]]
-version = "8.9.4"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v8.9.4-darwin-x64.tar.gz"
-etag = "bdbd711d842acb83238471181aed5687"
-
-[[releases]]
-version = "9.0.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.0.0-darwin-x64.tar.gz"
-etag = "71d7195b015f66c96a2d4e2094071730"
-
-[[releases]]
-version = "9.1.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.1.0-darwin-x64.tar.gz"
-etag = "81331b134680cf948c94baad99ffc69a"
-
-[[releases]]
-version = "9.10.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.10.0-darwin-x64.tar.gz"
-etag = "6983f25374dfcac22057a7f5b200a2e2"
-
-[[releases]]
-version = "9.10.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.10.1-darwin-x64.tar.gz"
-etag = "ebee6028fd9640179794d7c464931739"
-
-[[releases]]
-version = "9.11.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.11.0-darwin-x64.tar.gz"
-etag = "e1ebd4c9d3b14b4d689b18bc7a480d7c"
-
-[[releases]]
-version = "9.11.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.11.1-darwin-x64.tar.gz"
-etag = "6818f9754f3aff86ee0b4c5ee0a339aa"
-
-[[releases]]
-version = "9.11.2"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.11.2-darwin-x64.tar.gz"
-etag = "fc9c918d1ce899d2a48e0062ca4eeae0"
-
-[[releases]]
-version = "9.2.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.2.0-darwin-x64.tar.gz"
-etag = "4fe4f9d2d17e7a961bb354bfe05fc449"
-
-[[releases]]
-version = "9.2.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.2.1-darwin-x64.tar.gz"
-etag = "24fa4bb6425e89df981b699fd7dfd720"
-
-[[releases]]
-version = "9.3.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.3.0-darwin-x64.tar.gz"
-etag = "e78be9b5b17670b2f415c608b685e0a2"
-
-[[releases]]
-version = "9.4.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.4.0-darwin-x64.tar.gz"
-etag = "00af859a02eab98f9dd0c6071695e0a0"
-
-[[releases]]
-version = "9.5.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.5.0-darwin-x64.tar.gz"
-etag = "1dd0ae5e8fd0ec2f65fc49a7970f2210"
-
-[[releases]]
-version = "9.6.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.6.0-darwin-x64.tar.gz"
-etag = "31e5b9ab8daa7da8cc9abb33a176bf13"
-
-[[releases]]
-version = "9.6.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.6.1-darwin-x64.tar.gz"
-etag = "495aacaf16d6d26bb00349721ed709c6"
-
-[[releases]]
-version = "9.7.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.7.0-darwin-x64.tar.gz"
-etag = "a3f595934fe6f421e4db49538baccf7c"
-
-[[releases]]
-version = "9.7.1"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.7.1-darwin-x64.tar.gz"
-etag = "b56bf1c43373b2aed7341032fad4d76f"
-
-[[releases]]
-version = "9.8.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.8.0-darwin-x64.tar.gz"
-etag = "03bad9803dbec17794938f54452cb261"
-
-[[releases]]
-version = "9.9.0"
-channel = "release"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/darwin-x64/node-v9.9.0-darwin-x64.tar.gz"
-etag = "a4c0ab67127c1dbd875dd5967cf9cde8"
-
-[[releases]]
-version = "0.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.0-linux-x64.tar.gz"
-etag = "a586044d93acb053d28dd6c0ddf95362"
-
-[[releases]]
-version = "0.10.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.1-linux-x64.tar.gz"
-etag = "f24a1fca96c717abc050f7526ee0101a"
-
-[[releases]]
-version = "0.10.10"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.10-linux-x64.tar.gz"
-etag = "561e25c025d922f99d158dac813a4526"
-
-[[releases]]
-version = "0.10.11"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.11-linux-x64.tar.gz"
-etag = "037ca782761ac9e704cc34ae9936de75"
-
-[[releases]]
-version = "0.10.12"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.12-linux-x64.tar.gz"
-etag = "e396dfb737f2c396af7e5c459aadce08"
-
-[[releases]]
-version = "0.10.13"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.13-linux-x64.tar.gz"
-etag = "1819a87f2ac617fb8281ae9efa6abe42"
-
-[[releases]]
-version = "0.10.14"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.14-linux-x64.tar.gz"
-etag = "3a5b08dc92cc54ece1645bb47a33331b"
-
-[[releases]]
-version = "0.10.15"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.15-linux-x64.tar.gz"
-etag = "1f0b836dd88c20854459a67a46aa0bef"
-
-[[releases]]
-version = "0.10.16"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.16-linux-x64.tar.gz"
-etag = "3e7980d5d2fe25323b81bf741d41487f"
-
-[[releases]]
-version = "0.10.17"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.17-linux-x64.tar.gz"
-etag = "d26df32e934b88f2db44223c0112ff7b"
-
-[[releases]]
-version = "0.10.18"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.18-linux-x64.tar.gz"
-etag = "7e01855f266474bb4063209e391d4c61"
-
-[[releases]]
-version = "0.10.19"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.19-linux-x64.tar.gz"
-etag = "8222dc2f5d62f3c0f663852aba0a2b83"
-
-[[releases]]
-version = "0.10.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.2-linux-x64.tar.gz"
-etag = "3a42e17ab298349e8236f72c4e39e97a"
-
-[[releases]]
-version = "0.10.20"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.20-linux-x64.tar.gz"
-etag = "37cfd1484fc621078b487ff7678ee2d4"
-
-[[releases]]
-version = "0.10.21"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.21-linux-x64.tar.gz"
-etag = "eab73809ba4ca2840e8dc5f21c873759"
-
-[[releases]]
-version = "0.10.22"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.22-linux-x64.tar.gz"
-etag = "942740fdeceaffe091688a04d87caf2c"
-
-[[releases]]
-version = "0.10.23"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.23-linux-x64.tar.gz"
-etag = "8d39492c18751aed2d77aae60ed8cd64"
-
-[[releases]]
-version = "0.10.24"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.24-linux-x64.tar.gz"
-etag = "e4e23b3ab9ee1d72f98baab8b6aa9aa4"
-
-[[releases]]
-version = "0.10.25"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.25-linux-x64.tar.gz"
-etag = "3738f6c24743f53f520d896ecff5e2b5"
-
-[[releases]]
-version = "0.10.26"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.26-linux-x64.tar.gz"
-etag = "5d41f981ed3bca6cebd4cfc4444537f1"
-
-[[releases]]
-version = "0.10.27"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.27-linux-x64.tar.gz"
-etag = "b2c15782d81eb11c7fed30152217b43d"
-
-[[releases]]
-version = "0.10.28"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.28-linux-x64.tar.gz"
-etag = "693afa81416da3632077bb5c24c168fd"
-
-[[releases]]
-version = "0.10.29"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.29-linux-x64.tar.gz"
-etag = "ea96bef3eda6ebfef38a76ada5ecd24a"
-
-[[releases]]
-version = "0.10.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.3-linux-x64.tar.gz"
-etag = "c9746a7e5ff82bd25fd719b8f36203c1"
-
-[[releases]]
-version = "0.10.30"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.30-linux-x64.tar.gz"
-etag = "e96aebef3cc0feaca0e9a7b73740ed01"
-
-[[releases]]
-version = "0.10.31"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.31-linux-x64.tar.gz"
-etag = "566ce38b1b0b46560ac8edd2f50ab087"
-
-[[releases]]
-version = "0.10.32"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.32-linux-x64.tar.gz"
-etag = "126ed002d88315b8d37cec1ee4915454"
-
-[[releases]]
-version = "0.10.33"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.33-linux-x64.tar.gz"
-etag = "1efad7c248b453ee6c62a706f6f86dbe"
-
-[[releases]]
-version = "0.10.34"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.34-linux-x64.tar.gz"
-etag = "03bc7cfbd7be3a093daaa23b76bafd46"
-
-[[releases]]
-version = "0.10.35"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.35-linux-x64.tar.gz"
-etag = "f3b33eed97772ce3a9341bbeb67511d7"
-
-[[releases]]
-version = "0.10.36"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.36-linux-x64.tar.gz"
-etag = "d40acc6f134bc2ab207e04011f452564"
-
-[[releases]]
-version = "0.10.37"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.37-linux-x64.tar.gz"
-etag = "ad487cb3d4d0fe2c710cffbd25e4f238"
-
-[[releases]]
-version = "0.10.38"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.38-linux-x64.tar.gz"
-etag = "8893f1f5ce16c612ba2805432edc0138"
-
-[[releases]]
-version = "0.10.39"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.39-linux-x64.tar.gz"
-etag = "3994985df38a5b7d74ad8918282f411c"
-
-[[releases]]
-version = "0.10.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.4-linux-x64.tar.gz"
-etag = "7352980adaa9031fa406c5ad7b9617d9"
-
-[[releases]]
-version = "0.10.40"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.40-linux-x64.tar.gz"
-etag = "efacca570a6ed176a9a3ba18957301b6"
-
-[[releases]]
-version = "0.10.41"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.41-linux-x64.tar.gz"
-etag = "ec75dbc572e66d8d4f9ddbf5cde4dacc"
-
-[[releases]]
-version = "0.10.42"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.42-linux-x64.tar.gz"
-etag = "86a2b747beb3e051417f809a97891dc2"
-
-[[releases]]
-version = "0.10.43"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.43-linux-x64.tar.gz"
-etag = "2ce1317a985b6b359b8dfe22ae4d7c1e"
-
-[[releases]]
-version = "0.10.44"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.44-linux-x64.tar.gz"
-etag = "d06b675830ece4b9ebe21eb556ed4a5f"
-
-[[releases]]
-version = "0.10.45"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.45-linux-x64.tar.gz"
-etag = "1b8a131d469b357acdf219bd6536242a"
-
-[[releases]]
-version = "0.10.46"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.46-linux-x64.tar.gz"
-etag = "cd36e700215520e02eda9f2ae4d3fba5"
-
-[[releases]]
-version = "0.10.47"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.47-linux-x64.tar.gz"
-etag = "97cefdf9c1cec1f1737b53cfa64dfed3"
-
-[[releases]]
-version = "0.10.48"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.48-linux-x64.tar.gz"
-etag = "4eed9a2de77191a3c499c6550ce37f5d"
-
-[[releases]]
-version = "0.10.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.5-linux-x64.tar.gz"
-etag = "983f1d6d598038fc0b91da86afaa13a7"
-
-[[releases]]
-version = "0.10.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.6-linux-x64.tar.gz"
-etag = "ef7cca05167075f217981f58ed697a6d"
-
-[[releases]]
-version = "0.10.7"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.7-linux-x64.tar.gz"
-etag = "bd90c722623ba236e8869bb838e7801d"
-
-[[releases]]
-version = "0.10.8"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.8-linux-x64.tar.gz"
-etag = "9f723ebc985687fcaaa7636819d562cb"
-
-[[releases]]
-version = "0.10.9"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.10.9-linux-x64.tar.gz"
-etag = "8b723cf963ad01ddce7ab2d272ab34d6"
-
-[[releases]]
-version = "0.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.0-linux-x64.tar.gz"
-etag = "fda656d4a8691fd5103c91c7e22b7860"
-
-[[releases]]
-version = "0.11.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.1-linux-x64.tar.gz"
-etag = "bc18d6fe82cff1a6c4ed7cae1f90fa7d"
-
-[[releases]]
-version = "0.11.10"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.10-linux-x64.tar.gz"
-etag = "f9723689606eebaf0e05775ff038fb42"
-
-[[releases]]
-version = "0.11.11"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.11-linux-x64.tar.gz"
-etag = "d78cce4da7582d5ba35be115930522ed"
-
-[[releases]]
-version = "0.11.12"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.12-linux-x64.tar.gz"
-etag = "1c3fe24727955b517ff1b4e97a4cc903"
-
-[[releases]]
-version = "0.11.13"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.13-linux-x64.tar.gz"
-etag = "d8cc3a9d98629590b7d5d75e06fa2c61"
-
-[[releases]]
-version = "0.11.14"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.14-linux-x64.tar.gz"
-etag = "a1651a04eabd1097da63f011e13fea91"
-
-[[releases]]
-version = "0.11.15"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.15-linux-x64.tar.gz"
-etag = "eaec6219f25aff616675159c9717dcb9"
-
-[[releases]]
-version = "0.11.16"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.16-linux-x64.tar.gz"
-etag = "c667ab595837821f61306c9d2d3dd3b3"
-
-[[releases]]
-version = "0.11.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.2-linux-x64.tar.gz"
-etag = "2a19da4ca4897e7174960771964dbf8d"
-
-[[releases]]
-version = "0.11.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.3-linux-x64.tar.gz"
-etag = "a026a8e4ad3a28a04ba977a0fba4e930"
-
-[[releases]]
-version = "0.11.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.4-linux-x64.tar.gz"
-etag = "24f4412ef76de3cd44e993d79c9ee59a"
-
-[[releases]]
-version = "0.11.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.5-linux-x64.tar.gz"
-etag = "efd6067e57ea69d5f2474c3e765257a2"
-
-[[releases]]
-version = "0.11.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.6-linux-x64.tar.gz"
-etag = "3da96a942b381da8b8bba9dc5e09db55"
-
-[[releases]]
-version = "0.11.7"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.7-linux-x64.tar.gz"
-etag = "0f03042ca08e6d8e8412de5c5ccd9628"
-
-[[releases]]
-version = "0.11.8"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.8-linux-x64.tar.gz"
-etag = "53e3e7e39b686ac1b42de24d4cafbfdb"
-
-[[releases]]
-version = "0.11.9"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.11.9-linux-x64.tar.gz"
-etag = "3159350bcfc311dca5d414d63e0e3a52"
-
-[[releases]]
-version = "0.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.0-linux-x64.tar.gz"
-etag = "ce648d80c0167b0cfe6ec141466822b9"
-
-[[releases]]
-version = "0.12.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.1-linux-x64.tar.gz"
-etag = "b7546bd69ce043a9470f119a36944afd"
-
-[[releases]]
-version = "0.12.10"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.10-linux-x64.tar.gz"
-etag = "a5a377ac54183786875545974136cb47"
-
-[[releases]]
-version = "0.12.11"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.11-linux-x64.tar.gz"
-etag = "d886f1e126eae1474819d2b349d7130e"
-
-[[releases]]
-version = "0.12.12"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.12-linux-x64.tar.gz"
-etag = "67dabce97df771ba44bcd359bf91cae3"
-
-[[releases]]
-version = "0.12.13"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.13-linux-x64.tar.gz"
-etag = "ecb38dfea79405ce56d706a9ea69bcb7"
-
-[[releases]]
-version = "0.12.14"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.14-linux-x64.tar.gz"
-etag = "a15d1c3eb4fe38084b3042b686fe3a48"
-
-[[releases]]
-version = "0.12.15"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.15-linux-x64.tar.gz"
-etag = "e4c6b41e2e8699b14a17ded28bc8e556"
-
-[[releases]]
-version = "0.12.16"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.16-linux-x64.tar.gz"
-etag = "f2169d4ea96ee2e652308151adc2a308"
-
-[[releases]]
-version = "0.12.17"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.17-linux-x64.tar.gz"
-etag = "77947c84c8f360e84c2d84b78e6534cb"
-
-[[releases]]
-version = "0.12.18"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.18-linux-x64.tar.gz"
-etag = "9ef269e8581f18729001c09cc7bc8e57"
-
-[[releases]]
-version = "0.12.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.2-linux-x64.tar.gz"
-etag = "2cfce07dc35ee1ffe875e166b541df35"
-
-[[releases]]
-version = "0.12.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.3-linux-x64.tar.gz"
-etag = "0bc67ed79e01bcc0c673fa5c21f96c1c"
-
-[[releases]]
-version = "0.12.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.4-linux-x64.tar.gz"
-etag = "a4fd80871c4362d98a52b54ecb45d915"
-
-[[releases]]
-version = "0.12.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.5-linux-x64.tar.gz"
-etag = "d27a934de4763550e0f9fd180428b0be"
-
-[[releases]]
-version = "0.12.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.6-linux-x64.tar.gz"
-etag = "28c0750cd4cef5fc9785d9bfbfb5a72d"
-
-[[releases]]
-version = "0.12.7"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.7-linux-x64.tar.gz"
-etag = "182175d82395171f299e3a05a2ce70a1"
-
-[[releases]]
-version = "0.12.8"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.8-linux-x64.tar.gz"
-etag = "b0a9fe02aa0db91fc27611864da062b9"
-
-[[releases]]
-version = "0.12.9"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.12.9-linux-x64.tar.gz"
-etag = "0282a5cedf4580a6cc515096bd00cc6c"
-
-[[releases]]
-version = "0.8.10"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.10-linux-x64.tar.gz"
-etag = "e7746c57b7e5386d61cb76374b8e9f9d"
-
-[[releases]]
-version = "0.8.11"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.11-linux-x64.tar.gz"
-etag = "0198ab3e509420162819649c569334dd"
-
-[[releases]]
-version = "0.8.12"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.12-linux-x64.tar.gz"
-etag = "05811a262a34cba71aab2b0db099d2c6"
-
-[[releases]]
-version = "0.8.13"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.13-linux-x64.tar.gz"
-etag = "2508f05d2ff7d54a01f3a2df2b22ed00"
-
-[[releases]]
-version = "0.8.14"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.14-linux-x64.tar.gz"
-etag = "6f6c90b4f2a7b21ed5b9ad305201e6f7"
-
-[[releases]]
-version = "0.8.15"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.15-linux-x64.tar.gz"
-etag = "f0194431d70c47c0af6314842712ea8a"
-
-[[releases]]
-version = "0.8.16"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.16-linux-x64.tar.gz"
-etag = "b2d1f86053952db562a1be3351cf1a74"
-
-[[releases]]
-version = "0.8.17"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.17-linux-x64.tar.gz"
-etag = "5fbaf4c6311529486ed9d4e18c3ca8d3"
-
-[[releases]]
-version = "0.8.18"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.18-linux-x64.tar.gz"
-etag = "e60b276e013c5e0cf7fdee5bfc83b04d"
-
-[[releases]]
-version = "0.8.19"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.19-linux-x64.tar.gz"
-etag = "65cdb33fa88321188b9584f7bd2e19f0"
-
-[[releases]]
-version = "0.8.20"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.20-linux-x64.tar.gz"
-etag = "03a051d0d5c1f108f3303bdfc89988ce"
-
-[[releases]]
-version = "0.8.21"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.21-linux-x64.tar.gz"
-etag = "586d562fefa463cbbb362057e3718945"
-
-[[releases]]
-version = "0.8.22"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.22-linux-x64.tar.gz"
-etag = "1a45ed485153bdfacfbaee2a918c1c25"
-
-[[releases]]
-version = "0.8.23"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.23-linux-x64.tar.gz"
-etag = "df5d9ac473f06b75e684a368d3bfdf49"
-
-[[releases]]
-version = "0.8.24"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.24-linux-x64.tar.gz"
-etag = "1716b18cbf1af696a5312a65312d0cc0"
-
-[[releases]]
-version = "0.8.25"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.25-linux-x64.tar.gz"
-etag = "eb9585400192622bfa596d816d786385"
-
-[[releases]]
-version = "0.8.26"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.26-linux-x64.tar.gz"
-etag = "8b32ce92320f974d836239e477e687a6"
-
-[[releases]]
-version = "0.8.27"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.27-linux-x64.tar.gz"
-etag = "35e2b21a7879a2dd97ff198f19519850"
-
-[[releases]]
-version = "0.8.28"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.28-linux-x64.tar.gz"
-etag = "623d6b50f550034074b5928e05ab1a45"
-
-[[releases]]
-version = "0.8.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.6-linux-x64.tar.gz"
-etag = "e8d92d46201ba6e61ee748fc85ad2afa"
-
-[[releases]]
-version = "0.8.7"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.7-linux-x64.tar.gz"
-etag = "7a3bb324b1ad1864162a5ff6e9e5e012"
-
-[[releases]]
-version = "0.8.8"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.8-linux-x64.tar.gz"
-etag = "8a9272ee8d6dd25a09e641c85dd638e7"
-
-[[releases]]
-version = "0.8.9"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.8.9-linux-x64.tar.gz"
-etag = "1b2bc68dfe8c61a63063afeba89f24f3"
-
-[[releases]]
-version = "0.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.1-linux-x64.tar.gz"
-etag = "c2fbb42f94062ea6bdfefc722700604f"
-
-[[releases]]
-version = "0.9.10"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.10-linux-x64.tar.gz"
-etag = "6ee43eee7545622df8ffb44cf187a6f8"
-
-[[releases]]
-version = "0.9.11"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.11-linux-x64.tar.gz"
-etag = "df07d58f3e8f49fd7203c8920eed9850"
-
-[[releases]]
-version = "0.9.12"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.12-linux-x64.tar.gz"
-etag = "a228712b02ef2e8ae4f08378869104ba"
-
-[[releases]]
-version = "0.9.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.2-linux-x64.tar.gz"
-etag = "19133fc15485905898907e322699dff2"
-
-[[releases]]
-version = "0.9.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.3-linux-x64.tar.gz"
-etag = "172eb07f8e840dcbea67a6903411aa3d"
-
-[[releases]]
-version = "0.9.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.4-linux-x64.tar.gz"
-etag = "4b7289787c68baa3194245410ea15204"
-
-[[releases]]
-version = "0.9.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.5-linux-x64.tar.gz"
-etag = "8e312d20333be7ca5ac18545ca81d192"
-
-[[releases]]
-version = "0.9.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.6-linux-x64.tar.gz"
-etag = "a1895c5697faeffa9758e1038a75c333"
-
-[[releases]]
-version = "0.9.7"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.7-linux-x64.tar.gz"
-etag = "d5e013ef6ce93d65b307fdaf7f33bebb"
-
-[[releases]]
-version = "0.9.8"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.8-linux-x64.tar.gz"
-etag = "37c0909b31bc82e30430cc2bea1b2e45"
-
-[[releases]]
-version = "0.9.9"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v0.9.9-linux-x64.tar.gz"
-etag = "b22df68fb53151778c2ebeacb7a204b1"
-
-[[releases]]
-version = "10.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.0.0-linux-x64.tar.gz"
-etag = "815774181214108aa165de58314c6bfb"
-
-[[releases]]
-version = "10.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.1.0-linux-x64.tar.gz"
-etag = "4fb3b7467b19ad7e430f075dbd0ba172-3"
-
-[[releases]]
-version = "10.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.10.0-linux-x64.tar.gz"
-etag = "76edac78bdf3cf3122765736c0f83d9f-3"
-
-[[releases]]
-version = "10.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.11.0-linux-x64.tar.gz"
-etag = "f5f9addfbbfcea477ff8e8afb769850a-3"
-
-[[releases]]
-version = "10.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.12.0-linux-x64.tar.gz"
-etag = "79261291abf863dfd5fe44e949bc1490-3"
-
-[[releases]]
-version = "10.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.13.0-linux-x64.tar.gz"
-etag = "82a34d6ab9e59c96d76415dd9a67bf45-3"
-
-[[releases]]
-version = "10.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.14.0-linux-x64.tar.gz"
-etag = "30700affc50d2c7cf013d7508a43311b-3"
-
-[[releases]]
-version = "10.14.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.14.1-linux-x64.tar.gz"
-etag = "7f79b79070ed256eceac79ad748cf4d4-3"
-
-[[releases]]
-version = "10.14.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.14.2-linux-x64.tar.gz"
-etag = "2d55538fcafdd67b5a3c34fc7843502f-3"
-
-[[releases]]
-version = "10.15.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.15.0-linux-x64.tar.gz"
-etag = "94b54a8e661f3a059d3a218eaf1b4ce3-3"
-
-[[releases]]
-version = "10.15.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.15.1-linux-x64.tar.gz"
-etag = "667c6ce37855b51271f679ff88057f8c-3"
-
-[[releases]]
-version = "10.15.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.15.2-linux-x64.tar.gz"
-etag = "6972a42229b5b343f67dc1360742b7f2-3"
-
-[[releases]]
-version = "10.15.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.15.3-linux-x64.tar.gz"
-etag = "8a137b8f0de8b5b509bc3e118e0d983b-3"
-
-[[releases]]
-version = "10.16.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.16.0-linux-x64.tar.gz"
-etag = "fab40faa3e53cd150159b946f863abfe-3"
-
-[[releases]]
-version = "10.16.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.16.1-linux-x64.tar.gz"
-etag = "d6af63b2b77e3e4a2b2e20ce4fc449bb-3"
-
-[[releases]]
-version = "10.16.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.16.2-linux-x64.tar.gz"
-etag = "9401eed2234274cc0f9c7275ea369426-3"
-
-[[releases]]
-version = "10.16.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.16.3-linux-x64.tar.gz"
-etag = "d76675e5fce26151003c73e033fea3bd-3"
-
-[[releases]]
-version = "10.17.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.17.0-linux-x64.tar.gz"
-etag = "29e85c26db8b6b9f0adfe3f1e5b1857f-3"
-
-[[releases]]
-version = "10.18.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.18.0-linux-x64.tar.gz"
-etag = "2a8533f02ae1985c0d85afaed6887165-3"
-
-[[releases]]
-version = "10.18.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.18.1-linux-x64.tar.gz"
-etag = "bea0cdff6fe012ac53174297693ab349-3"
-
-[[releases]]
-version = "10.19.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.19.0-linux-x64.tar.gz"
-etag = "f482ebf412beeec9b76104467c81d291-3"
-
-[[releases]]
-version = "10.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.2.0-linux-x64.tar.gz"
-etag = "1adcf1141ef740279c0ba5cbd82cc3a4-3"
-
-[[releases]]
-version = "10.2.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.2.1-linux-x64.tar.gz"
-etag = "dbbc0965a912b69434c43b4775f96fa2-3"
-
-[[releases]]
-version = "10.20.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.20.0-linux-x64.tar.gz"
-etag = "44eba89064618c8c2c79402bcd0be63f-3"
-
-[[releases]]
-version = "10.20.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.20.1-linux-x64.tar.gz"
-etag = "b0f14eb6a6310f464c3db7544a3af492-3"
-
-[[releases]]
-version = "10.21.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.21.0-linux-x64.tar.gz"
-etag = "8d2f778b455afe7f80e6d1ea201f5733-3"
-
-[[releases]]
-version = "10.22.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.22.0-linux-x64.tar.gz"
-etag = "7cf59442c716572239cb14fdabb0ead5-3"
-
-[[releases]]
-version = "10.22.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.22.1-linux-x64.tar.gz"
-etag = "92b244406470e9a4f49cc233675fdf96-3"
-
-[[releases]]
-version = "10.23.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.23.0-linux-x64.tar.gz"
-etag = "3cc926fb4db5ad0d0ef161916760c25e-3"
-
-[[releases]]
-version = "10.23.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.23.1-linux-x64.tar.gz"
-etag = "5387220383fd6512e7cab92ef287426f-3"
-
-[[releases]]
-version = "10.23.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.23.2-linux-x64.tar.gz"
-etag = "f511a3763a63e7616fb608416e00a253-3"
-
-[[releases]]
-version = "10.23.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.23.3-linux-x64.tar.gz"
-etag = "6a05b6db3a7e812691eb2992c8287670-3"
-
-[[releases]]
-version = "10.24.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.24.0-linux-x64.tar.gz"
-etag = "b179fd013f51c02a3c77281fe744dd41-3"
-
-[[releases]]
-version = "10.24.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.24.1-linux-x64.tar.gz"
-etag = "957994ef8bf3610b7f0b67365691ebaf-3"
-
-[[releases]]
-version = "10.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.3.0-linux-x64.tar.gz"
-etag = "320a13fa365023bc52d75bb19eff3d7a"
-
-[[releases]]
-version = "10.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.4.0-linux-x64.tar.gz"
-etag = "4ad5730cffe5e745c32b2822cd5e30f1"
-
-[[releases]]
-version = "10.4.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.4.1-linux-x64.tar.gz"
-etag = "72f1a2dda2e73aaa8576d15f7a48ffe4"
-
-[[releases]]
-version = "10.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.5.0-linux-x64.tar.gz"
-etag = "2b54d378a1a0339a649b6a1acb0f7e0c"
-
-[[releases]]
-version = "10.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.6.0-linux-x64.tar.gz"
-etag = "3b6c99e7af8bd950a07353d2992c84b6"
-
-[[releases]]
-version = "10.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.7.0-linux-x64.tar.gz"
-etag = "ecfc64f7b5df211352b0527c09311531"
-
-[[releases]]
-version = "10.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.8.0-linux-x64.tar.gz"
-etag = "b5a4cb8c017c719deceaf5f89936c3d6"
-
-[[releases]]
-version = "10.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v10.9.0-linux-x64.tar.gz"
-etag = "70c617771708c7c4f36d5823fb413600"
-
-[[releases]]
-version = "11.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.0.0-linux-x64.tar.gz"
-etag = "6cc8a0761f4266183190c56b72363e98"
-
-[[releases]]
-version = "11.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.1.0-linux-x64.tar.gz"
-etag = "6f471bc29d30640097c743927c113f02"
-
-[[releases]]
-version = "11.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.10.0-linux-x64.tar.gz"
-etag = "a1239a07fbd8b9dc460e1e44246e5f29"
-
-[[releases]]
-version = "11.10.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.10.1-linux-x64.tar.gz"
-etag = "1e462fb3a741ce0abf3fe2b0d81574e2"
-
-[[releases]]
-version = "11.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.11.0-linux-x64.tar.gz"
-etag = "009c70629178fb47044333aa4a031c77"
-
-[[releases]]
-version = "11.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.12.0-linux-x64.tar.gz"
-etag = "da2736962216075cb9ad09e87a7f300e"
-
-[[releases]]
-version = "11.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.13.0-linux-x64.tar.gz"
-etag = "95d07b2b544793962b0214bd7e33441c"
-
-[[releases]]
-version = "11.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.14.0-linux-x64.tar.gz"
-etag = "d1ec8cc7a5a102c92d5486cfa9e03b00"
-
-[[releases]]
-version = "11.15.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.15.0-linux-x64.tar.gz"
-etag = "ab251fc5b77761064204d00be022fda3"
-
-[[releases]]
-version = "11.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.2.0-linux-x64.tar.gz"
-etag = "6f1e2002e2af3f660ec0d84dda5e8a6a"
-
-[[releases]]
-version = "11.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.3.0-linux-x64.tar.gz"
-etag = "dc1a836d178e97e06107e1673d3caf96"
-
-[[releases]]
-version = "11.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.4.0-linux-x64.tar.gz"
-etag = "2718dafe1f89dd3794a0da222ee365ae"
-
-[[releases]]
-version = "11.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.5.0-linux-x64.tar.gz"
-etag = "7a32d6b4c300f6a7b78f3a28ed4587e3"
-
-[[releases]]
-version = "11.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.6.0-linux-x64.tar.gz"
-etag = "9ab9d9540290c15caad5fdf0a32b40fa"
-
-[[releases]]
-version = "11.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.7.0-linux-x64.tar.gz"
-etag = "35c41456320eb8a712dde2aac4145166"
-
-[[releases]]
-version = "11.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.8.0-linux-x64.tar.gz"
-etag = "7a6bdb9ffd31bc5ae4c6d866b5462826"
-
-[[releases]]
-version = "11.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v11.9.0-linux-x64.tar.gz"
-etag = "8805aeb4cfb798106c6a99ed34536682"
-
-[[releases]]
-version = "12.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.0.0-linux-x64.tar.gz"
-etag = "246f00fcffbd01974f260b4383f91c58"
-
-[[releases]]
-version = "12.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.1.0-linux-x64.tar.gz"
-etag = "d4df5a60e1b73c062131985de2ada621"
-
-[[releases]]
-version = "12.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.10.0-linux-x64.tar.gz"
-etag = "74dc625cf656bd501f0cd08f28e92131"
-
-[[releases]]
-version = "12.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.11.0-linux-x64.tar.gz"
-etag = "3ad3502adff89d3a037cd910ef17f725"
-
-[[releases]]
-version = "12.11.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.11.1-linux-x64.tar.gz"
-etag = "fb56b6d4439d3ccca91a8ff419391c3e"
-
-[[releases]]
-version = "12.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.12.0-linux-x64.tar.gz"
-etag = "41e3b3ccc2e2254869234f1f4c50dffc"
-
-[[releases]]
-version = "12.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.13.0-linux-x64.tar.gz"
-etag = "5f1bc3459c59f8b80cf6ea3d38944da7"
-
-[[releases]]
-version = "12.13.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.13.1-linux-x64.tar.gz"
-etag = "169ca5c7407b7532ed947a2014a48b1e"
-
-[[releases]]
-version = "12.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.14.0-linux-x64.tar.gz"
-etag = "919f124e16acb7464459c58dd2cfd36e"
-
-[[releases]]
-version = "12.14.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.14.1-linux-x64.tar.gz"
-etag = "cf97b81a436bdd484e642660eb769e16"
-
-[[releases]]
-version = "12.15.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.15.0-linux-x64.tar.gz"
-etag = "6c5ee256556aec2f1ca11f02b58d81b4"
-
-[[releases]]
-version = "12.16.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.16.0-linux-x64.tar.gz"
-etag = "7f8d2520e715d7df82f368b0fab9d2b6"
-
-[[releases]]
-version = "12.16.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.16.1-linux-x64.tar.gz"
-etag = "656435219a1655586fe02ac5f8bfa694"
-
-[[releases]]
-version = "12.16.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.16.2-linux-x64.tar.gz"
-etag = "6bd0588c3db32a734d3d0c34ddb05e60"
-
-[[releases]]
-version = "12.16.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.16.3-linux-x64.tar.gz"
-etag = "20963d6e105a6f29c272734f64de5f67"
-
-[[releases]]
-version = "12.17.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.17.0-linux-x64.tar.gz"
-etag = "ae367608adc068358e0f805fbb548cc2"
-
-[[releases]]
-version = "12.18.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.0-linux-x64.tar.gz"
-etag = "f723197769cd3adc449ffa5835193c1f"
-
-[[releases]]
-version = "12.18.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.1-linux-x64.tar.gz"
-etag = "0c26eac16e4b5f0f8d0d4944d38258ef"
-
-[[releases]]
-version = "12.18.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.2-linux-x64.tar.gz"
-etag = "612d831288b3e3d896cde1596e5fe704"
-
-[[releases]]
-version = "12.18.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.3-linux-x64.tar.gz"
-etag = "9e7444e9d66072035f73e9ac0ee51322-3"
-
-[[releases]]
-version = "12.18.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.18.4-linux-x64.tar.gz"
-etag = "fdecf94ced8dcdeb972e14b333c72e47-3"
-
-[[releases]]
-version = "12.19.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.19.0-linux-x64.tar.gz"
-etag = "1962f4127fb09f2942b82f48f4ae2cf8-3"
-
-[[releases]]
-version = "12.19.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.19.1-linux-x64.tar.gz"
-etag = "7851352d2c9d60d4c5779910af828755-3"
-
-[[releases]]
-version = "12.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.2.0-linux-x64.tar.gz"
-etag = "87dc21fee7f484defd9010a6c606aa92"
-
-[[releases]]
-version = "12.20.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.20.0-linux-x64.tar.gz"
-etag = "3383e1624171a83a04740f24831c5c92-3"
-
-[[releases]]
-version = "12.20.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.20.1-linux-x64.tar.gz"
-etag = "51c80c3820855d8e77f37c9a67b9d89b-3"
-
-[[releases]]
-version = "12.20.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.20.2-linux-x64.tar.gz"
-etag = "d296cca07540a62c9c583ce4f23afee7-3"
-
-[[releases]]
-version = "12.21.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.21.0-linux-x64.tar.gz"
-etag = "a0fe4d871fc223d21fbac24689c598fd-3"
-
-[[releases]]
-version = "12.22.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.0-linux-x64.tar.gz"
-etag = "b0eb62d33d028e6cd3f1b7220b962a55-3"
-
-[[releases]]
-version = "12.22.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.1-linux-x64.tar.gz"
-etag = "4648915ed3eb1be12cf7cbe1c5b3e867-3"
-
-[[releases]]
-version = "12.22.10"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.10-linux-x64.tar.gz"
-etag = "58fe1bdc055914f433ee3f07bb380f36-3"
-
-[[releases]]
-version = "12.22.11"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.11-linux-x64.tar.gz"
-etag = "98a9f79ab4d7840b31c95968e82e9569-3"
-
-[[releases]]
-version = "12.22.12"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.12-linux-x64.tar.gz"
-etag = "84488d656cf19837e8dbc27b1a9993c9-3"
-
-[[releases]]
-version = "12.22.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.2-linux-x64.tar.gz"
-etag = "a014e16e46f6c158facd9d48c6a450f7-3"
-
-[[releases]]
-version = "12.22.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.3-linux-x64.tar.gz"
-etag = "41956f3f2a7cbbfc012e0d52facee55d-3"
-
-[[releases]]
-version = "12.22.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.4-linux-x64.tar.gz"
-etag = "461546c7894049caaa06041520e4172e-3"
-
-[[releases]]
-version = "12.22.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.5-linux-x64.tar.gz"
-etag = "2e8f7e52697114e493a312d7c4493fb0-3"
-
-[[releases]]
-version = "12.22.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.6-linux-x64.tar.gz"
-etag = "d61482b86203da8b3542f25723ca8f6a-3"
-
-[[releases]]
-version = "12.22.7"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.7-linux-x64.tar.gz"
-etag = "28b7bdac5d0a1a5361cf4504898d985e-3"
-
-[[releases]]
-version = "12.22.8"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.8-linux-x64.tar.gz"
-etag = "e7ca67cb90ca08afe64d87f9cdfbe2f9-3"
-
-[[releases]]
-version = "12.22.9"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.9-linux-x64.tar.gz"
-etag = "827ab91c2a29f14e1ad39e0fbd2ede10-3"
-
-[[releases]]
-version = "12.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.3.0-linux-x64.tar.gz"
-etag = "123a93553a06e8a7615c444c1ea42882"
-
-[[releases]]
-version = "12.3.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.3.1-linux-x64.tar.gz"
-etag = "82721dca1c9757af1e50fda8f23a0175"
-
-[[releases]]
-version = "12.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.4.0-linux-x64.tar.gz"
-etag = "75341c471626e3155079041fc8737bab"
-
-[[releases]]
-version = "12.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.5.0-linux-x64.tar.gz"
-etag = "7377ca5f3d429dba8069808c57509f24"
-
-[[releases]]
-version = "12.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.6.0-linux-x64.tar.gz"
-etag = "259326813ae277cf8a2cd764c610df8c"
-
-[[releases]]
-version = "12.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.7.0-linux-x64.tar.gz"
-etag = "8d802407f95e54738199fe262311fe61-3"
-
-[[releases]]
-version = "12.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.8.0-linux-x64.tar.gz"
-etag = "2bc1f6bf496bfb6447c3fa129cf8a3d6"
-
-[[releases]]
-version = "12.8.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.8.1-linux-x64.tar.gz"
-etag = "861e3e41d606cba07b8d5e2840a4b3ee-3"
-
-[[releases]]
-version = "12.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.9.0-linux-x64.tar.gz"
-etag = "a0a7f5ea00f4bfc8580c18bfa2499d2c-3"
-
-[[releases]]
-version = "12.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.9.1-linux-x64.tar.gz"
-etag = "74001acf6e4f1980045a985a86b198d1"
-
-[[releases]]
-version = "13.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.0.0-linux-x64.tar.gz"
-etag = "502a2f483442724fee5f9f0211548b88-4"
-
-[[releases]]
-version = "13.0.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.0.1-linux-x64.tar.gz"
-etag = "2baf49181f3e96643fd2ecd11bcadb72-4"
-
-[[releases]]
-version = "13.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.1.0-linux-x64.tar.gz"
-etag = "5f8f1fbe4f22e319c6dbf2a57ee120fd-4"
-
-[[releases]]
-version = "13.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.10.0-linux-x64.tar.gz"
-etag = "21ed55d5eb72662fa397007f059dacc6-4"
-
-[[releases]]
-version = "13.10.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.10.1-linux-x64.tar.gz"
-etag = "9820787c904a8832f20539e85ff5d475-4"
-
-[[releases]]
-version = "13.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.11.0-linux-x64.tar.gz"
-etag = "2af22200c0261f417cf32a3279da2621-4"
-
-[[releases]]
-version = "13.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.12.0-linux-x64.tar.gz"
-etag = "8d22abc5a44d5645c0a9eab6177df570-4"
-
-[[releases]]
-version = "13.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.13.0-linux-x64.tar.gz"
-etag = "b9a24b0caa34a7a12ebb3e31b6830769-4"
-
-[[releases]]
-version = "13.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.14.0-linux-x64.tar.gz"
-etag = "45c315bd788c3505a636fd925445a240"
-
-[[releases]]
-version = "13.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.2.0-linux-x64.tar.gz"
-etag = "d1e63b1e6d2d88fd4b5340dbc1cddc26-4"
-
-[[releases]]
-version = "13.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.3.0-linux-x64.tar.gz"
-etag = "0984273970fbe1b55d46a74132c79768"
-
-[[releases]]
-version = "13.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.4.0-linux-x64.tar.gz"
-etag = "8c9381cc980b97c9da87d8ddfcadd412-4"
-
-[[releases]]
-version = "13.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.5.0-linux-x64.tar.gz"
-etag = "217fc9ae83b23d35bbb28af0647b7289-4"
-
-[[releases]]
-version = "13.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.6.0-linux-x64.tar.gz"
-etag = "5758d37594fa78cabb0b4578771a01fd"
-
-[[releases]]
-version = "13.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.7.0-linux-x64.tar.gz"
-etag = "47a5b05e78d5c8104cc58fd313649633-4"
-
-[[releases]]
-version = "13.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.8.0-linux-x64.tar.gz"
-etag = "a0cc522352876fdb52dc2f7817998dc4-4"
-
-[[releases]]
-version = "13.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v13.9.0-linux-x64.tar.gz"
-etag = "4245c4d98069215fbe0b5cd3742d7e33-4"
-
-[[releases]]
-version = "14.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.0.0-linux-x64.tar.gz"
-etag = "6d385ef3fffc1c5e5d870c590627552f"
-
-[[releases]]
-version = "14.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.1.0-linux-x64.tar.gz"
-etag = "42fffcd3e0ec9789ec127684a1d30539"
-
-[[releases]]
-version = "14.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.10.0-linux-x64.tar.gz"
-etag = "0692912fe38915d832ac97d9c8e75b6f-5"
-
-[[releases]]
-version = "14.10.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.10.1-linux-x64.tar.gz"
-etag = "4cc3f36a5a752141310ce9462b83b9e1-5"
-
-[[releases]]
-version = "14.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.11.0-linux-x64.tar.gz"
-etag = "5f0b0d752a988c5846e2850251d0de6e-5"
-
-[[releases]]
-version = "14.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.12.0-linux-x64.tar.gz"
-etag = "d543750360e322f6172ebbac5180f794-5"
-
-[[releases]]
-version = "14.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.13.0-linux-x64.tar.gz"
-etag = "d8db874594a71ef0a537e563f69403d5-5"
-
-[[releases]]
-version = "14.13.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.13.1-linux-x64.tar.gz"
-etag = "5fd8b1ffb4fe1f889bd39be6911ef12a-5"
-
-[[releases]]
-version = "14.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.14.0-linux-x64.tar.gz"
-etag = "8048c3ed071d05c927c4fbf21b7ce1d8-5"
-
-[[releases]]
-version = "14.15.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.0-linux-x64.tar.gz"
-etag = "53ded239e3e7b19ff58c63a13fc7295a-5"
-
-[[releases]]
-version = "14.15.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.1-linux-x64.tar.gz"
-etag = "ee95fa0dd4b142e075f7f61d6e9fdd3c-5"
-
-[[releases]]
-version = "14.15.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.2-linux-x64.tar.gz"
-etag = "f344e8a0fb555aa7cad8df8ee227c053-4"
-
-[[releases]]
-version = "14.15.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.3-linux-x64.tar.gz"
-etag = "929b59a348873583cf0eece6e997f694-4"
-
-[[releases]]
-version = "14.15.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.4-linux-x64.tar.gz"
-etag = "ad295578e70f4838d619a289c7d7654e-4"
-
-[[releases]]
-version = "14.15.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.15.5-linux-x64.tar.gz"
-etag = "78ef6759634ee37a78d17be7af46ed79-4"
-
-[[releases]]
-version = "14.16.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.16.0-linux-x64.tar.gz"
-etag = "f2cbbae39184fee9c13b611437b10921-4"
-
-[[releases]]
-version = "14.16.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.16.1-linux-x64.tar.gz"
-etag = "e03bf3ea73d969d9c08c8b7ae5493613-4"
-
-[[releases]]
-version = "14.17.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.0-linux-x64.tar.gz"
-etag = "cdc57f6a3cc4ca6f12f49dadd75a554e-5"
-
-[[releases]]
-version = "14.17.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.1-linux-x64.tar.gz"
-etag = "b41c1f2d90ecda727af59f7cc7c5dcfb-5"
-
-[[releases]]
-version = "14.17.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.2-linux-x64.tar.gz"
-etag = "7021d231631d65ece0f74c95bbc43eb3-5"
-
-[[releases]]
-version = "14.17.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.3-linux-x64.tar.gz"
-etag = "0bdbb8e1b6e813dbc040da523831c684-5"
-
-[[releases]]
-version = "14.17.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.4-linux-x64.tar.gz"
-etag = "81ca69987ef377abff2ecb2ae35d7ad7-5"
-
-[[releases]]
-version = "14.17.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.5-linux-x64.tar.gz"
-etag = "4e872307dfbc942a43b0eb5e6e44765c-5"
-
-[[releases]]
-version = "14.17.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.17.6-linux-x64.tar.gz"
-etag = "888e9ad0d2a56802507f3f6cd27f7ebe-5"
-
-[[releases]]
-version = "14.18.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.18.0-linux-x64.tar.gz"
-etag = "a667cd6939a25a71d4773357a693e170-5"
-
-[[releases]]
-version = "14.18.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.18.1-linux-x64.tar.gz"
-etag = "4a620703f674343fe1041b2bd0dfba66-5"
-
-[[releases]]
-version = "14.18.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.18.2-linux-x64.tar.gz"
-etag = "dad4b0c2b0daed55d75fd98500e57d62-5"
-
-[[releases]]
-version = "14.18.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.18.3-linux-x64.tar.gz"
-etag = "af7ed8db30228507dad9cf71afcce543-5"
-
-[[releases]]
-version = "14.19.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.0-linux-x64.tar.gz"
-etag = "06a14f4fdc59ae064ba047d4e9736fa3-5"
-
-[[releases]]
-version = "14.19.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.1-linux-x64.tar.gz"
-etag = "fcb00a3d0c4b22c1b6e157a558949657-5"
-
-[[releases]]
-version = "14.19.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.2-linux-x64.tar.gz"
-etag = "a6dd0bfb2f656166aeefefa37cfa8122-5"
-
-[[releases]]
-version = "14.19.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.3-linux-x64.tar.gz"
-etag = "3990a70c4d0794e8646575c76bff11a7-5"
-
-[[releases]]
-version = "14.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.2.0-linux-x64.tar.gz"
-etag = "130cb565b0fac4199fbc31df53a5f767"
-
-[[releases]]
-version = "14.20.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.20.0-linux-x64.tar.gz"
-etag = "f6da9962195174482d28f10830caf07d-5"
-
-[[releases]]
-version = "14.20.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.20.1-linux-x64.tar.gz"
-etag = "6bd6a27bebf33e019e154c29429dbbb8-5"
-
-[[releases]]
-version = "14.21.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.21.0-linux-x64.tar.gz"
-etag = "f9e6f039213ecb86ce8babadc3649dc9-5"
-
-[[releases]]
-version = "14.21.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.21.1-linux-x64.tar.gz"
-etag = "446470bd964ca7dc06d559b2aab6a123-5"
-
-[[releases]]
-version = "14.21.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.21.2-linux-x64.tar.gz"
-etag = "48813c8f1c235ce08888a9f1240c964c-5"
-
-[[releases]]
-version = "14.21.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.21.3-linux-x64.tar.gz"
-etag = "342cdbb59809aaa41d29ae298f73b365-5"
-
-[[releases]]
-version = "14.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.3.0-linux-x64.tar.gz"
-etag = "801b4e07a0f9686d54f21d56f982843c"
-
-[[releases]]
-version = "14.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.4.0-linux-x64.tar.gz"
-etag = "dd8f4cc53204e154b77729fa7bad99df"
-
-[[releases]]
-version = "14.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.5.0-linux-x64.tar.gz"
-etag = "cd5748870280f52ba9c1b2c35d6e0823"
-
-[[releases]]
-version = "14.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.6.0-linux-x64.tar.gz"
-etag = "e076d8f3ac1ffaf3540b6bff5fa14dd1-5"
-
-[[releases]]
-version = "14.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.7.0-linux-x64.tar.gz"
-etag = "98021eb36abb1d21ed54521a85ce5fa6-5"
-
-[[releases]]
-version = "14.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.8.0-linux-x64.tar.gz"
-etag = "00e00bc07580f6376df8f218b7196594-5"
-
-[[releases]]
-version = "14.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.9.0-linux-x64.tar.gz"
-etag = "2353027766ae1fdc82aa2fefc9cfad25-5"
-
-[[releases]]
-version = "15.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.0.0-linux-x64.tar.gz"
-etag = "39eea40a8dc5ca81ef1010088ae74ea5-5"
-
-[[releases]]
-version = "15.0.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.0.1-linux-x64.tar.gz"
-etag = "4066ea9cd7b29f9084c237a1024872c7-5"
-
-[[releases]]
-version = "15.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.1.0-linux-x64.tar.gz"
-etag = "e1d3af432eb7accbfc614a3cf48c7583-4"
-
-[[releases]]
-version = "15.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.10.0-linux-x64.tar.gz"
-etag = "485a712d740b014662a226e834bd9557-4"
-
-[[releases]]
-version = "15.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.11.0-linux-x64.tar.gz"
-etag = "ef6f1f9484a255594673ca7bcfbed280-4"
-
-[[releases]]
-version = "15.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.12.0-linux-x64.tar.gz"
-etag = "231a5764d7aafa2c8d99fcd147b0e875-4"
-
-[[releases]]
-version = "15.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.13.0-linux-x64.tar.gz"
-etag = "6a6b953c042ee7fca4a7e4482de60dc2-4"
-
-[[releases]]
-version = "15.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.14.0-linux-x64.tar.gz"
-etag = "0f2e0ef70eebc4840eab7547e59880ae-4"
-
-[[releases]]
-version = "15.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.2.0-linux-x64.tar.gz"
-etag = "784df9e5242bb304820b2c14512d9ce3-4"
-
-[[releases]]
-version = "15.2.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.2.1-linux-x64.tar.gz"
-etag = "ca1c922ba43df36fbb23fd8b3a8ea876-4"
-
-[[releases]]
-version = "15.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.3.0-linux-x64.tar.gz"
-etag = "292ba2368577fa093bedb1b7f5014402-4"
-
-[[releases]]
-version = "15.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.4.0-linux-x64.tar.gz"
-etag = "69eeff861c07a0fed33fda82b35a5ecb-4"
-
-[[releases]]
-version = "15.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.5.0-linux-x64.tar.gz"
-etag = "b5bc122b0bb815f48128c67709a76cf0-4"
-
-[[releases]]
-version = "15.5.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.5.1-linux-x64.tar.gz"
-etag = "37e51c2d28beb27f4488fbd5b4a58f59-4"
-
-[[releases]]
-version = "15.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.6.0-linux-x64.tar.gz"
-etag = "aeb1a459afa11e7fc482e0a672cf1fe2-4"
-
-[[releases]]
-version = "15.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.7.0-linux-x64.tar.gz"
-etag = "065a4833bd91372bf26a45a46820f77a-4"
-
-[[releases]]
-version = "15.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.8.0-linux-x64.tar.gz"
-etag = "e88c6266c1926b5c4348ad943e1c2ee2-4"
-
-[[releases]]
-version = "15.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v15.9.0-linux-x64.tar.gz"
-etag = "38308de828100c4f52adb07e8de3cc9d-4"
-
-[[releases]]
-version = "16.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.0.0-linux-x64.tar.gz"
-etag = "9ced677cf96c5ca3b4067f35c21311ac-4"
-
-[[releases]]
-version = "16.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.1.0-linux-x64.tar.gz"
-etag = "8d4e3e558429cf64b22302f210b3d7e5-4"
-
-[[releases]]
-version = "16.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.10.0-linux-x64.tar.gz"
-etag = "d91908102992fad63e2eb2c9b8082553-4"
-
-[[releases]]
-version = "16.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.11.0-linux-x64.tar.gz"
-etag = "c93e9efb20bf3f5807ec0e058bd83d5c-4"
-
-[[releases]]
-version = "16.11.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.11.1-linux-x64.tar.gz"
-etag = "ae7ebdb2d57c11865882e4dc3d6fc5e5-4"
-
-[[releases]]
-version = "16.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.12.0-linux-x64.tar.gz"
-etag = "66344ff27247c29c3a5fbe85fe5acb9d-4"
-
-[[releases]]
-version = "16.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.13.0-linux-x64.tar.gz"
-etag = "d445951da7d338a5d6d758aa24b6804d-4"
-
-[[releases]]
-version = "16.13.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.13.1-linux-x64.tar.gz"
-etag = "5ed5638fad670c7568cb216775f03cc6-4"
-
-[[releases]]
-version = "16.13.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.13.2-linux-x64.tar.gz"
-etag = "8104fa926e76b71b0c22236b24310732-4"
-
-[[releases]]
-version = "16.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.0-linux-x64.tar.gz"
-etag = "5bc4c0b1c1c94fad08c80561e259ee99-4"
-
-[[releases]]
-version = "16.14.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.1-linux-x64.tar.gz"
-etag = "64b4bbdf40af72cd2fe6accfc8054b16-4"
-
-[[releases]]
-version = "16.14.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.2-linux-x64.tar.gz"
-etag = "4db20ae2bbff10cf3c8aa2f7ea370fb0-4"
-
-[[releases]]
-version = "16.15.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.15.0-linux-x64.tar.gz"
-etag = "4df8f054993a43950ef0f2e42b9ff53d-4"
-
-[[releases]]
-version = "16.15.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.15.1-linux-x64.tar.gz"
-etag = "b863d244e4b1c0df901c8c8c8967dd68-4"
-
-[[releases]]
-version = "16.16.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.16.0-linux-x64.tar.gz"
-etag = "ad683ead6ffb89f81e933ab93a9c770a-4"
-
-[[releases]]
-version = "16.17.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.17.0-linux-x64.tar.gz"
-etag = "2525dc9822008f0666d3f0908c4c4c43-5"
-
-[[releases]]
-version = "16.17.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.17.1-linux-x64.tar.gz"
-etag = "f341015b15c91fe90ae9a8d6a3cc9fc8-5"
-
-[[releases]]
-version = "16.18.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.18.0-linux-x64.tar.gz"
-etag = "288b5e721e34d3983f55b0f77d5eb006-5"
-
-[[releases]]
-version = "16.18.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.18.1-linux-x64.tar.gz"
-etag = "64f9e77e6b1548cadb8c9251c7c841eb-5"
-
-[[releases]]
-version = "16.19.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.19.0-linux-x64.tar.gz"
-etag = "2f7c8ff9691c80c08007f26d42a99aaf-5"
-
-[[releases]]
-version = "16.19.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.19.1-linux-x64.tar.gz"
-etag = "243011854e70850bbc464bd26f02cdff-5"
-
-[[releases]]
-version = "16.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.2.0-linux-x64.tar.gz"
-etag = "ee81bd1f587c60c54432650eba4c51bc-4"
-
-[[releases]]
-version = "16.20.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.20.0-linux-x64.tar.gz"
-etag = "c8b5ddcdbfabac844be2ecf344311855-5"
-
-[[releases]]
-version = "16.20.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.20.1-linux-x64.tar.gz"
-etag = "313de9955d2e869fd3a3dc80bde922b9-5"
-
-[[releases]]
-version = "16.20.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.20.2-linux-x64.tar.gz"
-etag = "340ee5fabdbd527b9ae833c3e6b88d3b-5"
-
-[[releases]]
-version = "16.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.3.0-linux-x64.tar.gz"
-etag = "b0a9cecd669951adac9e27a35102923d-4"
-
-[[releases]]
-version = "16.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.4.0-linux-x64.tar.gz"
-etag = "8a77e82e1ca44f4fe1922714403161e8-4"
-
-[[releases]]
-version = "16.4.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.4.1-linux-x64.tar.gz"
-etag = "558b0575a48ff39c21a1fd9402fa0b84-4"
-
-[[releases]]
-version = "16.4.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.4.2-linux-x64.tar.gz"
-etag = "722a9783a7201b020ad6a89b9703cc3b-4"
-
-[[releases]]
-version = "16.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.5.0-linux-x64.tar.gz"
-etag = "5322a660d103a2974b9e073eae890bfb-4"
-
-[[releases]]
-version = "16.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.6.0-linux-x64.tar.gz"
-etag = "dfbee0cdf68d776ad1e51ca482250b0a-4"
-
-[[releases]]
-version = "16.6.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.6.1-linux-x64.tar.gz"
-etag = "bc15b11b0fd5ff2b62c6bf83646c82df-4"
-
-[[releases]]
-version = "16.6.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.6.2-linux-x64.tar.gz"
-etag = "0f897c317d9f01058731d4d283ce1cf2-4"
-
-[[releases]]
-version = "16.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.7.0-linux-x64.tar.gz"
-etag = "5db3c31791f4f8f75a8e8737e2ad2382-4"
-
-[[releases]]
-version = "16.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.8.0-linux-x64.tar.gz"
-etag = "2cf9f82dd69a9d35ba71532459629f83-4"
-
-[[releases]]
-version = "16.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.9.0-linux-x64.tar.gz"
-etag = "f76ebd4df376e0a9a8138bfcbe3a3079-4"
-
-[[releases]]
-version = "16.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.9.1-linux-x64.tar.gz"
-etag = "b591f8229fa8bf2f0a387c23b8277c55-4"
-
-[[releases]]
-version = "17.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.0.0-linux-x64.tar.gz"
-etag = "86c99126a99b3a82d007caedabdb9fa1-6"
-
-[[releases]]
-version = "17.0.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.0.1-linux-x64.tar.gz"
-etag = "10dc62fa317414c345bed79c04cc71fc-6"
-
-[[releases]]
-version = "17.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.1.0-linux-x64.tar.gz"
-etag = "8bf50f0462ee3144f34c6da85ae09e32-6"
-
-[[releases]]
-version = "17.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.2.0-linux-x64.tar.gz"
-etag = "0aee67a645145fd83f1e9c333c68c655-6"
-
-[[releases]]
-version = "17.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.3.0-linux-x64.tar.gz"
-etag = "43a9c23500b6183f63c62fe1c72bbdcd-6"
-
-[[releases]]
-version = "17.3.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.3.1-linux-x64.tar.gz"
-etag = "89f0dc5714f090fb5255b2ab4b943c03-6"
-
-[[releases]]
-version = "17.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.4.0-linux-x64.tar.gz"
-etag = "72cd45ee41e736a3d15ccd255bc42ea5-6"
-
-[[releases]]
-version = "17.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.5.0-linux-x64.tar.gz"
-etag = "85ca8cdd9038440dbad047487fe5caad-6"
-
-[[releases]]
-version = "17.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.6.0-linux-x64.tar.gz"
-etag = "acb898de485f6fd431c5bba29737cdd6-6"
-
-[[releases]]
-version = "17.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.0-linux-x64.tar.gz"
-etag = "3ae4ee1f090945e80ad2209beb2c019e-6"
-
-[[releases]]
-version = "17.7.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.1-linux-x64.tar.gz"
-etag = "45444848e3db9df8e1906f30303f0b73-6"
-
-[[releases]]
-version = "17.7.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.2-linux-x64.tar.gz"
-etag = "5bfd0dc5e7e878dd4561fd0e41035051-6"
-
-[[releases]]
-version = "17.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.8.0-linux-x64.tar.gz"
-etag = "062cf4cae4ec3b032c41909a49df706e-6"
-
-[[releases]]
-version = "17.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.9.0-linux-x64.tar.gz"
-etag = "d82856ef7d8fd6ee756e0c4054e686aa-6"
-
-[[releases]]
-version = "17.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.9.1-linux-x64.tar.gz"
-etag = "5abb91fe234c1cb3709811ca8c62ee88-6"
-
-[[releases]]
-version = "18.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.0.0-linux-x64.tar.gz"
-etag = "48ae6c63e24f5ce074e86188287198e0-6"
-
-[[releases]]
-version = "18.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.1.0-linux-x64.tar.gz"
-etag = "37faa7d1b87accc2b5f8c5c8af3d4a85-6"
-
-[[releases]]
-version = "18.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.10.0-linux-x64.tar.gz"
-etag = "d31a7a94f60ae2ee3d2c5d208dd9fa06-6"
-
-[[releases]]
-version = "18.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.11.0-linux-x64.tar.gz"
-etag = "163783aaa395b4bafe69067e81e71ab8-6"
-
-[[releases]]
-version = "18.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.12.0-linux-x64.tar.gz"
-etag = "86649fe86748ea3febf98e929d498119-6"
-
-[[releases]]
-version = "18.12.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.12.1-linux-x64.tar.gz"
-etag = "a06f34eaf7ae2352c789e8faea99176c-6"
-
-[[releases]]
-version = "18.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.13.0-linux-x64.tar.gz"
-etag = "015f9dfe56aeb2d10a9abe0a0a28ac6d-6"
-
-[[releases]]
-version = "18.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.14.0-linux-x64.tar.gz"
-etag = "f64feba223d30bb5145dd5d5240609d3-6"
-
-[[releases]]
-version = "18.14.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.14.1-linux-x64.tar.gz"
-etag = "9ad4db80f4608dd332bf22ae10977f3d-6"
-
-[[releases]]
-version = "18.14.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.14.2-linux-x64.tar.gz"
-etag = "2a33290e3c193b654808b29ec7aef765-6"
-
-[[releases]]
-version = "18.15.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.15.0-linux-x64.tar.gz"
-etag = "26343f5611dc89155f9d066aa8164dfe-6"
-
-[[releases]]
-version = "18.16.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.16.0-linux-x64.tar.gz"
-etag = "d617fab87f8ee9b80abebd50857e2bde-6"
-
-[[releases]]
-version = "18.16.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.16.1-linux-x64.tar.gz"
-etag = "8575aa84fc0fe642d2ee88d671093b45-6"
-
-[[releases]]
-version = "18.17.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.17.0-linux-x64.tar.gz"
-etag = "85fc8af719a2480b4104d663b30ea0b4-6"
-
-[[releases]]
-version = "18.17.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.17.1-linux-x64.tar.gz"
-etag = "40bed92d4aebcdbb9cee979e1f03859e-6"
-
-[[releases]]
-version = "18.18.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.18.0-linux-x64.tar.gz"
-etag = "6786cf20445987a3db61fe4d032d1f56-6"
-
-[[releases]]
-version = "18.18.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.18.1-linux-x64.tar.gz"
-etag = "42f1a933e23073a3c891a724e131436c-6"
-
-[[releases]]
-version = "18.18.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.18.2-linux-x64.tar.gz"
-etag = "840d418911ebab9041cc40478e88481a-6"
-
-[[releases]]
-version = "18.19.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.19.0-linux-x64.tar.gz"
-etag = "461c309590898b3c14c81415d391338c-6"
-
-[[releases]]
-version = "18.19.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.19.1-linux-x64.tar.gz"
-etag = "bffbf48e034f6eacbaa001706c43ec02-6"
-
-[[releases]]
-version = "18.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.2.0-linux-x64.tar.gz"
-etag = "3e7b3258d258a95ba0e1ad06ed7f482d-6"
-
-[[releases]]
-version = "18.20.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.20.0-linux-x64.tar.gz"
-etag = "e14d7b25765e676961181ae825e35237-6"
-
-[[releases]]
-version = "18.20.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.20.1-linux-x64.tar.gz"
-etag = "98104c2126119e2a8842c333b3425319-6"
-
-[[releases]]
-version = "18.20.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.20.2-linux-x64.tar.gz"
-etag = "ab370285dc857c504de1b21ecafff302-6"
-
-[[releases]]
-version = "18.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.3.0-linux-x64.tar.gz"
-etag = "0882fd16bcfeabd57379441604051ca4-6"
-
-[[releases]]
-version = "18.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.4.0-linux-x64.tar.gz"
-etag = "05ff72f9371a8705b8e5b895dfd8f6b5-6"
-
-[[releases]]
-version = "18.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.5.0-linux-x64.tar.gz"
-etag = "9bd9fc6a152929b992967d7efe40cfa6-6"
-
-[[releases]]
-version = "18.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.6.0-linux-x64.tar.gz"
-etag = "96773288cff667058e088a4fb418aca3-6"
-
-[[releases]]
-version = "18.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.7.0-linux-x64.tar.gz"
-etag = "a0a3893b6b148788381bbc6f7260d35e-6"
-
-[[releases]]
-version = "18.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.8.0-linux-x64.tar.gz"
-etag = "cc3fcca2aa2dccdc333fbc0709428463-6"
-
-[[releases]]
-version = "18.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.9.0-linux-x64.tar.gz"
-etag = "8e53d83d4455c1861a22030a78f0a076-6"
-
-[[releases]]
-version = "18.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.9.1-linux-x64.tar.gz"
-etag = "6e9038bdbfb630d31d3875cf1f56e2ba-6"
-
-[[releases]]
-version = "19.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.0.0-linux-x64.tar.gz"
-etag = "99d158299058e3a6b76f1bdc8e18393a-6"
-
-[[releases]]
-version = "19.0.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.0.1-linux-x64.tar.gz"
-etag = "ac996f828499ee7fa1774b9939f5d6c7-6"
-
-[[releases]]
-version = "19.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.1.0-linux-x64.tar.gz"
-etag = "43ac81eb0cbcb40ca1d740ac0d078596-6"
-
-[[releases]]
-version = "19.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.2.0-linux-x64.tar.gz"
-etag = "250cb7f6bf897efc151f6dc8141c4d47-6"
-
-[[releases]]
-version = "19.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.3.0-linux-x64.tar.gz"
-etag = "28f7e1417152b4b5353376ddf2250d47-6"
-
-[[releases]]
-version = "19.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.4.0-linux-x64.tar.gz"
-etag = "2fd4267d28ed47fa708ff6856eac32fb-6"
-
-[[releases]]
-version = "19.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.5.0-linux-x64.tar.gz"
-etag = "265bced5d9813609194da5492a9120b2-6"
-
-[[releases]]
-version = "19.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.6.0-linux-x64.tar.gz"
-etag = "fa1942df595ee976b2f3fc527a6ae54b-6"
-
-[[releases]]
-version = "19.6.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.6.1-linux-x64.tar.gz"
-etag = "3da49c80eb81a859fae044f18bed25b8-6"
-
-[[releases]]
-version = "19.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.7.0-linux-x64.tar.gz"
-etag = "285a1444b527be5801d8d828a5dac1af-6"
-
-[[releases]]
-version = "19.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.8.0-linux-x64.tar.gz"
-etag = "5c1de4f49ba34ce1d462562c5f5841fc-6"
-
-[[releases]]
-version = "19.8.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.8.1-linux-x64.tar.gz"
-etag = "0f11104d9c1e305858586a6671beec73-6"
-
-[[releases]]
-version = "19.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v19.9.0-linux-x64.tar.gz"
-etag = "ebce078cbac8006fab82956e5882bc28-6"
-
-[[releases]]
-version = "20.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.0.0-linux-x64.tar.gz"
-etag = "3456465494f47de14edc1a97caec1baf-6"
-
-[[releases]]
-version = "20.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.1.0-linux-x64.tar.gz"
-etag = "3b470a161894e01274666e85c898728b-6"
-
-[[releases]]
-version = "20.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.10.0-linux-x64.tar.gz"
-etag = "b5ad95e5081d4eac6d9e110d41ca113c-6"
-
-[[releases]]
-version = "20.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.11.0-linux-x64.tar.gz"
-etag = "a16cdc046eb902f001f3d804d21dfcc4-6"
-
-[[releases]]
-version = "20.11.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.11.1-linux-x64.tar.gz"
-etag = "ad233338a82aa8ad65674d8ac692fcbf-6"
-
-[[releases]]
-version = "20.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.12.0-linux-x64.tar.gz"
-etag = "6c71dcbb9752eff4a3a26a9d323f0d47-6"
-
-[[releases]]
-version = "20.12.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.12.1-linux-x64.tar.gz"
-etag = "ca6b782f1f2a27ea6bfddbd8929ddb3c-6"
-
-[[releases]]
-version = "20.12.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.12.2-linux-x64.tar.gz"
-etag = "e75d77b8c63cf15c067dac446f15a5a7-6"
-
-[[releases]]
-version = "20.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.2.0-linux-x64.tar.gz"
-etag = "262c2e27fdb5b764df8a642e6e942106-6"
-
-[[releases]]
-version = "20.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.3.0-linux-x64.tar.gz"
-etag = "65d88a642f89392d1a5348df3c20dfcb-6"
-
-[[releases]]
-version = "20.3.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.3.1-linux-x64.tar.gz"
-etag = "9f1f86365832de86bbd5f69d708d7b92-6"
-
-[[releases]]
-version = "20.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.4.0-linux-x64.tar.gz"
-etag = "c79bd136991f23975504c1b9ba49e438-6"
-
-[[releases]]
-version = "20.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.5.0-linux-x64.tar.gz"
-etag = "4cdf6ecb33b6e7c2c6b0e180ba2da698-6"
-
-[[releases]]
-version = "20.5.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.5.1-linux-x64.tar.gz"
-etag = "f3de44a4f1ce4a000f2119dbfe66c54e-6"
-
-[[releases]]
-version = "20.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.6.0-linux-x64.tar.gz"
-etag = "ae54a8c0c43e65a0d6656a8c58b17128-6"
-
-[[releases]]
-version = "20.6.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.6.1-linux-x64.tar.gz"
-etag = "31337a8bf7b975a112c982cb59634fb6-6"
-
-[[releases]]
-version = "20.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.7.0-linux-x64.tar.gz"
-etag = "e0f1b651dcf0db279846ccfab09321dc-6"
-
-[[releases]]
-version = "20.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.8.0-linux-x64.tar.gz"
-etag = "537d2c2b3f13e969b67e61e4f8ed8a0f-6"
-
-[[releases]]
-version = "20.8.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.8.1-linux-x64.tar.gz"
-etag = "641b5ed8d951cf81f68a150402e2493c-6"
-
-[[releases]]
-version = "20.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v20.9.0-linux-x64.tar.gz"
-etag = "bffcf3dafb209d997f882a0632c972fc-6"
-
-[[releases]]
-version = "21.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.0.0-linux-x64.tar.gz"
-etag = "d87d4baf7c3cbc4289065f7ff6667820-6"
-
-[[releases]]
-version = "21.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.1.0-linux-x64.tar.gz"
-etag = "989be60b0d87b975630baad69b6dea76-6"
-
-[[releases]]
-version = "21.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.2.0-linux-x64.tar.gz"
-etag = "778a67c5ab73dce04532b6ee57ab3fec-6"
-
-[[releases]]
-version = "21.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.3.0-linux-x64.tar.gz"
-etag = "781ad38fed32c307945252a4741a6516-6"
-
-[[releases]]
-version = "21.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.4.0-linux-x64.tar.gz"
-etag = "26dae86935144cb59b664b6dad930094-6"
-
-[[releases]]
-version = "21.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.5.0-linux-x64.tar.gz"
-etag = "298ce3676087bdbc14a0681eaa51f34f-6"
-
-[[releases]]
-version = "21.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.6.0-linux-x64.tar.gz"
-etag = "5378b4b305c3158f220eaf66e8038210-6"
-
-[[releases]]
-version = "21.6.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.6.1-linux-x64.tar.gz"
-etag = "6bce46a2b348fc4fadec57359a3c4b38-6"
-
-[[releases]]
-version = "21.6.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.6.2-linux-x64.tar.gz"
-etag = "1b9429107ff9f90e168fe2ac97bac16a-6"
-
-[[releases]]
-version = "21.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.7.0-linux-x64.tar.gz"
-etag = "17b93378a96909b6135c9583c2cfe3ab-6"
-
-[[releases]]
-version = "21.7.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.7.1-linux-x64.tar.gz"
-etag = "63aedc5af5b844790816af8398113b4b-6"
-
-[[releases]]
-version = "21.7.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.7.2-linux-x64.tar.gz"
-etag = "b9ab93cb5d106b2820c868413c40303b-6"
-
-[[releases]]
-version = "21.7.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v21.7.3-linux-x64.tar.gz"
-etag = "7df02414e8064e54d732fa634c86fc81-6"
-
-[[releases]]
-version = "22.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v22.0.0-linux-x64.tar.gz"
-etag = "b20984c4fce616e0d1b791316c5a6c94-7"
-
-[[releases]]
+[[artifacts]]
 version = "22.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v22.1.0-linux-x64.tar.gz"
-etag = "c1c5706ffd11190f43a0b18f5e62c5db-7"
-
-[[releases]]
-version = "4.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.0.0-linux-x64.tar.gz"
-etag = "ad9aa8802fe1ef5b9c96913fd2d08816"
-
-[[releases]]
-version = "4.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.1.0-linux-x64.tar.gz"
-etag = "5110ec82838293fbbfb67df9cd72b029"
-
-[[releases]]
-version = "4.1.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.1.1-linux-x64.tar.gz"
-etag = "e5d370e666f2305787a1fce3661fd89e"
-
-[[releases]]
-version = "4.1.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.1.2-linux-x64.tar.gz"
-etag = "0fdf4986da53ea7828ed3aa651a23834"
-
-[[releases]]
-version = "4.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.0-linux-x64.tar.gz"
-etag = "157502f1f71c36a7331e2515b27a4e55"
-
-[[releases]]
-version = "4.2.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.1-linux-x64.tar.gz"
-etag = "6c89bd44bc01e3806958192913cd2df1"
-
-[[releases]]
-version = "4.2.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.2-linux-x64.tar.gz"
-etag = "d15578f9497cfc470876035be6817b44"
-
-[[releases]]
-version = "4.2.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.3-linux-x64.tar.gz"
-etag = "d147b47f159a450ca2ddb21efa15494b"
-
-[[releases]]
-version = "4.2.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.4-linux-x64.tar.gz"
-etag = "3a5a62cf70ccd3da8f236fe8970c56f3"
-
-[[releases]]
-version = "4.2.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.5-linux-x64.tar.gz"
-etag = "ac75a1f161cc038d7864e31f836544cc"
-
-[[releases]]
-version = "4.2.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.2.6-linux-x64.tar.gz"
-etag = "99e171e31ada52506ea19921c8f12655"
-
-[[releases]]
-version = "4.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.3.0-linux-x64.tar.gz"
-etag = "971d69c8630e86d310a1e9358dd9d784"
-
-[[releases]]
-version = "4.3.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.3.1-linux-x64.tar.gz"
-etag = "4ffab69c4a38b4239b902575cb2e3c8e"
-
-[[releases]]
-version = "4.3.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.3.2-linux-x64.tar.gz"
-etag = "c97908f365d55ac8112a85504498d9d4"
-
-[[releases]]
-version = "4.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.0-linux-x64.tar.gz"
-etag = "f53766c3065beaf5df816cbbcabbbaa8"
-
-[[releases]]
-version = "4.4.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.1-linux-x64.tar.gz"
-etag = "e63bc99f24096ce83a310342bc33185d"
-
-[[releases]]
-version = "4.4.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.2-linux-x64.tar.gz"
-etag = "b298f15e97e2bf65a51074a6274989c3"
-
-[[releases]]
-version = "4.4.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.3-linux-x64.tar.gz"
-etag = "57b39b7e98d7267118536db1ce9c61c2"
-
-[[releases]]
-version = "4.4.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.4-linux-x64.tar.gz"
-etag = "7c120af0281a7e7195e99f61e6d7ba31"
-
-[[releases]]
-version = "4.4.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.5-linux-x64.tar.gz"
-etag = "f182997bd203528c5a358c8fb1082a5e"
-
-[[releases]]
-version = "4.4.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.6-linux-x64.tar.gz"
-etag = "4c72d988c91bf95e4dde32cb2adfb4f0"
-
-[[releases]]
-version = "4.4.7"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.4.7-linux-x64.tar.gz"
-etag = "9a5e9d9eeaa9a48f5eacf619fd8c11d8"
-
-[[releases]]
-version = "4.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.5.0-linux-x64.tar.gz"
-etag = "05a630d65295c2fb854fb76277681233"
-
-[[releases]]
-version = "4.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.6.0-linux-x64.tar.gz"
-etag = "9ea38915970403e2f39ffb7ddeab037f"
-
-[[releases]]
-version = "4.6.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.6.1-linux-x64.tar.gz"
-etag = "2a0f179566efbc1018c0f5b8e79dd37f"
-
-[[releases]]
-version = "4.6.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.6.2-linux-x64.tar.gz"
-etag = "076573f2f809e5050098c8969a32327e"
-
-[[releases]]
-version = "4.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.7.0-linux-x64.tar.gz"
-etag = "7f6f2e8172bb61666b75de84f430703d"
-
-[[releases]]
-version = "4.7.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.7.1-linux-x64.tar.gz"
-etag = "e130bd5a3cc159aa32c54d082e7963dd"
-
-[[releases]]
-version = "4.7.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.7.2-linux-x64.tar.gz"
-etag = "d438c6cf3d2b63aedae84f7770dba2bf"
-
-[[releases]]
-version = "4.7.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.7.3-linux-x64.tar.gz"
-etag = "15508f8fea6b2c3f15a7094b85a400ac"
-
-[[releases]]
-version = "4.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.0-linux-x64.tar.gz"
-etag = "9b0f9368f140ce6095d0338196ef3d0e"
-
-[[releases]]
-version = "4.8.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.1-linux-x64.tar.gz"
-etag = "c061c265953467cbaecb528936a4350d"
-
-[[releases]]
-version = "4.8.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.2-linux-x64.tar.gz"
-etag = "3838bed594a34909e3e960db823fe5cb"
-
-[[releases]]
-version = "4.8.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.3-linux-x64.tar.gz"
-etag = "f7a7392704f74ae1c35ac43e57147518"
-
-[[releases]]
-version = "4.8.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.4-linux-x64.tar.gz"
-etag = "d4cbf24ebcfe3208eda22474917159ba"
-
-[[releases]]
-version = "4.8.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.5-linux-x64.tar.gz"
-etag = "96af0054769096d569981f2d22131a96"
-
-[[releases]]
-version = "4.8.6"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.6-linux-x64.tar.gz"
-etag = "b0b95ceab3ac27aba8a56033f94658b9"
-
-[[releases]]
-version = "4.8.7"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.8.7-linux-x64.tar.gz"
-etag = "ccf19b560bb65f53132e6bb09b0eb9b1"
-
-[[releases]]
-version = "4.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.9.0-linux-x64.tar.gz"
-etag = "edb491d2bcc46fac4974319543610d84"
-
-[[releases]]
-version = "4.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v4.9.1-linux-x64.tar.gz"
-etag = "55cc20b7f650c25cd57c41dfffdd2bc1"
-
-[[releases]]
-version = "5.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.0.0-linux-x64.tar.gz"
-etag = "fdc2c555c36c94ebf114638ce335930c"
-
-[[releases]]
-version = "5.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.1.0-linux-x64.tar.gz"
-etag = "18b6afd5c49e93e5389b951e7e9c14a5"
-
-[[releases]]
-version = "5.1.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.1.1-linux-x64.tar.gz"
-etag = "0657d46ced225b0416198d1b3e263c40"
-
-[[releases]]
-version = "5.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.10.0-linux-x64.tar.gz"
-etag = "16beb606311791a408e612fd3837f17f"
-
-[[releases]]
-version = "5.10.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.10.1-linux-x64.tar.gz"
-etag = "4c2f9b58fdd04f44c253eec1fcda6c8b"
-
-[[releases]]
-version = "5.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.11.0-linux-x64.tar.gz"
-etag = "27b1e305aa8024b9254851a46101b5ac"
-
-[[releases]]
-version = "5.11.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.11.1-linux-x64.tar.gz"
-etag = "a410e0dd3f79a9030c5704abb24e4eed"
-
-[[releases]]
-version = "5.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.12.0-linux-x64.tar.gz"
-etag = "a573a36713bd2d77094794e39562c9a9"
-
-[[releases]]
-version = "5.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.2.0-linux-x64.tar.gz"
-etag = "547de6e8b2f42e6f6948e3e8e83205b0"
-
-[[releases]]
-version = "5.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.3.0-linux-x64.tar.gz"
-etag = "fd5b49ff2073e48667e9420cb8e14485"
-
-[[releases]]
-version = "5.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.4.0-linux-x64.tar.gz"
-etag = "29d19e2095e6610c69d5e3425467a837"
-
-[[releases]]
-version = "5.4.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.4.1-linux-x64.tar.gz"
-etag = "59504ee13daa0b00ee5d1ed9b8293c83"
-
-[[releases]]
-version = "5.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.5.0-linux-x64.tar.gz"
-etag = "da931cbd0d7ddabce6a8e4cd0bfea252"
-
-[[releases]]
-version = "5.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.6.0-linux-x64.tar.gz"
-etag = "9094bd62a5c44b5794e1c781186211a1"
-
-[[releases]]
-version = "5.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.7.0-linux-x64.tar.gz"
-etag = "e5703bedcb1796c323b4875476f1aa42"
-
-[[releases]]
-version = "5.7.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.7.1-linux-x64.tar.gz"
-etag = "23516f737f0301a02b653f6791bb1b7b"
-
-[[releases]]
-version = "5.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.8.0-linux-x64.tar.gz"
-etag = "6dc325980c02dbc6d2784f0f4a8ac2c0"
-
-[[releases]]
-version = "5.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.9.0-linux-x64.tar.gz"
-etag = "728b0fb8dd32ed22e9ececc7494ee017"
-
-[[releases]]
-version = "5.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v5.9.1-linux-x64.tar.gz"
-etag = "08c9841f4462cc3db1723b3f769545bb"
-
-[[releases]]
-version = "6.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.0.0-linux-x64.tar.gz"
-etag = "13b4c32b6547c960fe271dff9e5271ef"
-
-[[releases]]
-version = "6.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.1.0-linux-x64.tar.gz"
-etag = "7ae088e219791fc7b8ec2e113de351ed"
-
-[[releases]]
-version = "6.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.10.0-linux-x64.tar.gz"
-etag = "f5296665baa81cb1d2963e6e035bab3f"
-
-[[releases]]
-version = "6.10.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.10.1-linux-x64.tar.gz"
-etag = "b84f8dc95e36713130f02eb74a510f66"
-
-[[releases]]
-version = "6.10.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.10.2-linux-x64.tar.gz"
-etag = "422d938406ab4e87b540ff702cc0be0f"
-
-[[releases]]
-version = "6.10.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.10.3-linux-x64.tar.gz"
-etag = "30393301e956e1c1378b6e2b4134960d"
-
-[[releases]]
-version = "6.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.0-linux-x64.tar.gz"
-etag = "e6ade07945c32f82da184ebbcb5347dc"
-
-[[releases]]
-version = "6.11.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.1-linux-x64.tar.gz"
-etag = "07ad56154c716d5d4024485cf541cacd"
-
-[[releases]]
-version = "6.11.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.2-linux-x64.tar.gz"
-etag = "a9d11ee59c2f1323dd7779f22319da0b"
-
-[[releases]]
-version = "6.11.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.3-linux-x64.tar.gz"
-etag = "27ca55c32e83981d0262c86b3098ab53"
-
-[[releases]]
-version = "6.11.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.4-linux-x64.tar.gz"
-etag = "c6ef84d3d69e83cece7fe70b34fb3ead"
-
-[[releases]]
-version = "6.11.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.11.5-linux-x64.tar.gz"
-etag = "feb8cc0de5bdcd852b6ead5ca449c54e"
-
-[[releases]]
-version = "6.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.12.0-linux-x64.tar.gz"
-etag = "3bb30780f5a2375186050d3331124eb3"
-
-[[releases]]
-version = "6.12.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.12.1-linux-x64.tar.gz"
-etag = "fe934ea079157537e519ab8abac97821"
-
-[[releases]]
-version = "6.12.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.12.2-linux-x64.tar.gz"
-etag = "d17c3d9d7abc2b6fa87d77b1194f49ed"
-
-[[releases]]
-version = "6.12.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.12.3-linux-x64.tar.gz"
-etag = "3449dadfee5ae4310806b586b22415ea"
-
-[[releases]]
-version = "6.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.13.0-linux-x64.tar.gz"
-etag = "bb14c7dc4cdcdda93864b54641a904eb"
-
-[[releases]]
-version = "6.13.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.13.1-linux-x64.tar.gz"
-etag = "8ea19d0947367394b64196d6ef31d279"
-
-[[releases]]
-version = "6.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.0-linux-x64.tar.gz"
-etag = "55df304d39af6d80b2fea82bc3a0c23c"
-
-[[releases]]
-version = "6.14.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.1-linux-x64.tar.gz"
-etag = "2a9d81e30b09a4f097426e469d67d159"
-
-[[releases]]
-version = "6.14.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.2-linux-x64.tar.gz"
-etag = "18ccee563e25f5c4561681bfcccd815b"
-
-[[releases]]
-version = "6.14.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.3-linux-x64.tar.gz"
-etag = "c03210f252a9a6f1025a32abd817466b"
-
-[[releases]]
-version = "6.14.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.14.4-linux-x64.tar.gz"
-etag = "c81242d62dbad357134ad9e8c938fce6"
-
-[[releases]]
-version = "6.15.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.15.0-linux-x64.tar.gz"
-etag = "bc75fc652bb28aa07d92e99b212dd75e"
-
-[[releases]]
-version = "6.15.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.15.1-linux-x64.tar.gz"
-etag = "8b6b409811ba540653b06a2f87af2b58"
-
-[[releases]]
-version = "6.16.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.16.0-linux-x64.tar.gz"
-etag = "e4b7d1cc7c4156ae36af213795b9a2ab"
-
-[[releases]]
-version = "6.17.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.17.0-linux-x64.tar.gz"
-etag = "24b84466f5f921fa793243f87915800a"
-
-[[releases]]
-version = "6.17.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.17.1-linux-x64.tar.gz"
-etag = "eb59e6ef416d02bfcd1188b4151bddcd"
-
-[[releases]]
-version = "6.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.2.0-linux-x64.tar.gz"
-etag = "fdd0261e3c7bafee1cc7fc65984fdf88"
-
-[[releases]]
-version = "6.2.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.2.1-linux-x64.tar.gz"
-etag = "f3d14bdcb186588b49d62e79e7f01485"
-
-[[releases]]
-version = "6.2.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz"
-etag = "a6fec1180281f7ac2d4958e6ce7d3389"
-
-[[releases]]
-version = "6.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.3.0-linux-x64.tar.gz"
-etag = "41d14f57079c5935a4f0b470abd9f6b6"
-
-[[releases]]
-version = "6.3.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.3.1-linux-x64.tar.gz"
-etag = "6eef640b0ec7aa824495648de0b98b8a"
-
-[[releases]]
-version = "6.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.4.0-linux-x64.tar.gz"
-etag = "5a6a85902804e80805b9e768965de9e7"
-
-[[releases]]
-version = "6.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.5.0-linux-x64.tar.gz"
-etag = "9ecd8aa9b9604d0a00c8e49bf4972e8a"
-
-[[releases]]
-version = "6.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.6.0-linux-x64.tar.gz"
-etag = "d1d8e73c4bf00bd775134133eb272db1"
-
-[[releases]]
-version = "6.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.7.0-linux-x64.tar.gz"
-etag = "408f4cd1cb7ec43c3c160e8fed1976f5"
-
-[[releases]]
-version = "6.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.8.0-linux-x64.tar.gz"
-etag = "67095f5a08b9e43af45fb5ae0148518c"
-
-[[releases]]
-version = "6.8.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.8.1-linux-x64.tar.gz"
-etag = "755c549fe29a3a5b96c3389e09944f26"
-
-[[releases]]
-version = "6.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.0-linux-x64.tar.gz"
-etag = "04b33ad10f00911e1e62d1564b0291a5"
-
-[[releases]]
-version = "6.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.1-linux-x64.tar.gz"
-etag = "125817abbbe0268f7344a4bdc9f6ca6c"
-
-[[releases]]
-version = "6.9.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.2-linux-x64.tar.gz"
-etag = "93bed4cb06d1c70dd6c353eb464fcc14"
-
-[[releases]]
-version = "6.9.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.3-linux-x64.tar.gz"
-etag = "77c692175c2be398a5e3a293642e815f"
-
-[[releases]]
-version = "6.9.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.4-linux-x64.tar.gz"
-etag = "6ef6a9c5d2157605b8c1c8428d79562e"
-
-[[releases]]
-version = "6.9.5"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v6.9.5-linux-x64.tar.gz"
-etag = "07fe033bfc86aaa9f92f34d7b99fd26f"
-
-[[releases]]
-version = "7.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.0.0-linux-x64.tar.gz"
-etag = "9e9e91b3acb928e4ba648d8e74a1da58"
-
-[[releases]]
-version = "7.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.1.0-linux-x64.tar.gz"
-etag = "9ab4aebedf1ffaa3a969e967155fb682"
-
-[[releases]]
-version = "7.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.10.0-linux-x64.tar.gz"
-etag = "ec8a2ff9c2419699b6b64c23dadd0e97"
-
-[[releases]]
-version = "7.10.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.10.1-linux-x64.tar.gz"
-etag = "cfdda50dfcdc0cf220a3a2cde7c47eed"
-
-[[releases]]
-version = "7.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.2.0-linux-x64.tar.gz"
-etag = "0addb80324fde7895d575217e586de61"
-
-[[releases]]
-version = "7.2.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.2.1-linux-x64.tar.gz"
-etag = "c3bed6afc9602cf939db1d5fa17a8ecd"
-
-[[releases]]
-version = "7.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.3.0-linux-x64.tar.gz"
-etag = "f72707a8488b83b1c960a0f92f0c0407"
-
-[[releases]]
-version = "7.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.4.0-linux-x64.tar.gz"
-etag = "d39110f7d54c8232681af944e35a643a"
-
-[[releases]]
-version = "7.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.5.0-linux-x64.tar.gz"
-etag = "6deb5f26b7d6b1abb891ec1c91417a44"
-
-[[releases]]
-version = "7.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.6.0-linux-x64.tar.gz"
-etag = "ba3e24f7785494fa862bb09df962cb6a"
-
-[[releases]]
-version = "7.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.0-linux-x64.tar.gz"
-etag = "e39a464e4327f52b857a0014e5c834d5"
-
-[[releases]]
-version = "7.7.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.1-linux-x64.tar.gz"
-etag = "12cf3996237e73af1734abbb04aaa08e"
-
-[[releases]]
-version = "7.7.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.2-linux-x64.tar.gz"
-etag = "4d721a9751057c93c361b20285319ce9"
-
-[[releases]]
-version = "7.7.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.3-linux-x64.tar.gz"
-etag = "8fba665863dc1d8f22d5848e2464c66d"
-
-[[releases]]
-version = "7.7.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.7.4-linux-x64.tar.gz"
-etag = "e3382e0292c909731d0db2e98662dc35"
-
-[[releases]]
-version = "7.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.8.0-linux-x64.tar.gz"
-etag = "d338a977caa4908b9634c457eec00607"
-
-[[releases]]
-version = "7.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v7.9.0-linux-x64.tar.gz"
-etag = "905dd98406730fa6c7a6f142759797fe"
-
-[[releases]]
-version = "8.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.0.0-linux-x64.tar.gz"
-etag = "7c4a36c3fa8e26f6293f8b7419b80dce"
-
-[[releases]]
-version = "8.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.0-linux-x64.tar.gz"
-etag = "47785a1a21fee13cf0c257bb4f61c400"
-
-[[releases]]
-version = "8.1.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.1-linux-x64.tar.gz"
-etag = "66b23604717b0895162e24e372003bc0"
-
-[[releases]]
-version = "8.1.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.2-linux-x64.tar.gz"
-etag = "ae9ed0103665e67eded93b9ae52a6ec5"
-
-[[releases]]
-version = "8.1.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.3-linux-x64.tar.gz"
-etag = "ce89b28204e1b6d5c2d1bb08d3f85d95"
-
-[[releases]]
-version = "8.1.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.1.4-linux-x64.tar.gz"
-etag = "ae43cf579539b3898432a9c3d49cf9d3"
-
-[[releases]]
-version = "8.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.10.0-linux-x64.tar.gz"
-etag = "79b3e7736b4f5d0d902684f773748805"
-
-[[releases]]
-version = "8.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.0-linux-x64.tar.gz"
-etag = "3d3264b0503613ad6672858f271392a1"
-
-[[releases]]
-version = "8.11.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.1-linux-x64.tar.gz"
-etag = "cdfc6c0c8da81d697cb6e93219143817"
-
-[[releases]]
-version = "8.11.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.2-linux-x64.tar.gz"
-etag = "5d6bbd76cf31838ac22863cee6b35314"
-
-[[releases]]
-version = "8.11.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.3-linux-x64.tar.gz"
-etag = "55f2efc92e347c22d94f1c75e14cc4a9"
-
-[[releases]]
-version = "8.11.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.11.4-linux-x64.tar.gz"
-etag = "5764e757cee7ffa6eda727784ac2dde8"
-
-[[releases]]
-version = "8.12.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.12.0-linux-x64.tar.gz"
-etag = "c2dc07f9b840abe01461328caad03179"
-
-[[releases]]
-version = "8.13.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.13.0-linux-x64.tar.gz"
-etag = "ec5e096251b6b78f508971d7038a5d14"
-
-[[releases]]
-version = "8.14.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.14.0-linux-x64.tar.gz"
-etag = "6e1117831d6dfa9cf73a998f84a70aa2"
-
-[[releases]]
-version = "8.14.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.14.1-linux-x64.tar.gz"
-etag = "b62684a89bde079c53fb54dce47ff715"
-
-[[releases]]
-version = "8.15.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.15.0-linux-x64.tar.gz"
-etag = "117139b710ca7795feda9e643ce11fe9"
-
-[[releases]]
-version = "8.15.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.15.1-linux-x64.tar.gz"
-etag = "4c4497b86c0004401d5a93aa36c7e959"
-
-[[releases]]
-version = "8.16.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.16.0-linux-x64.tar.gz"
-etag = "caabf1838fba99b1d228dfa66c38254f"
-
-[[releases]]
-version = "8.16.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.16.1-linux-x64.tar.gz"
-etag = "7208de0aad92d58374fa8f3763d6305c"
-
-[[releases]]
-version = "8.16.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.16.2-linux-x64.tar.gz"
-etag = "327ec94535ca1a5390fd2eebb970936d"
-
-[[releases]]
-version = "8.17.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.17.0-linux-x64.tar.gz"
-etag = "6218e59c4e3632a4b4eae5214aceeb08"
-
-[[releases]]
-version = "8.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.2.0-linux-x64.tar.gz"
-etag = "68c673f28439316feca4d62e9422fa61"
-
-[[releases]]
-version = "8.2.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.2.1-linux-x64.tar.gz"
-etag = "771c0c0d6dee6eb23246acde43d9a322"
-
-[[releases]]
-version = "8.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.3.0-linux-x64.tar.gz"
-etag = "cd9f3d9d745ff7ed7b70e666120f6f33"
-
-[[releases]]
-version = "8.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.4.0-linux-x64.tar.gz"
-etag = "47995fbac1f5d13335b9793193852865"
-
-[[releases]]
-version = "8.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.5.0-linux-x64.tar.gz"
-etag = "fabf00e6bd0340ac7b9eea01c14b5553"
-
-[[releases]]
-version = "8.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.6.0-linux-x64.tar.gz"
-etag = "43086fd3d13a2f5da84ca0a425603384"
-
-[[releases]]
-version = "8.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.7.0-linux-x64.tar.gz"
-etag = "cc0009950642acd26d84cdd41fc6a63f"
-
-[[releases]]
-version = "8.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.8.0-linux-x64.tar.gz"
-etag = "9dbef387aa662bcd886e1d9e12c53391"
-
-[[releases]]
-version = "8.8.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.8.1-linux-x64.tar.gz"
-etag = "05a227ed26e6d10673d7b5d43548fa27"
-
-[[releases]]
-version = "8.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.0-linux-x64.tar.gz"
-etag = "344c4ece19f3288e49580aa924efb6b6"
-
-[[releases]]
-version = "8.9.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.1-linux-x64.tar.gz"
-etag = "4988b63c61a557d435ca84a8fd7b16e5"
-
-[[releases]]
-version = "8.9.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.2-linux-x64.tar.gz"
-etag = "d44840575fb65f8af588f104b191f1fa"
-
-[[releases]]
-version = "8.9.3"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.3-linux-x64.tar.gz"
-etag = "bcb479799cf91d21c5dea9f11be3e8f0"
-
-[[releases]]
-version = "8.9.4"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v8.9.4-linux-x64.tar.gz"
-etag = "53afee57c2832145d0192075cee3a0f5"
-
-[[releases]]
-version = "9.0.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.0.0-linux-x64.tar.gz"
-etag = "daf114d7fc0feedaddee00fffb05795c"
-
-[[releases]]
-version = "9.1.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.1.0-linux-x64.tar.gz"
-etag = "f1f3e6c33c998aec8bc976dff9bd288a"
-
-[[releases]]
-version = "9.10.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.10.0-linux-x64.tar.gz"
-etag = "72f8c387f69e787eb62a711a6bcb567e"
-
-[[releases]]
-version = "9.10.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.10.1-linux-x64.tar.gz"
-etag = "7c8500163ca5129ae369b1c385fe510b"
-
-[[releases]]
-version = "9.11.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.11.0-linux-x64.tar.gz"
-etag = "333cebc3ddc900647bdf634dd0b85712"
-
-[[releases]]
-version = "9.11.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.11.1-linux-x64.tar.gz"
-etag = "c57e646e046d336ff99973f53f146e3e"
-
-[[releases]]
-version = "9.11.2"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.11.2-linux-x64.tar.gz"
-etag = "2e3946fb496d4fe7da658d4fe84d2f83"
-
-[[releases]]
-version = "9.2.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.2.0-linux-x64.tar.gz"
-etag = "d5fbf801c5b1e5fd920b6d06abedf64c"
-
-[[releases]]
-version = "9.2.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.2.1-linux-x64.tar.gz"
-etag = "794a1419d7b37ca31f6b26ec523fe9a1"
-
-[[releases]]
-version = "9.3.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.3.0-linux-x64.tar.gz"
-etag = "0b7d3a357d309cb9a49d4bf26d9dc279"
-
-[[releases]]
-version = "9.4.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.4.0-linux-x64.tar.gz"
-etag = "513c419b06c88bf467ab8c153bd4f311"
-
-[[releases]]
-version = "9.5.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.5.0-linux-x64.tar.gz"
-etag = "3d7a719f4839b67751c4293de1cc4a25"
-
-[[releases]]
-version = "9.6.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.6.0-linux-x64.tar.gz"
-etag = "6b1fda53508ebf1d18c987d23007daa7"
-
-[[releases]]
-version = "9.6.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.6.1-linux-x64.tar.gz"
-etag = "51a778e44a46edf617985416e52a4eba"
-
-[[releases]]
-version = "9.7.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.7.0-linux-x64.tar.gz"
-etag = "684489f171a42c96ccc2734b6dbe6035"
-
-[[releases]]
-version = "9.7.1"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.7.1-linux-x64.tar.gz"
-etag = "eafd7894337e4c8325ad318df6e8f5c8"
-
-[[releases]]
-version = "9.8.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.8.0-linux-x64.tar.gz"
-etag = "f16b1750184ebed9dc4144a549bbabfc"
-
-[[releases]]
-version = "9.9.0"
-channel = "release"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v9.9.0-linux-x64.tar.gz"
-etag = "b6d0dd7311e34f96057b66280ac29e7a"
-
-[[releases]]
-version = "10.1.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.1.0-darwin-x64.tar.gz"
-etag = "075338fcbfb421d80b8b272167367149-2"
-
-[[releases]]
-version = "10.10.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.10.0-darwin-x64.tar.gz"
-etag = "c21bffff553546ac2776cdb28fb7363c-2"
-
-[[releases]]
-version = "10.11.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.11.0-darwin-x64.tar.gz"
-etag = "7c1f911d3b24c71f9f0718b93d9bb6b8-2"
-
-[[releases]]
-version = "10.12.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.12.0-darwin-x64.tar.gz"
-etag = "ffe227e5a6512104f9c2414fafb1b55a-2"
-
-[[releases]]
-version = "10.13.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.13.0-darwin-x64.tar.gz"
-etag = "d5f7998b145c354695fd17fae1b3f02b-2"
-
-[[releases]]
-version = "10.14.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.14.0-darwin-x64.tar.gz"
-etag = "c121ed62304a207ba5c7f6b49037fd1b-2"
-
-[[releases]]
-version = "10.14.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.14.1-darwin-x64.tar.gz"
-etag = "eed04220f203896d319837b77919dcff-2"
-
-[[releases]]
-version = "10.14.2"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.14.2-darwin-x64.tar.gz"
-etag = "b1d3e9268544048430ab8ff3e08b4483-2"
-
-[[releases]]
-version = "10.15.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.15.0-darwin-x64.tar.gz"
-etag = "7ff7b375d370a97fcd4746f2541fefa0-2"
-
-[[releases]]
-version = "10.15.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.15.1-darwin-x64.tar.gz"
-etag = "7ea7702617b20c5deb6416261782630a-2"
-
-[[releases]]
-version = "10.15.2"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.15.2-darwin-x64.tar.gz"
-etag = "963ffeecd266832a954db7724fcd86fe-2"
-
-[[releases]]
-version = "10.15.3"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.15.3-darwin-x64.tar.gz"
-etag = "6b7bb08f102bb5e4e8dee88b46548fb7-2"
-
-[[releases]]
-version = "10.16.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.16.0-darwin-x64.tar.gz"
-etag = "70b927cdc7bc9d0fd3bc558e5a205cca-3"
-
-[[releases]]
-version = "10.16.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.16.1-darwin-x64.tar.gz"
-etag = "782b24811bc14de243941e17e3e3603c-3"
-
-[[releases]]
-version = "10.16.2"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.16.2-darwin-x64.tar.gz"
-etag = "cbabef467c591e4d643ec6174f0ec122-3"
-
-[[releases]]
-version = "10.16.3"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.16.3-darwin-x64.tar.gz"
-etag = "8740ea019b634b1947bbbbfce372c8ee-3"
-
-[[releases]]
-version = "10.17.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.17.0-darwin-x64.tar.gz"
-etag = "c288126f9b163ae8f210d4be4e544be7-3"
-
-[[releases]]
-version = "10.18.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.18.0-darwin-x64.tar.gz"
-etag = "0c95534e9dac2cc99fac2f0ddc1bcd46-3"
-
-[[releases]]
-version = "10.18.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.18.1-darwin-x64.tar.gz"
-etag = "1beab3e621a27924a076f88bbd0180f8-3"
-
-[[releases]]
-version = "10.19.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.19.0-darwin-x64.tar.gz"
-etag = "06ce71192fd267dd866827edccda5996-3"
-
-[[releases]]
-version = "10.2.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.2.0-darwin-x64.tar.gz"
-etag = "0ea30daa604b1bd929ee178d40af8352-2"
-
-[[releases]]
-version = "10.2.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.2.1-darwin-x64.tar.gz"
-etag = "aa160c78897cd7245bee4412f3bc96e2-2"
-
-[[releases]]
-version = "10.20.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.20.0-darwin-x64.tar.gz"
-etag = "9333a777f0a74f5b7ea87550d74262c3-3"
-
-[[releases]]
-version = "10.20.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.20.1-darwin-x64.tar.gz"
-etag = "878c0c4323e31dd9106d756abb0b9002-3"
-
-[[releases]]
-version = "10.21.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.21.0-darwin-x64.tar.gz"
-etag = "3df5c0dec214c35f2d731726733b1c6a-3"
-
-[[releases]]
-version = "10.22.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.22.0-darwin-x64.tar.gz"
-etag = "0037544c07933ec1d5da9c33092f6831-3"
-
-[[releases]]
-version = "10.22.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.22.1-darwin-x64.tar.gz"
-etag = "d32be387d0f7f21abf2642e23d47b19c-3"
-
-[[releases]]
-version = "10.23.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.23.0-darwin-x64.tar.gz"
-etag = "7d35b632cb913bb0cee161b3f949932f-3"
-
-[[releases]]
-version = "10.23.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.23.1-darwin-x64.tar.gz"
-etag = "292b25a4474b5829b2ac34a1ecc32100-3"
-
-[[releases]]
-version = "10.9.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v10.9.0-darwin-x64.tar.gz"
-etag = "589b2b59735c2756fa3ab64cdfb1f1a9"
-
-[[releases]]
-version = "11.0.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.0.0-darwin-x64.tar.gz"
-etag = "ecc3e19ec147553f53a1d55cd7985054"
-
-[[releases]]
-version = "11.1.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.1.0-darwin-x64.tar.gz"
-etag = "58249d44f40a5a5299fa83f3fd1ee36c"
-
-[[releases]]
-version = "11.10.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.10.0-darwin-x64.tar.gz"
-etag = "bf5fd780114c9e7981146a4909e2ffde"
-
-[[releases]]
-version = "11.10.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.10.1-darwin-x64.tar.gz"
-etag = "80ac0921ffeca782eabae1e543cf5a1d"
-
-[[releases]]
-version = "11.11.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.11.0-darwin-x64.tar.gz"
-etag = "736858f23fb79479af941461817424a4"
-
-[[releases]]
-version = "11.12.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.12.0-darwin-x64.tar.gz"
-etag = "77636576d7ba54c52a984e9891413b16"
-
-[[releases]]
-version = "11.13.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.13.0-darwin-x64.tar.gz"
-etag = "56d811e1709ae0ba4b591ee2489003c3"
-
-[[releases]]
-version = "11.14.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.14.0-darwin-x64.tar.gz"
-etag = "59478d7f4976d5d4248b8e6d24b19270"
-
-[[releases]]
-version = "11.15.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.15.0-darwin-x64.tar.gz"
-etag = "3cc7ff95006b05b6d8cb7b727388c19b"
-
-[[releases]]
-version = "11.2.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.2.0-darwin-x64.tar.gz"
-etag = "3dbded714a5cebaf5ac447c4484e32fe"
-
-[[releases]]
-version = "11.3.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.3.0-darwin-x64.tar.gz"
-etag = "d15a0a760aeb7fcd4c0b6a25529759c0"
-
-[[releases]]
-version = "11.4.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.4.0-darwin-x64.tar.gz"
-etag = "0badf49f8d6aa6d8132916052547865d"
-
-[[releases]]
-version = "11.5.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.5.0-darwin-x64.tar.gz"
-etag = "f1968a180739aec5a35e7778b77d4bea"
-
-[[releases]]
-version = "11.6.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.6.0-darwin-x64.tar.gz"
-etag = "bc6044faecbd1a216d11ab8ac05f3a41"
-
-[[releases]]
-version = "11.7.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.7.0-darwin-x64.tar.gz"
-etag = "ccea4d6956bf66ce6af96cefb93d1f04"
-
-[[releases]]
-version = "11.8.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.8.0-darwin-x64.tar.gz"
-etag = "d7d522f5bf1e1821d258cdb3ebf87e7c"
-
-[[releases]]
-version = "11.9.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v11.9.0-darwin-x64.tar.gz"
-etag = "1dce07e744fd518a9d3bf1611c0e721a"
-
-[[releases]]
-version = "12.0.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.0.0-darwin-x64.tar.gz"
-etag = "9bd5425992b3e8b27542dd0017140feb"
-
-[[releases]]
-version = "12.1.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.1.0-darwin-x64.tar.gz"
-etag = "f6464cf5569dcd84a7930dd463636418"
-
-[[releases]]
-version = "12.10.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.10.0-darwin-x64.tar.gz"
-etag = "ae17569da0e787b77f7811b255c528cb"
-
-[[releases]]
-version = "12.11.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.11.0-darwin-x64.tar.gz"
-etag = "cfb6ddede26476faa95e4e445dee6254"
-
-[[releases]]
-version = "12.11.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.11.1-darwin-x64.tar.gz"
-etag = "870f6467a4e95f1d3b29f08f8158dde1"
-
-[[releases]]
-version = "12.12.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.12.0-darwin-x64.tar.gz"
-etag = "72b892d17a1de38b40cddd7fdb39e8e7"
-
-[[releases]]
-version = "12.13.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.13.0-darwin-x64.tar.gz"
-etag = "e5cb03e25d7996ae24a230a4512c5817"
-
-[[releases]]
-version = "12.13.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.13.1-darwin-x64.tar.gz"
-etag = "a347868afbb81d5b18116619b57f016a-3"
-
-[[releases]]
-version = "12.14.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.14.0-darwin-x64.tar.gz"
-etag = "1ec6c21238c6af4b8c2cb20ae6630df8"
-
-[[releases]]
-version = "12.14.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.14.1-darwin-x64.tar.gz"
-etag = "d98df77c47b0b83b3d0cb04d97374e90"
-
-[[releases]]
-version = "12.15.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.15.0-darwin-x64.tar.gz"
-etag = "8bf0ff87a9cd53de20f9905a4266b445"
-
-[[releases]]
-version = "12.16.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.16.0-darwin-x64.tar.gz"
-etag = "5504043d93837eeee1fb3dbfaa52eaa6"
-
-[[releases]]
-version = "12.16.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.16.1-darwin-x64.tar.gz"
-etag = "3bcfe9b7553b9836878c87394d585fbd"
-
-[[releases]]
-version = "12.16.2"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.16.2-darwin-x64.tar.gz"
-etag = "a92da45fe607326748c57adf4aada73f-3"
-
-[[releases]]
-version = "12.16.3"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.16.3-darwin-x64.tar.gz"
-etag = "db0e17a2dffe405e6077c817131a823d-3"
-
-[[releases]]
-version = "12.2.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.2.0-darwin-x64.tar.gz"
-etag = "d95b66b6c81e4bbddd94b7ddfa4a4a2f"
-
-[[releases]]
-version = "12.3.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.3.0-darwin-x64.tar.gz"
-etag = "3b55e52fc17ba959ce339c7fdcee0f56"
-
-[[releases]]
-version = "12.3.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.3.1-darwin-x64.tar.gz"
-etag = "67a1cf0fd7d2b623ff3503f5026b21d4"
-
-[[releases]]
-version = "12.4.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.4.0-darwin-x64.tar.gz"
-etag = "1327d9429ca77b14ce14b52b622031f2"
-
-[[releases]]
-version = "12.5.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.5.0-darwin-x64.tar.gz"
-etag = "ace7c880c8178bbdbdc2efae749a9ac7"
-
-[[releases]]
-version = "12.6.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.6.0-darwin-x64.tar.gz"
-etag = "383b60f419a752c565bfeb1b95a0e843-3"
-
-[[releases]]
-version = "12.7.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.7.0-darwin-x64.tar.gz"
-etag = "de537f6e5640466b44d7774b61616864-3"
-
-[[releases]]
-version = "12.8.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.8.0-darwin-x64.tar.gz"
-etag = "a6bf0fad73dd99a3eb92c8dffdf73a9e"
-
-[[releases]]
-version = "12.8.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.8.1-darwin-x64.tar.gz"
-etag = "4c89a11e9cf7c81fdccaaaa23243a52a-3"
-
-[[releases]]
-version = "12.9.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.9.0-darwin-x64.tar.gz"
-etag = "db54bea21ff05b1faf4515b62df166cc"
-
-[[releases]]
-version = "12.9.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v12.9.1-darwin-x64.tar.gz"
-etag = "b6c2184b83c94254b3267e485b9540c5-3"
-
-[[releases]]
-version = "13.0.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.0.0-darwin-x64.tar.gz"
-etag = "9c1d16f64f45ae8f041ede55f9ca3f27-4"
-
-[[releases]]
-version = "13.0.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.0.1-darwin-x64.tar.gz"
-etag = "2e9b0f36d6f58841817fc6eb178e8a09-4"
-
-[[releases]]
-version = "13.1.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.1.0-darwin-x64.tar.gz"
-etag = "60da832dd768d69cd01dbfccad8fc154-4"
-
-[[releases]]
-version = "13.10.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.10.0-darwin-x64.tar.gz"
-etag = "0908ebf0f16e61c25083f66bb37f115a-4"
-
-[[releases]]
-version = "13.10.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.10.1-darwin-x64.tar.gz"
-etag = "56e611f1cb321731eb1ef238991ef4da-4"
-
-[[releases]]
-version = "13.11.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.11.0-darwin-x64.tar.gz"
-etag = "4370def07b18d225755e4acca647593d-4"
-
-[[releases]]
-version = "13.12.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.12.0-darwin-x64.tar.gz"
-etag = "f014fcc400f09fc071ea300b7b68eed3-4"
-
-[[releases]]
-version = "13.13.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.13.0-darwin-x64.tar.gz"
-etag = "1503b4a33b739dffa30cb28609c3c882-4"
-
-[[releases]]
-version = "13.2.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.2.0-darwin-x64.tar.gz"
-etag = "6b7239eebb6bc344cc2e642014ea8402-4"
-
-[[releases]]
-version = "13.3.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.3.0-darwin-x64.tar.gz"
-etag = "a2090fb5b2388c6e3a970d66a982b267"
-
-[[releases]]
-version = "13.4.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.4.0-darwin-x64.tar.gz"
-etag = "22c2828a7db7547e4c5487b7cd18f2ce-4"
-
-[[releases]]
-version = "13.5.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.5.0-darwin-x64.tar.gz"
-etag = "7099d8d7eece8092aadf065201195309-4"
-
-[[releases]]
-version = "13.6.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.6.0-darwin-x64.tar.gz"
-etag = "4b02b6953ad7f299be3047e9337abbd9"
-
-[[releases]]
-version = "13.7.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.7.0-darwin-x64.tar.gz"
-etag = "86d6f2e39c4163584ba86e18abad26fb-4"
-
-[[releases]]
-version = "13.8.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.8.0-darwin-x64.tar.gz"
-etag = "363e99e2177ffbf685410148cb4cf701-4"
-
-[[releases]]
-version = "13.9.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v13.9.0-darwin-x64.tar.gz"
-etag = "25433a0b64a3b71b981656b01b3b0031"
-
-[[releases]]
-version = "16.2.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v16.2.0-darwin-x64.tar.gz"
-etag = "a5edf585cde418ce69f99eb1c99e4910-4"
-
-[[releases]]
-version = "6.14.4"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.14.4-darwin-x64.tar.gz"
-etag = "0bb04f12c5041367429175a765e0f948"
-
-[[releases]]
-version = "6.15.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.15.0-darwin-x64.tar.gz"
-etag = "d8db6fa9ab2757996604a0b6e5af31d4"
-
-[[releases]]
-version = "6.15.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.15.1-darwin-x64.tar.gz"
-etag = "f4c860c829f4749ee9196f94239cd2ad"
-
-[[releases]]
-version = "6.16.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.16.0-darwin-x64.tar.gz"
-etag = "ece449be5f8b9a7a5acc6d7c75d2a97e"
-
-[[releases]]
-version = "6.17.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.17.0-darwin-x64.tar.gz"
-etag = "0a3afceae5144b47d497c01d40e57fed"
-
-[[releases]]
-version = "6.17.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v6.17.1-darwin-x64.tar.gz"
-etag = "55394ba4babf46ec8eeded045c1c8c56"
-
-[[releases]]
-version = "8.11.4"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.11.4-darwin-x64.tar.gz"
-etag = "c30ef72d947f05a2a803f7bfd32d511b"
-
-[[releases]]
-version = "8.12.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.12.0-darwin-x64.tar.gz"
-etag = "f1489227237471edcbe1f02505b49ce4"
-
-[[releases]]
-version = "8.13.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.13.0-darwin-x64.tar.gz"
-etag = "77934dd4a77be45aab6069a2e2cc327c"
-
-[[releases]]
-version = "8.14.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.14.0-darwin-x64.tar.gz"
-etag = "cd6cfa062d4f62e7126ad653f8ed42aa"
-
-[[releases]]
-version = "8.14.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.14.1-darwin-x64.tar.gz"
-etag = "bf1e2d414c9b8b4ced0fb921536396fd"
-
-[[releases]]
-version = "8.15.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.15.0-darwin-x64.tar.gz"
-etag = "2b8d16fd1b804feb2534e5dc9d513e4f"
-
-[[releases]]
-version = "8.15.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.15.1-darwin-x64.tar.gz"
-etag = "bf05532c0ef3262c5a40a4af4ee8273a"
-
-[[releases]]
-version = "8.16.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.16.0-darwin-x64.tar.gz"
-etag = "765e9fb02e197f83d80f8afddf97438d"
-
-[[releases]]
-version = "8.16.1"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.16.1-darwin-x64.tar.gz"
-etag = "0d5148d32e59dafe82c772ede431290c"
-
-[[releases]]
-version = "8.16.2"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.16.2-darwin-x64.tar.gz"
-etag = "f5e20750bcc2d5b8642c1d0221f5ae71"
-
-[[releases]]
-version = "8.17.0"
-channel = "staging"
-arch = "darwin-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/darwin-x64/node-v8.17.0-darwin-x64.tar.gz"
-etag = "794cf5d11fa08aab90c69e879f82a117"
-
-[[releases]]
-version = "10.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.1.0-linux-x64.tar.gz"
-etag = "4fb3b7467b19ad7e430f075dbd0ba172-3"
-
-[[releases]]
-version = "10.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.10.0-linux-x64.tar.gz"
-etag = "76edac78bdf3cf3122765736c0f83d9f-3"
-
-[[releases]]
-version = "10.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.11.0-linux-x64.tar.gz"
-etag = "f5f9addfbbfcea477ff8e8afb769850a-3"
-
-[[releases]]
-version = "10.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.12.0-linux-x64.tar.gz"
-etag = "79261291abf863dfd5fe44e949bc1490-3"
-
-[[releases]]
-version = "10.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.13.0-linux-x64.tar.gz"
-etag = "82a34d6ab9e59c96d76415dd9a67bf45-3"
-
-[[releases]]
-version = "10.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.14.0-linux-x64.tar.gz"
-etag = "30700affc50d2c7cf013d7508a43311b-3"
-
-[[releases]]
-version = "10.14.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.14.1-linux-x64.tar.gz"
-etag = "7f79b79070ed256eceac79ad748cf4d4-3"
-
-[[releases]]
-version = "10.14.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.14.2-linux-x64.tar.gz"
-etag = "2d55538fcafdd67b5a3c34fc7843502f-3"
-
-[[releases]]
-version = "10.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.15.0-linux-x64.tar.gz"
-etag = "94b54a8e661f3a059d3a218eaf1b4ce3-3"
-
-[[releases]]
-version = "10.15.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.15.1-linux-x64.tar.gz"
-etag = "667c6ce37855b51271f679ff88057f8c-3"
-
-[[releases]]
-version = "10.15.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.15.2-linux-x64.tar.gz"
-etag = "6972a42229b5b343f67dc1360742b7f2-3"
-
-[[releases]]
-version = "10.15.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.15.3-linux-x64.tar.gz"
-etag = "8a137b8f0de8b5b509bc3e118e0d983b-3"
-
-[[releases]]
-version = "10.16.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.16.0-linux-x64.tar.gz"
-etag = "fab40faa3e53cd150159b946f863abfe-3"
-
-[[releases]]
-version = "10.16.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.16.1-linux-x64.tar.gz"
-etag = "d6af63b2b77e3e4a2b2e20ce4fc449bb-3"
-
-[[releases]]
-version = "10.16.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.16.2-linux-x64.tar.gz"
-etag = "9401eed2234274cc0f9c7275ea369426-3"
-
-[[releases]]
-version = "10.16.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.16.3-linux-x64.tar.gz"
-etag = "d76675e5fce26151003c73e033fea3bd-3"
-
-[[releases]]
-version = "10.17.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.17.0-linux-x64.tar.gz"
-etag = "29e85c26db8b6b9f0adfe3f1e5b1857f-3"
-
-[[releases]]
-version = "10.18.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.18.0-linux-x64.tar.gz"
-etag = "2a8533f02ae1985c0d85afaed6887165-3"
-
-[[releases]]
-version = "10.18.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.18.1-linux-x64.tar.gz"
-etag = "bea0cdff6fe012ac53174297693ab349-3"
-
-[[releases]]
-version = "10.19.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.19.0-linux-x64.tar.gz"
-etag = "f482ebf412beeec9b76104467c81d291-3"
-
-[[releases]]
-version = "10.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.2.0-linux-x64.tar.gz"
-etag = "1adcf1141ef740279c0ba5cbd82cc3a4-3"
-
-[[releases]]
-version = "10.2.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.2.1-linux-x64.tar.gz"
-etag = "dbbc0965a912b69434c43b4775f96fa2-3"
-
-[[releases]]
-version = "10.20.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.20.0-linux-x64.tar.gz"
-etag = "44eba89064618c8c2c79402bcd0be63f-3"
-
-[[releases]]
-version = "10.20.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.20.1-linux-x64.tar.gz"
-etag = "b0f14eb6a6310f464c3db7544a3af492-3"
-
-[[releases]]
-version = "10.21.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.21.0-linux-x64.tar.gz"
-etag = "8d2f778b455afe7f80e6d1ea201f5733-3"
-
-[[releases]]
-version = "10.22.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.22.0-linux-x64.tar.gz"
-etag = "7cf59442c716572239cb14fdabb0ead5-3"
-
-[[releases]]
-version = "10.22.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.22.1-linux-x64.tar.gz"
-etag = "92b244406470e9a4f49cc233675fdf96-3"
-
-[[releases]]
-version = "10.23.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.23.0-linux-x64.tar.gz"
-etag = "3cc926fb4db5ad0d0ef161916760c25e-3"
-
-[[releases]]
-version = "10.23.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.23.1-linux-x64.tar.gz"
-etag = "5387220383fd6512e7cab92ef287426f-3"
-
-[[releases]]
-version = "10.23.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.23.2-linux-x64.tar.gz"
-etag = "f511a3763a63e7616fb608416e00a253-3"
-
-[[releases]]
-version = "10.23.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.23.3-linux-x64.tar.gz"
-etag = "6a05b6db3a7e812691eb2992c8287670-3"
-
-[[releases]]
-version = "10.24.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.24.0-linux-x64.tar.gz"
-etag = "b179fd013f51c02a3c77281fe744dd41-3"
-
-[[releases]]
-version = "10.24.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.24.1-linux-x64.tar.gz"
-etag = "957994ef8bf3610b7f0b67365691ebaf-3"
-
-[[releases]]
-version = "10.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v10.9.0-linux-x64.tar.gz"
-etag = "70c617771708c7c4f36d5823fb413600"
-
-[[releases]]
-version = "11.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.0.0-linux-x64.tar.gz"
-etag = "6cc8a0761f4266183190c56b72363e98"
-
-[[releases]]
-version = "11.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.1.0-linux-x64.tar.gz"
-etag = "6f471bc29d30640097c743927c113f02"
-
-[[releases]]
-version = "11.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.10.0-linux-x64.tar.gz"
-etag = "a1239a07fbd8b9dc460e1e44246e5f29"
-
-[[releases]]
-version = "11.10.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.10.1-linux-x64.tar.gz"
-etag = "1e462fb3a741ce0abf3fe2b0d81574e2"
-
-[[releases]]
-version = "11.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.11.0-linux-x64.tar.gz"
-etag = "009c70629178fb47044333aa4a031c77"
-
-[[releases]]
-version = "11.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.12.0-linux-x64.tar.gz"
-etag = "da2736962216075cb9ad09e87a7f300e"
-
-[[releases]]
-version = "11.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.13.0-linux-x64.tar.gz"
-etag = "95d07b2b544793962b0214bd7e33441c"
-
-[[releases]]
-version = "11.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.14.0-linux-x64.tar.gz"
-etag = "d1ec8cc7a5a102c92d5486cfa9e03b00"
-
-[[releases]]
-version = "11.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.15.0-linux-x64.tar.gz"
-etag = "ab251fc5b77761064204d00be022fda3"
-
-[[releases]]
-version = "11.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.2.0-linux-x64.tar.gz"
-etag = "6f1e2002e2af3f660ec0d84dda5e8a6a"
-
-[[releases]]
-version = "11.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.3.0-linux-x64.tar.gz"
-etag = "dc1a836d178e97e06107e1673d3caf96"
-
-[[releases]]
-version = "11.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.4.0-linux-x64.tar.gz"
-etag = "2718dafe1f89dd3794a0da222ee365ae"
-
-[[releases]]
-version = "11.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.5.0-linux-x64.tar.gz"
-etag = "7a32d6b4c300f6a7b78f3a28ed4587e3"
-
-[[releases]]
-version = "11.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.6.0-linux-x64.tar.gz"
-etag = "9ab9d9540290c15caad5fdf0a32b40fa"
-
-[[releases]]
-version = "11.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.7.0-linux-x64.tar.gz"
-etag = "35c41456320eb8a712dde2aac4145166"
-
-[[releases]]
-version = "11.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.8.0-linux-x64.tar.gz"
-etag = "7a6bdb9ffd31bc5ae4c6d866b5462826"
-
-[[releases]]
-version = "11.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v11.9.0-linux-x64.tar.gz"
-etag = "8805aeb4cfb798106c6a99ed34536682"
-
-[[releases]]
-version = "12.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.0.0-linux-x64.tar.gz"
-etag = "246f00fcffbd01974f260b4383f91c58"
-
-[[releases]]
-version = "12.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.1.0-linux-x64.tar.gz"
-etag = "d4df5a60e1b73c062131985de2ada621"
-
-[[releases]]
-version = "12.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.10.0-linux-x64.tar.gz"
-etag = "74dc625cf656bd501f0cd08f28e92131"
-
-[[releases]]
-version = "12.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.11.0-linux-x64.tar.gz"
-etag = "3ad3502adff89d3a037cd910ef17f725"
-
-[[releases]]
-version = "12.11.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.11.1-linux-x64.tar.gz"
-etag = "fb56b6d4439d3ccca91a8ff419391c3e"
-
-[[releases]]
-version = "12.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.12.0-linux-x64.tar.gz"
-etag = "41e3b3ccc2e2254869234f1f4c50dffc"
-
-[[releases]]
-version = "12.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.13.0-linux-x64.tar.gz"
-etag = "5f1bc3459c59f8b80cf6ea3d38944da7"
-
-[[releases]]
-version = "12.13.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.13.1-linux-x64.tar.gz"
-etag = "169ca5c7407b7532ed947a2014a48b1e"
-
-[[releases]]
-version = "12.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.14.0-linux-x64.tar.gz"
-etag = "919f124e16acb7464459c58dd2cfd36e"
-
-[[releases]]
-version = "12.14.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.14.1-linux-x64.tar.gz"
-etag = "cf97b81a436bdd484e642660eb769e16"
-
-[[releases]]
-version = "12.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.15.0-linux-x64.tar.gz"
-etag = "6c5ee256556aec2f1ca11f02b58d81b4"
-
-[[releases]]
-version = "12.16.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.16.0-linux-x64.tar.gz"
-etag = "7f8d2520e715d7df82f368b0fab9d2b6"
-
-[[releases]]
-version = "12.16.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.16.1-linux-x64.tar.gz"
-etag = "656435219a1655586fe02ac5f8bfa694"
-
-[[releases]]
-version = "12.16.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.16.2-linux-x64.tar.gz"
-etag = "ee1bd62aa6e09c627610868e3d0117bf-3"
-
-[[releases]]
-version = "12.16.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.16.3-linux-x64.tar.gz"
-etag = "f0478be22ff8042183df5b8cf0e6a736-3"
-
-[[releases]]
-version = "12.17.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.17.0-linux-x64.tar.gz"
-etag = "4a9c63315d8b0c2e41711caf04121acd-3"
-
-[[releases]]
-version = "12.18.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.0-linux-x64.tar.gz"
-etag = "cce51b56de0a404d30864591c1b6695c-3"
-
-[[releases]]
-version = "12.18.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.1-linux-x64.tar.gz"
-etag = "8e2e94383d7e833eb42fa619c27ed4df-3"
-
-[[releases]]
-version = "12.18.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.2-linux-x64.tar.gz"
-etag = "655570eb6f1b10edafc64366878dd03e-3"
-
-[[releases]]
-version = "12.18.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.3-linux-x64.tar.gz"
-etag = "9e7444e9d66072035f73e9ac0ee51322-3"
-
-[[releases]]
-version = "12.18.4"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.18.4-linux-x64.tar.gz"
-etag = "fdecf94ced8dcdeb972e14b333c72e47-3"
-
-[[releases]]
-version = "12.19.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.19.0-linux-x64.tar.gz"
-etag = "1962f4127fb09f2942b82f48f4ae2cf8-3"
-
-[[releases]]
-version = "12.19.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.19.1-linux-x64.tar.gz"
-etag = "7851352d2c9d60d4c5779910af828755-3"
-
-[[releases]]
-version = "12.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.2.0-linux-x64.tar.gz"
-etag = "87dc21fee7f484defd9010a6c606aa92"
-
-[[releases]]
-version = "12.20.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.20.0-linux-x64.tar.gz"
-etag = "3383e1624171a83a04740f24831c5c92-3"
-
-[[releases]]
-version = "12.20.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.20.1-linux-x64.tar.gz"
-etag = "51c80c3820855d8e77f37c9a67b9d89b-3"
-
-[[releases]]
-version = "12.20.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.20.2-linux-x64.tar.gz"
-etag = "d296cca07540a62c9c583ce4f23afee7-3"
-
-[[releases]]
-version = "12.21.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.21.0-linux-x64.tar.gz"
-etag = "a0fe4d871fc223d21fbac24689c598fd-3"
-
-[[releases]]
-version = "12.22.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.0-linux-x64.tar.gz"
-etag = "b0eb62d33d028e6cd3f1b7220b962a55-3"
-
-[[releases]]
-version = "12.22.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.1-linux-x64.tar.gz"
-etag = "4648915ed3eb1be12cf7cbe1c5b3e867-3"
-
-[[releases]]
-version = "12.22.10"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.10-linux-x64.tar.gz"
-etag = "58fe1bdc055914f433ee3f07bb380f36-3"
-
-[[releases]]
-version = "12.22.11"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.11-linux-x64.tar.gz"
-etag = "98a9f79ab4d7840b31c95968e82e9569-3"
-
-[[releases]]
-version = "12.22.12"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.12-linux-x64.tar.gz"
-etag = "84488d656cf19837e8dbc27b1a9993c9-3"
-
-[[releases]]
-version = "12.22.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.2-linux-x64.tar.gz"
-etag = "a014e16e46f6c158facd9d48c6a450f7-3"
-
-[[releases]]
-version = "12.22.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.3-linux-x64.tar.gz"
-etag = "41956f3f2a7cbbfc012e0d52facee55d-3"
-
-[[releases]]
-version = "12.22.4"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.4-linux-x64.tar.gz"
-etag = "461546c7894049caaa06041520e4172e-3"
-
-[[releases]]
-version = "12.22.5"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.5-linux-x64.tar.gz"
-etag = "2e8f7e52697114e493a312d7c4493fb0-3"
-
-[[releases]]
-version = "12.22.6"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.6-linux-x64.tar.gz"
-etag = "d61482b86203da8b3542f25723ca8f6a-3"
-
-[[releases]]
-version = "12.22.7"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.7-linux-x64.tar.gz"
-etag = "28b7bdac5d0a1a5361cf4504898d985e-3"
-
-[[releases]]
-version = "12.22.8"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.8-linux-x64.tar.gz"
-etag = "e7ca67cb90ca08afe64d87f9cdfbe2f9-3"
-
-[[releases]]
-version = "12.22.9"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.9-linux-x64.tar.gz"
-etag = "827ab91c2a29f14e1ad39e0fbd2ede10-3"
-
-[[releases]]
-version = "12.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.3.0-linux-x64.tar.gz"
-etag = "123a93553a06e8a7615c444c1ea42882"
-
-[[releases]]
-version = "12.3.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.3.1-linux-x64.tar.gz"
-etag = "82721dca1c9757af1e50fda8f23a0175"
-
-[[releases]]
-version = "12.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.4.0-linux-x64.tar.gz"
-etag = "75341c471626e3155079041fc8737bab"
-
-[[releases]]
-version = "12.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.5.0-linux-x64.tar.gz"
-etag = "7377ca5f3d429dba8069808c57509f24"
-
-[[releases]]
-version = "12.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.6.0-linux-x64.tar.gz"
-etag = "a994f0952f86c01a8d887c49b7012024-3"
-
-[[releases]]
-version = "12.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.7.0-linux-x64.tar.gz"
-etag = "8d802407f95e54738199fe262311fe61-3"
-
-[[releases]]
-version = "12.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.8.0-linux-x64.tar.gz"
-etag = "2bc1f6bf496bfb6447c3fa129cf8a3d6"
-
-[[releases]]
-version = "12.8.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.8.1-linux-x64.tar.gz"
-etag = "861e3e41d606cba07b8d5e2840a4b3ee-3"
-
-[[releases]]
-version = "12.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.9.0-linux-x64.tar.gz"
-etag = "a0a7f5ea00f4bfc8580c18bfa2499d2c-3"
-
-[[releases]]
-version = "12.9.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.9.1-linux-x64.tar.gz"
-etag = "22a3ae7cb680c3ed5b6cf6ec50dbf879-3"
-
-[[releases]]
-version = "13.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.0.0-linux-x64.tar.gz"
-etag = "502a2f483442724fee5f9f0211548b88-4"
-
-[[releases]]
-version = "13.0.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.0.1-linux-x64.tar.gz"
-etag = "2baf49181f3e96643fd2ecd11bcadb72-4"
-
-[[releases]]
-version = "13.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.1.0-linux-x64.tar.gz"
-etag = "5f8f1fbe4f22e319c6dbf2a57ee120fd-4"
-
-[[releases]]
-version = "13.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.10.0-linux-x64.tar.gz"
-etag = "21ed55d5eb72662fa397007f059dacc6-4"
-
-[[releases]]
-version = "13.10.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.10.1-linux-x64.tar.gz"
-etag = "9820787c904a8832f20539e85ff5d475-4"
-
-[[releases]]
-version = "13.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.11.0-linux-x64.tar.gz"
-etag = "2af22200c0261f417cf32a3279da2621-4"
-
-[[releases]]
-version = "13.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.12.0-linux-x64.tar.gz"
-etag = "8d22abc5a44d5645c0a9eab6177df570-4"
-
-[[releases]]
-version = "13.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.13.0-linux-x64.tar.gz"
-etag = "b9a24b0caa34a7a12ebb3e31b6830769-4"
-
-[[releases]]
-version = "13.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.14.0-linux-x64.tar.gz"
-etag = "70ecff1b96a40b3330cc0b98ddf529b5-4"
-
-[[releases]]
-version = "13.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.2.0-linux-x64.tar.gz"
-etag = "d1e63b1e6d2d88fd4b5340dbc1cddc26-4"
-
-[[releases]]
-version = "13.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.3.0-linux-x64.tar.gz"
-etag = "0984273970fbe1b55d46a74132c79768"
-
-[[releases]]
-version = "13.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.4.0-linux-x64.tar.gz"
-etag = "8c9381cc980b97c9da87d8ddfcadd412-4"
-
-[[releases]]
-version = "13.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.5.0-linux-x64.tar.gz"
-etag = "217fc9ae83b23d35bbb28af0647b7289-4"
-
-[[releases]]
-version = "13.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.6.0-linux-x64.tar.gz"
-etag = "5758d37594fa78cabb0b4578771a01fd"
-
-[[releases]]
-version = "13.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.7.0-linux-x64.tar.gz"
-etag = "47a5b05e78d5c8104cc58fd313649633-4"
-
-[[releases]]
-version = "13.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.8.0-linux-x64.tar.gz"
-etag = "a0cc522352876fdb52dc2f7817998dc4-4"
-
-[[releases]]
-version = "13.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v13.9.0-linux-x64.tar.gz"
-etag = "4245c4d98069215fbe0b5cd3742d7e33-4"
-
-[[releases]]
-version = "14.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.0.0-linux-x64.tar.gz"
-etag = "4894abb65e1b01df7847a72cf5711cd7-4"
-
-[[releases]]
-version = "14.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.1.0-linux-x64.tar.gz"
-etag = "5acc3c5cb805c9714ee666212eeb7da8-4"
-
-[[releases]]
-version = "14.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.10.0-linux-x64.tar.gz"
-etag = "0692912fe38915d832ac97d9c8e75b6f-5"
-
-[[releases]]
-version = "14.10.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.10.1-linux-x64.tar.gz"
-etag = "4cc3f36a5a752141310ce9462b83b9e1-5"
-
-[[releases]]
-version = "14.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.11.0-linux-x64.tar.gz"
-etag = "5f0b0d752a988c5846e2850251d0de6e-5"
-
-[[releases]]
-version = "14.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.12.0-linux-x64.tar.gz"
-etag = "d543750360e322f6172ebbac5180f794-5"
-
-[[releases]]
-version = "14.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.13.0-linux-x64.tar.gz"
-etag = "d8db874594a71ef0a537e563f69403d5-5"
-
-[[releases]]
-version = "14.13.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.13.1-linux-x64.tar.gz"
-etag = "5fd8b1ffb4fe1f889bd39be6911ef12a-5"
-
-[[releases]]
-version = "14.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.14.0-linux-x64.tar.gz"
-etag = "8048c3ed071d05c927c4fbf21b7ce1d8-5"
-
-[[releases]]
-version = "14.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.0-linux-x64.tar.gz"
-etag = "53ded239e3e7b19ff58c63a13fc7295a-5"
-
-[[releases]]
-version = "14.15.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.1-linux-x64.tar.gz"
-etag = "ee95fa0dd4b142e075f7f61d6e9fdd3c-5"
-
-[[releases]]
-version = "14.15.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.2-linux-x64.tar.gz"
-etag = "f344e8a0fb555aa7cad8df8ee227c053-4"
-
-[[releases]]
-version = "14.15.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.3-linux-x64.tar.gz"
-etag = "929b59a348873583cf0eece6e997f694-4"
-
-[[releases]]
-version = "14.15.4"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.4-linux-x64.tar.gz"
-etag = "ad295578e70f4838d619a289c7d7654e-4"
-
-[[releases]]
-version = "14.15.5"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.15.5-linux-x64.tar.gz"
-etag = "78ef6759634ee37a78d17be7af46ed79-4"
-
-[[releases]]
-version = "14.16.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.16.0-linux-x64.tar.gz"
-etag = "f2cbbae39184fee9c13b611437b10921-4"
-
-[[releases]]
-version = "14.16.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.16.1-linux-x64.tar.gz"
-etag = "e03bf3ea73d969d9c08c8b7ae5493613-4"
-
-[[releases]]
-version = "14.17.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.0-linux-x64.tar.gz"
-etag = "cdc57f6a3cc4ca6f12f49dadd75a554e-5"
-
-[[releases]]
-version = "14.17.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.1-linux-x64.tar.gz"
-etag = "b41c1f2d90ecda727af59f7cc7c5dcfb-5"
-
-[[releases]]
-version = "14.17.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.2-linux-x64.tar.gz"
-etag = "7021d231631d65ece0f74c95bbc43eb3-5"
-
-[[releases]]
-version = "14.17.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.3-linux-x64.tar.gz"
-etag = "0bdbb8e1b6e813dbc040da523831c684-5"
-
-[[releases]]
-version = "14.17.4"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.4-linux-x64.tar.gz"
-etag = "81ca69987ef377abff2ecb2ae35d7ad7-5"
-
-[[releases]]
-version = "14.17.5"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.5-linux-x64.tar.gz"
-etag = "4e872307dfbc942a43b0eb5e6e44765c-5"
-
-[[releases]]
-version = "14.17.6"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.17.6-linux-x64.tar.gz"
-etag = "888e9ad0d2a56802507f3f6cd27f7ebe-5"
-
-[[releases]]
-version = "14.18.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.18.0-linux-x64.tar.gz"
-etag = "a667cd6939a25a71d4773357a693e170-5"
-
-[[releases]]
-version = "14.18.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.18.1-linux-x64.tar.gz"
-etag = "4a620703f674343fe1041b2bd0dfba66-5"
-
-[[releases]]
-version = "14.18.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.18.2-linux-x64.tar.gz"
-etag = "dad4b0c2b0daed55d75fd98500e57d62-5"
-
-[[releases]]
-version = "14.18.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.18.3-linux-x64.tar.gz"
-etag = "af7ed8db30228507dad9cf71afcce543-5"
-
-[[releases]]
-version = "14.19.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.0-linux-x64.tar.gz"
-etag = "06a14f4fdc59ae064ba047d4e9736fa3-5"
-
-[[releases]]
-version = "14.19.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.1-linux-x64.tar.gz"
-etag = "fcb00a3d0c4b22c1b6e157a558949657-5"
-
-[[releases]]
-version = "14.19.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.2-linux-x64.tar.gz"
-etag = "a6dd0bfb2f656166aeefefa37cfa8122-5"
-
-[[releases]]
-version = "14.19.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.3-linux-x64.tar.gz"
-etag = "3990a70c4d0794e8646575c76bff11a7-5"
-
-[[releases]]
-version = "14.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.2.0-linux-x64.tar.gz"
-etag = "f41be74dd195a5714eabfeb4b3b95cc2-4"
-
-[[releases]]
-version = "14.20.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.20.0-linux-x64.tar.gz"
-etag = "f6da9962195174482d28f10830caf07d-5"
-
-[[releases]]
-version = "14.20.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.20.1-linux-x64.tar.gz"
-etag = "6bd6a27bebf33e019e154c29429dbbb8-5"
-
-[[releases]]
-version = "14.21.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.21.0-linux-x64.tar.gz"
-etag = "f9e6f039213ecb86ce8babadc3649dc9-5"
-
-[[releases]]
-version = "14.21.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.21.1-linux-x64.tar.gz"
-etag = "446470bd964ca7dc06d559b2aab6a123-5"
-
-[[releases]]
-version = "14.21.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.21.2-linux-x64.tar.gz"
-etag = "48813c8f1c235ce08888a9f1240c964c-5"
-
-[[releases]]
-version = "14.21.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.21.3-linux-x64.tar.gz"
-etag = "342cdbb59809aaa41d29ae298f73b365-5"
-
-[[releases]]
-version = "14.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.3.0-linux-x64.tar.gz"
-etag = "4dcfa3708c0bab7b77783a543e37120e-4"
-
-[[releases]]
-version = "14.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.4.0-linux-x64.tar.gz"
-etag = "cb4e531dd8b4cca8883d3884b4345644-4"
-
-[[releases]]
-version = "14.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.5.0-linux-x64.tar.gz"
-etag = "5c92a547ff32fe8f9c507455863ab531-5"
-
-[[releases]]
-version = "14.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.6.0-linux-x64.tar.gz"
-etag = "e076d8f3ac1ffaf3540b6bff5fa14dd1-5"
-
-[[releases]]
-version = "14.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.7.0-linux-x64.tar.gz"
-etag = "98021eb36abb1d21ed54521a85ce5fa6-5"
-
-[[releases]]
-version = "14.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.8.0-linux-x64.tar.gz"
-etag = "00e00bc07580f6376df8f218b7196594-5"
-
-[[releases]]
-version = "14.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.9.0-linux-x64.tar.gz"
-etag = "2353027766ae1fdc82aa2fefc9cfad25-5"
-
-[[releases]]
-version = "15.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.0.0-linux-x64.tar.gz"
-etag = "39eea40a8dc5ca81ef1010088ae74ea5-5"
-
-[[releases]]
-version = "15.0.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.0.1-linux-x64.tar.gz"
-etag = "4066ea9cd7b29f9084c237a1024872c7-5"
-
-[[releases]]
-version = "15.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.1.0-linux-x64.tar.gz"
-etag = "e1d3af432eb7accbfc614a3cf48c7583-4"
-
-[[releases]]
-version = "15.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.10.0-linux-x64.tar.gz"
-etag = "485a712d740b014662a226e834bd9557-4"
-
-[[releases]]
-version = "15.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.11.0-linux-x64.tar.gz"
-etag = "ef6f1f9484a255594673ca7bcfbed280-4"
-
-[[releases]]
-version = "15.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.12.0-linux-x64.tar.gz"
-etag = "231a5764d7aafa2c8d99fcd147b0e875-4"
-
-[[releases]]
-version = "15.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.13.0-linux-x64.tar.gz"
-etag = "6a6b953c042ee7fca4a7e4482de60dc2-4"
-
-[[releases]]
-version = "15.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.14.0-linux-x64.tar.gz"
-etag = "0f2e0ef70eebc4840eab7547e59880ae-4"
-
-[[releases]]
-version = "15.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.2.0-linux-x64.tar.gz"
-etag = "784df9e5242bb304820b2c14512d9ce3-4"
-
-[[releases]]
-version = "15.2.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.2.1-linux-x64.tar.gz"
-etag = "ca1c922ba43df36fbb23fd8b3a8ea876-4"
-
-[[releases]]
-version = "15.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.3.0-linux-x64.tar.gz"
-etag = "292ba2368577fa093bedb1b7f5014402-4"
-
-[[releases]]
-version = "15.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.4.0-linux-x64.tar.gz"
-etag = "69eeff861c07a0fed33fda82b35a5ecb-4"
-
-[[releases]]
-version = "15.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.5.0-linux-x64.tar.gz"
-etag = "b5bc122b0bb815f48128c67709a76cf0-4"
-
-[[releases]]
-version = "15.5.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.5.1-linux-x64.tar.gz"
-etag = "37e51c2d28beb27f4488fbd5b4a58f59-4"
-
-[[releases]]
-version = "15.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.6.0-linux-x64.tar.gz"
-etag = "aeb1a459afa11e7fc482e0a672cf1fe2-4"
-
-[[releases]]
-version = "15.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.7.0-linux-x64.tar.gz"
-etag = "065a4833bd91372bf26a45a46820f77a-4"
-
-[[releases]]
-version = "15.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.8.0-linux-x64.tar.gz"
-etag = "e88c6266c1926b5c4348ad943e1c2ee2-4"
-
-[[releases]]
-version = "15.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v15.9.0-linux-x64.tar.gz"
-etag = "38308de828100c4f52adb07e8de3cc9d-4"
-
-[[releases]]
-version = "16.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.0.0-linux-x64.tar.gz"
-etag = "9ced677cf96c5ca3b4067f35c21311ac-4"
-
-[[releases]]
-version = "16.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.1.0-linux-x64.tar.gz"
-etag = "8d4e3e558429cf64b22302f210b3d7e5-4"
-
-[[releases]]
-version = "16.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.10.0-linux-x64.tar.gz"
-etag = "d91908102992fad63e2eb2c9b8082553-4"
-
-[[releases]]
-version = "16.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.11.0-linux-x64.tar.gz"
-etag = "c93e9efb20bf3f5807ec0e058bd83d5c-4"
-
-[[releases]]
-version = "16.11.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.11.1-linux-x64.tar.gz"
-etag = "ae7ebdb2d57c11865882e4dc3d6fc5e5-4"
-
-[[releases]]
-version = "16.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.12.0-linux-x64.tar.gz"
-etag = "66344ff27247c29c3a5fbe85fe5acb9d-4"
-
-[[releases]]
-version = "16.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.13.0-linux-x64.tar.gz"
-etag = "d445951da7d338a5d6d758aa24b6804d-4"
-
-[[releases]]
-version = "16.13.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.13.1-linux-x64.tar.gz"
-etag = "5ed5638fad670c7568cb216775f03cc6-4"
-
-[[releases]]
-version = "16.13.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.13.2-linux-x64.tar.gz"
-etag = "8104fa926e76b71b0c22236b24310732-4"
-
-[[releases]]
-version = "16.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.0-linux-x64.tar.gz"
-etag = "5bc4c0b1c1c94fad08c80561e259ee99-4"
-
-[[releases]]
-version = "16.14.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.1-linux-x64.tar.gz"
-etag = "64b4bbdf40af72cd2fe6accfc8054b16-4"
-
-[[releases]]
-version = "16.14.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.2-linux-x64.tar.gz"
-etag = "4db20ae2bbff10cf3c8aa2f7ea370fb0-4"
-
-[[releases]]
-version = "16.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.15.0-linux-x64.tar.gz"
-etag = "4df8f054993a43950ef0f2e42b9ff53d-4"
-
-[[releases]]
-version = "16.15.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.15.1-linux-x64.tar.gz"
-etag = "b863d244e4b1c0df901c8c8c8967dd68-4"
-
-[[releases]]
-version = "16.16.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.16.0-linux-x64.tar.gz"
-etag = "ad683ead6ffb89f81e933ab93a9c770a-4"
-
-[[releases]]
-version = "16.17.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.17.0-linux-x64.tar.gz"
-etag = "2525dc9822008f0666d3f0908c4c4c43-5"
-
-[[releases]]
-version = "16.17.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.17.1-linux-x64.tar.gz"
-etag = "f341015b15c91fe90ae9a8d6a3cc9fc8-5"
-
-[[releases]]
-version = "16.18.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.18.0-linux-x64.tar.gz"
-etag = "288b5e721e34d3983f55b0f77d5eb006-5"
-
-[[releases]]
-version = "16.18.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.18.1-linux-x64.tar.gz"
-etag = "64f9e77e6b1548cadb8c9251c7c841eb-5"
-
-[[releases]]
-version = "16.19.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.19.0-linux-x64.tar.gz"
-etag = "2f7c8ff9691c80c08007f26d42a99aaf-5"
-
-[[releases]]
-version = "16.19.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.19.1-linux-x64.tar.gz"
-etag = "243011854e70850bbc464bd26f02cdff-5"
-
-[[releases]]
-version = "16.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.2.0-linux-x64.tar.gz"
-etag = "ee81bd1f587c60c54432650eba4c51bc-4"
-
-[[releases]]
-version = "16.20.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.20.0-linux-x64.tar.gz"
-etag = "c8b5ddcdbfabac844be2ecf344311855-5"
-
-[[releases]]
-version = "16.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.3.0-linux-x64.tar.gz"
-etag = "b0a9cecd669951adac9e27a35102923d-4"
-
-[[releases]]
-version = "16.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.4.0-linux-x64.tar.gz"
-etag = "8a77e82e1ca44f4fe1922714403161e8-4"
-
-[[releases]]
-version = "16.4.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.4.1-linux-x64.tar.gz"
-etag = "558b0575a48ff39c21a1fd9402fa0b84-4"
-
-[[releases]]
-version = "16.4.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.4.2-linux-x64.tar.gz"
-etag = "722a9783a7201b020ad6a89b9703cc3b-4"
-
-[[releases]]
-version = "16.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.5.0-linux-x64.tar.gz"
-etag = "5322a660d103a2974b9e073eae890bfb-4"
-
-[[releases]]
-version = "16.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.6.0-linux-x64.tar.gz"
-etag = "dfbee0cdf68d776ad1e51ca482250b0a-4"
-
-[[releases]]
-version = "16.6.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.6.1-linux-x64.tar.gz"
-etag = "bc15b11b0fd5ff2b62c6bf83646c82df-4"
-
-[[releases]]
-version = "16.6.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.6.2-linux-x64.tar.gz"
-etag = "0f897c317d9f01058731d4d283ce1cf2-4"
-
-[[releases]]
-version = "16.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.7.0-linux-x64.tar.gz"
-etag = "5db3c31791f4f8f75a8e8737e2ad2382-4"
-
-[[releases]]
-version = "16.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.8.0-linux-x64.tar.gz"
-etag = "2cf9f82dd69a9d35ba71532459629f83-4"
-
-[[releases]]
-version = "16.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.9.0-linux-x64.tar.gz"
-etag = "f76ebd4df376e0a9a8138bfcbe3a3079-4"
-
-[[releases]]
-version = "16.9.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.9.1-linux-x64.tar.gz"
-etag = "b591f8229fa8bf2f0a387c23b8277c55-4"
-
-[[releases]]
-version = "17.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.0.0-linux-x64.tar.gz"
-etag = "86c99126a99b3a82d007caedabdb9fa1-6"
-
-[[releases]]
-version = "17.0.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.0.1-linux-x64.tar.gz"
-etag = "10dc62fa317414c345bed79c04cc71fc-6"
-
-[[releases]]
-version = "17.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.1.0-linux-x64.tar.gz"
-etag = "8bf50f0462ee3144f34c6da85ae09e32-6"
-
-[[releases]]
-version = "17.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.2.0-linux-x64.tar.gz"
-etag = "0aee67a645145fd83f1e9c333c68c655-6"
-
-[[releases]]
-version = "17.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.3.0-linux-x64.tar.gz"
-etag = "43a9c23500b6183f63c62fe1c72bbdcd-6"
-
-[[releases]]
-version = "17.3.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.3.1-linux-x64.tar.gz"
-etag = "89f0dc5714f090fb5255b2ab4b943c03-6"
-
-[[releases]]
-version = "17.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.4.0-linux-x64.tar.gz"
-etag = "72cd45ee41e736a3d15ccd255bc42ea5-6"
-
-[[releases]]
-version = "17.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.5.0-linux-x64.tar.gz"
-etag = "85ca8cdd9038440dbad047487fe5caad-6"
-
-[[releases]]
-version = "17.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.6.0-linux-x64.tar.gz"
-etag = "acb898de485f6fd431c5bba29737cdd6-6"
-
-[[releases]]
-version = "17.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.7.0-linux-x64.tar.gz"
-etag = "3ae4ee1f090945e80ad2209beb2c019e-6"
-
-[[releases]]
-version = "17.7.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.7.2-linux-x64.tar.gz"
-etag = "5bfd0dc5e7e878dd4561fd0e41035051-6"
-
-[[releases]]
-version = "17.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.8.0-linux-x64.tar.gz"
-etag = "062cf4cae4ec3b032c41909a49df706e-6"
-
-[[releases]]
-version = "17.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.9.0-linux-x64.tar.gz"
-etag = "d82856ef7d8fd6ee756e0c4054e686aa-6"
-
-[[releases]]
-version = "17.9.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.9.1-linux-x64.tar.gz"
-etag = "5abb91fe234c1cb3709811ca8c62ee88-6"
-
-[[releases]]
-version = "18.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.0.0-linux-x64.tar.gz"
-etag = "48ae6c63e24f5ce074e86188287198e0-6"
-
-[[releases]]
-version = "18.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.1.0-linux-x64.tar.gz"
-etag = "37faa7d1b87accc2b5f8c5c8af3d4a85-6"
-
-[[releases]]
-version = "18.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.10.0-linux-x64.tar.gz"
-etag = "d31a7a94f60ae2ee3d2c5d208dd9fa06-6"
-
-[[releases]]
-version = "18.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.11.0-linux-x64.tar.gz"
-etag = "163783aaa395b4bafe69067e81e71ab8-6"
-
-[[releases]]
-version = "18.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.12.0-linux-x64.tar.gz"
-etag = "86649fe86748ea3febf98e929d498119-6"
-
-[[releases]]
-version = "18.12.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.12.1-linux-x64.tar.gz"
-etag = "a06f34eaf7ae2352c789e8faea99176c-6"
-
-[[releases]]
-version = "18.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.13.0-linux-x64.tar.gz"
-etag = "015f9dfe56aeb2d10a9abe0a0a28ac6d-6"
-
-[[releases]]
-version = "18.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.14.0-linux-x64.tar.gz"
-etag = "f64feba223d30bb5145dd5d5240609d3-6"
-
-[[releases]]
-version = "18.14.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.14.1-linux-x64.tar.gz"
-etag = "9ad4db80f4608dd332bf22ae10977f3d-6"
-
-[[releases]]
-version = "18.14.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.14.2-linux-x64.tar.gz"
-etag = "2a33290e3c193b654808b29ec7aef765-6"
-
-[[releases]]
-version = "18.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.15.0-linux-x64.tar.gz"
-etag = "26343f5611dc89155f9d066aa8164dfe-6"
-
-[[releases]]
-version = "18.16.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.16.0-linux-x64.tar.gz"
-etag = "d617fab87f8ee9b80abebd50857e2bde-6"
-
-[[releases]]
-version = "18.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.2.0-linux-x64.tar.gz"
-etag = "3e7b3258d258a95ba0e1ad06ed7f482d-6"
-
-[[releases]]
-version = "18.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.3.0-linux-x64.tar.gz"
-etag = "0882fd16bcfeabd57379441604051ca4-6"
-
-[[releases]]
-version = "18.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.4.0-linux-x64.tar.gz"
-etag = "05ff72f9371a8705b8e5b895dfd8f6b5-6"
-
-[[releases]]
-version = "18.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.5.0-linux-x64.tar.gz"
-etag = "9bd9fc6a152929b992967d7efe40cfa6-6"
-
-[[releases]]
-version = "18.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.6.0-linux-x64.tar.gz"
-etag = "96773288cff667058e088a4fb418aca3-6"
-
-[[releases]]
-version = "18.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.7.0-linux-x64.tar.gz"
-etag = "a0a3893b6b148788381bbc6f7260d35e-6"
-
-[[releases]]
-version = "18.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.8.0-linux-x64.tar.gz"
-etag = "cc3fcca2aa2dccdc333fbc0709428463-6"
-
-[[releases]]
-version = "18.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.9.0-linux-x64.tar.gz"
-etag = "8e53d83d4455c1861a22030a78f0a076-6"
-
-[[releases]]
-version = "18.9.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.9.1-linux-x64.tar.gz"
-etag = "6e9038bdbfb630d31d3875cf1f56e2ba-6"
-
-[[releases]]
-version = "19.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.0.0-linux-x64.tar.gz"
-etag = "99d158299058e3a6b76f1bdc8e18393a-6"
-
-[[releases]]
-version = "19.0.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.0.1-linux-x64.tar.gz"
-etag = "ac996f828499ee7fa1774b9939f5d6c7-6"
-
-[[releases]]
-version = "19.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.1.0-linux-x64.tar.gz"
-etag = "43ac81eb0cbcb40ca1d740ac0d078596-6"
-
-[[releases]]
-version = "19.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.2.0-linux-x64.tar.gz"
-etag = "250cb7f6bf897efc151f6dc8141c4d47-6"
-
-[[releases]]
-version = "19.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.3.0-linux-x64.tar.gz"
-etag = "28f7e1417152b4b5353376ddf2250d47-6"
-
-[[releases]]
-version = "19.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.4.0-linux-x64.tar.gz"
-etag = "2fd4267d28ed47fa708ff6856eac32fb-6"
-
-[[releases]]
-version = "19.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.5.0-linux-x64.tar.gz"
-etag = "265bced5d9813609194da5492a9120b2-6"
-
-[[releases]]
-version = "19.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.6.0-linux-x64.tar.gz"
-etag = "fa1942df595ee976b2f3fc527a6ae54b-6"
-
-[[releases]]
-version = "19.6.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.6.1-linux-x64.tar.gz"
-etag = "3da49c80eb81a859fae044f18bed25b8-6"
-
-[[releases]]
-version = "19.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.7.0-linux-x64.tar.gz"
-etag = "285a1444b527be5801d8d828a5dac1af-6"
-
-[[releases]]
-version = "19.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.8.0-linux-x64.tar.gz"
-etag = "5c1de4f49ba34ce1d462562c5f5841fc-6"
-
-[[releases]]
-version = "19.8.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.8.1-linux-x64.tar.gz"
-etag = "0f11104d9c1e305858586a6671beec73-6"
-
-[[releases]]
-version = "19.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v19.9.0-linux-x64.tar.gz"
-etag = "ebce078cbac8006fab82956e5882bc28-6"
-
-[[releases]]
-version = "20.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v20.0.0-linux-x64.tar.gz"
-etag = "3456465494f47de14edc1a97caec1baf-6"
-
-[[releases]]
-version = "20.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v20.1.0-linux-x64.tar.gz"
-etag = "3b470a161894e01274666e85c898728b-6"
-
-[[releases]]
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v22.1.0/node-v22.1.0-linux-arm64.tar.gz"
+checksum = "sha256:9c111af1f951e8869615bca3601ce7ab6969374933bdba6397469843b808f222"
+
+[[artifacts]]
+version = "22.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v22.1.0/node-v22.1.0-linux-x64.tar.gz"
+checksum = "sha256:d8ae35a9e2bb0c0c0611ee9bacf564ea51cc8291ace1447f95ee6aeaf4f1d61d"
+
+[[artifacts]]
+version = "22.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v22.0.0/node-v22.0.0-linux-arm64.tar.gz"
+checksum = "sha256:1d3547226be7e59aceee5c7d01a9f8fc18de67e015c5a15d8cf385b6e02d062b"
+
+[[artifacts]]
+version = "22.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v22.0.0/node-v22.0.0-linux-x64.tar.gz"
+checksum = "sha256:74bb0f3a80307c529421c3ed84517b8f543867709f41e53cd73df99e6442af4d"
+
+[[artifacts]]
+version = "21.7.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.7.3/node-v21.7.3-linux-arm64.tar.gz"
+checksum = "sha256:15390ba8509b71c0051e61f75a6fdb0a2eb38318c03a01bf60c93d33d414d138"
+
+[[artifacts]]
+version = "21.7.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.7.3/node-v21.7.3-linux-x64.tar.gz"
+checksum = "sha256:a64cbb12282cb60d35743ef4f51561f8d89946a5f0a484f99168f4de602d7c3d"
+
+[[artifacts]]
+version = "21.7.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.7.2/node-v21.7.2-linux-arm64.tar.gz"
+checksum = "sha256:5cf1cb89feb40404adad999307659754dd17fc9afa6c086aaff690ecbf8af66c"
+
+[[artifacts]]
+version = "21.7.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.7.2/node-v21.7.2-linux-x64.tar.gz"
+checksum = "sha256:06b891c82c9b19b8d8553222de5de8afd43a38c1b898f9ca323e1d2e22da9075"
+
+[[artifacts]]
+version = "21.7.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.7.1/node-v21.7.1-linux-arm64.tar.gz"
+checksum = "sha256:466647785722c5b9b9f2e430e11645e16f1d112b303b0ffdf2d5fa0eb95e647c"
+
+[[artifacts]]
+version = "21.7.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.7.1/node-v21.7.1-linux-x64.tar.gz"
+checksum = "sha256:c7b15146aed968b781c235b6a8f67608be559c4615de9526a9851ae28660cc09"
+
+[[artifacts]]
+version = "21.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.7.0/node-v21.7.0-linux-arm64.tar.gz"
+checksum = "sha256:520a3e5c83a05a782b1f4959f150c2fdc03e2ea056e855ef6bbb74f6ccf7aa7d"
+
+[[artifacts]]
+version = "21.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.7.0/node-v21.7.0-linux-x64.tar.gz"
+checksum = "sha256:0fce039e2b6af00766492127a49f959ae92ed22fede4c49e9a8c2543aadbd6e2"
+
+[[artifacts]]
+version = "21.6.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.6.2/node-v21.6.2-linux-arm64.tar.gz"
+checksum = "sha256:b8431985c53cc14e02cddf4c128d043c62af19023f908ebcdc1c6a683ee995f3"
+
+[[artifacts]]
+version = "21.6.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.6.2/node-v21.6.2-linux-x64.tar.gz"
+checksum = "sha256:d4504dcbcd1a9ded42d86bc20a7e72d6d631e49dcf3f9c849c3b51b12f3f4544"
+
+[[artifacts]]
+version = "21.6.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.6.1/node-v21.6.1-linux-arm64.tar.gz"
+checksum = "sha256:e19a4364cf27c9c0cdc1472faf4eece6313b590f1e9c55852d8ec3efa89fe097"
+
+[[artifacts]]
+version = "21.6.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.6.1/node-v21.6.1-linux-x64.tar.gz"
+checksum = "sha256:d2ac105754e5fc657a6a25ea7d31f19dd63d3ec845dce0aef0232533d52bc125"
+
+[[artifacts]]
+version = "21.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.6.0/node-v21.6.0-linux-arm64.tar.gz"
+checksum = "sha256:4c795134f243ac95db587b9d5de94bb066b96b3821604a806d3c1853ee44ec56"
+
+[[artifacts]]
+version = "21.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.6.0/node-v21.6.0-linux-x64.tar.gz"
+checksum = "sha256:d12a6fc04091aa246402b4cac67215cd2578f178300a361cfa9e28b2ca16d679"
+
+[[artifacts]]
+version = "21.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.5.0/node-v21.5.0-linux-arm64.tar.gz"
+checksum = "sha256:ed8d7c80f301af4546d60bb0d25930ade432a45560d2eecf17c23818c05ce12f"
+
+[[artifacts]]
+version = "21.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.5.0/node-v21.5.0-linux-x64.tar.gz"
+checksum = "sha256:6e61f81fe1759892fb1f84f62fe470c8d4d6dfc07969af5700f06b4672a9e8d3"
+
+[[artifacts]]
+version = "21.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.4.0/node-v21.4.0-linux-arm64.tar.gz"
+checksum = "sha256:071b90b14c2e74f8400c48683c21250491951faf9ae54756a2b53340c1574a27"
+
+[[artifacts]]
+version = "21.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.4.0/node-v21.4.0-linux-x64.tar.gz"
+checksum = "sha256:d8cd0ec0b78bcbc591e7a4655a92c1c667e64bc434e7a895904dc1fe9442af1d"
+
+[[artifacts]]
+version = "21.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.3.0/node-v21.3.0-linux-arm64.tar.gz"
+checksum = "sha256:3daa24a423bd32d0636554695e147c902b29fd3f3ca654894f07c792d5e4edc9"
+
+[[artifacts]]
+version = "21.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.3.0/node-v21.3.0-linux-x64.tar.gz"
+checksum = "sha256:e8f8af0a4a5b07ff9ced55efc1b6ea712a1441b95c02ce0d8814070148f27f42"
+
+[[artifacts]]
+version = "21.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.2.0/node-v21.2.0-linux-arm64.tar.gz"
+checksum = "sha256:d202d583e5cf3b0a8ba4f8e242467fd7bdea57c94a81c63cfa78aa224bdec7e1"
+
+[[artifacts]]
+version = "21.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.2.0/node-v21.2.0-linux-x64.tar.gz"
+checksum = "sha256:2600d1103d9963ca194aa52b5610ea28f1e4c2df81e525799fba9b7b530c6e54"
+
+[[artifacts]]
+version = "21.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.1.0/node-v21.1.0-linux-arm64.tar.gz"
+checksum = "sha256:5480f438703049f55f19fc3247f6aa1e8059b2f47cf08e9adfdcb7ce7aedff70"
+
+[[artifacts]]
+version = "21.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.1.0/node-v21.1.0-linux-x64.tar.gz"
+checksum = "sha256:b919cad4e8a5abbd7e6a4433c4f8a7cdc1a78c1e526c6c1aa4a5fcf74011ad2b"
+
+[[artifacts]]
+version = "21.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v21.0.0/node-v21.0.0-linux-arm64.tar.gz"
+checksum = "sha256:d30396893a9acbdd2a879ac92072932919c8d6dac41177fee86a0336bf9a909d"
+
+[[artifacts]]
+version = "21.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v21.0.0/node-v21.0.0-linux-x64.tar.gz"
+checksum = "sha256:013f370f1772197cb4e22f22f2185ee26d2e5f3acdb2f252d11cd214e9a8cdb9"
+
+[[artifacts]]
+version = "20.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.13.0/node-v20.13.0-linux-arm64.tar.gz"
+checksum = "sha256:29e904b9dd7325911ab38f79c5462f1d562d5573b97e8f63d700870a270ef43a"
+
+[[artifacts]]
+version = "20.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.13.0/node-v20.13.0-linux-x64.tar.gz"
+checksum = "sha256:a74ceb142362d152aa871710ef9fb338ab72c76415f5afa802fc0aea445397b3"
+
+[[artifacts]]
+version = "20.12.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.12.2/node-v20.12.2-linux-arm64.tar.gz"
+checksum = "sha256:2dc8ffa0da135bf493f881d2d38aac610772c801bb7b6208fcc5de9350f119f7"
+
+[[artifacts]]
+version = "20.12.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.12.2/node-v20.12.2-linux-x64.tar.gz"
+checksum = "sha256:f8f9b6877778ed2d5f920a5bd853f0f8a8be1c42f6d448c763a95625cbbb4b0d"
+
+[[artifacts]]
+version = "20.12.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.12.1/node-v20.12.1-linux-arm64.tar.gz"
+checksum = "sha256:6eb199eaa4f83a729242c69792a126cb58ca6a60d791dffd9cedb4cfd32b96c0"
+
+[[artifacts]]
+version = "20.12.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.12.1/node-v20.12.1-linux-x64.tar.gz"
+checksum = "sha256:da2f590a39717792dcf8c4bf6b9e4b269601e6ce3a3f150a3c4b379f7eea6d83"
+
+[[artifacts]]
+version = "20.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.12.0/node-v20.12.0-linux-arm64.tar.gz"
+checksum = "sha256:8e180526df8ad4086a4df7bfaaa14d21eb2a6cf58b1c5493c639022c165c2884"
+
+[[artifacts]]
+version = "20.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.12.0/node-v20.12.0-linux-x64.tar.gz"
+checksum = "sha256:b6b998947595c9550d6b89c815a68d608f5920275f1b48812f89792de3fdd893"
+
+[[artifacts]]
+version = "20.11.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.11.1/node-v20.11.1-linux-arm64.tar.gz"
+checksum = "sha256:e34ab2fc2726b4abd896bcbff0250e9b2da737cbd9d24267518a802ed0606f3b"
+
+[[artifacts]]
+version = "20.11.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.11.1/node-v20.11.1-linux-x64.tar.gz"
+checksum = "sha256:bf3a779bef19452da90fb88358ec2c57e0d2f882839b20dc6afc297b6aafc0d7"
+
+[[artifacts]]
+version = "20.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.11.0/node-v20.11.0-linux-arm64.tar.gz"
+checksum = "sha256:402178cd5438b9ed89bffafc119e2bd4148616390bcdfd7089090ffc4615c981"
+
+[[artifacts]]
+version = "20.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.11.0/node-v20.11.0-linux-x64.tar.gz"
+checksum = "sha256:9556262f6cd4c020af027782afba31ca6d1a37e45ac0b56cecd2d5a4daf720e0"
+
+[[artifacts]]
+version = "20.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.10.0/node-v20.10.0-linux-arm64.tar.gz"
+checksum = "sha256:8354cdb7cb2ad585ee6bb24819f5229bb48c118c5dabb282dfed153d766a68a4"
+
+[[artifacts]]
+version = "20.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.10.0/node-v20.10.0-linux-x64.tar.gz"
+checksum = "sha256:d3f0908a9d9190a8525c5b9a716ed91bb57e908555841b0c47f75b2a001ff91b"
+
+[[artifacts]]
+version = "20.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-arm64.tar.gz"
+checksum = "sha256:d2a7dbeeb274bfd16b579d2cafb92f673010df36c83a5b55de3916aad6806a6a"
+
+[[artifacts]]
+version = "20.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64.tar.gz"
+checksum = "sha256:f0919f092fbf74544438907fa083c21e76b2d7a4bc287f0607ada1553ef16f60"
+
+[[artifacts]]
+version = "20.8.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.8.1/node-v20.8.1-linux-arm64.tar.gz"
+checksum = "sha256:c0420fef5f6e637888be3f400e99297bb844932166fbad5ffa4f188ce59cfcdf"
+
+[[artifacts]]
+version = "20.8.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.8.1/node-v20.8.1-linux-x64.tar.gz"
+checksum = "sha256:a42ac1f81704b14c7d07ddde989a8e290087b0487ee3f47185eb0240ba518195"
+
+[[artifacts]]
+version = "20.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.8.0/node-v20.8.0-linux-arm64.tar.gz"
+checksum = "sha256:cec9be5a060f63bfda7ef5b5a368cba5cfa0ce673b117bae8c146ec5df767cbe"
+
+[[artifacts]]
+version = "20.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.8.0/node-v20.8.0-linux-x64.tar.gz"
+checksum = "sha256:ae6f288a21a3bc7a82b79d3f00c52216df6de09c45eac0ea754243a9c7fb5e69"
+
+[[artifacts]]
+version = "20.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.7.0/node-v20.7.0-linux-arm64.tar.gz"
+checksum = "sha256:98a1ad20c1e81870467a891b050db85deb06d912c8f286a303681876d2eea5f0"
+
+[[artifacts]]
+version = "20.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.7.0/node-v20.7.0-linux-x64.tar.gz"
+checksum = "sha256:034bbec28da7b729aea531000a56b37076e94e44aa5dfa346a1d1a89025915a8"
+
+[[artifacts]]
+version = "20.6.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.6.1/node-v20.6.1-linux-arm64.tar.gz"
+checksum = "sha256:d38fe2e41e3fe8ae81b517b4cf49521f500e181e54f4c3d05e2b2d691a57b2ca"
+
+[[artifacts]]
+version = "20.6.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.6.1/node-v20.6.1-linux-x64.tar.gz"
+checksum = "sha256:26dd13a6f7253f0ab9bcab561353985a297d927840771d905566735b792868da"
+
+[[artifacts]]
+version = "20.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.6.0/node-v20.6.0-linux-arm64.tar.gz"
+checksum = "sha256:b68ae1ca9bd7387223c5d30a9d355e66ef4595bfe26ef6e9ae29824bc9abf25b"
+
+[[artifacts]]
+version = "20.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.6.0/node-v20.6.0-linux-x64.tar.gz"
+checksum = "sha256:fc14b089783e7fcaefd01bb7afc0561fac55e1950d56a6b33891a93cb8007b17"
+
+[[artifacts]]
+version = "20.5.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.5.1/node-v20.5.1-linux-arm64.tar.gz"
+checksum = "sha256:bb7321b4555abdf9fcd62426a23993f3610ac4c18d6fb843e35c2f8add631510"
+
+[[artifacts]]
+version = "20.5.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.5.1/node-v20.5.1-linux-x64.tar.gz"
+checksum = "sha256:a8678ae00425acdf692e943e3f1cea11a4c46281e4257b82886423bd4ef6f2b5"
+
+[[artifacts]]
+version = "20.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.5.0/node-v20.5.0-linux-arm64.tar.gz"
+checksum = "sha256:fde339b181db5827b42b83bd20479a44fe5bd5b8e4b71a5d09ee2f1f8152de97"
+
+[[artifacts]]
+version = "20.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.5.0/node-v20.5.0-linux-x64.tar.gz"
+checksum = "sha256:6799042a2970dcecdb71a91d392c53d954ec06d36155c7d11bf7c9a4983b60ea"
+
+[[artifacts]]
+version = "20.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.4.0/node-v20.4.0-linux-arm64.tar.gz"
+checksum = "sha256:6ed340475a8bd5db5f04fe943b8fb89b7b2a8fd919f91217c6386dfa59865ba3"
+
+[[artifacts]]
+version = "20.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.4.0/node-v20.4.0-linux-x64.tar.gz"
+checksum = "sha256:2a9b03dd17fa6d9241b93e244d7e8f2524c4019fb5cfe3a99e59da1ee983cb9a"
+
+[[artifacts]]
+version = "20.3.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.3.1/node-v20.3.1-linux-arm64.tar.gz"
+checksum = "sha256:4785061286dccf43cef673d8f9fec637f7a27d7e4c5b075f393e99ae13089f17"
+
+[[artifacts]]
+version = "20.3.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.3.1/node-v20.3.1-linux-x64.tar.gz"
+checksum = "sha256:100507c0c4b4cf2f0661ab8ca79b21790c20a4aae24859e9ab60b7d95fbfd740"
+
+[[artifacts]]
+version = "20.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.3.0/node-v20.3.0-linux-arm64.tar.gz"
+checksum = "sha256:c3476b293f3b26a14163184171896ef17dc33ee26a208256170556b493a2b2c5"
+
+[[artifacts]]
+version = "20.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.3.0/node-v20.3.0-linux-x64.tar.gz"
+checksum = "sha256:80238ee1a9dee6b0d5d1081503c6fdd1c7f81bdf4ca6abd90aa5a568712a2eaa"
+
+[[artifacts]]
 version = "20.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v20.2.0-linux-x64.tar.gz"
-etag = "262c2e27fdb5b764df8a642e6e942106-6"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.2.0/node-v20.2.0-linux-arm64.tar.gz"
+checksum = "sha256:c5a755230e9cf63ed708a79bd06604fe4c01283bdf9e9bc687ea107d02d3a2fd"
 
-[[releases]]
-version = "6.14.4"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.14.4-linux-x64.tar.gz"
-etag = "c81242d62dbad357134ad9e8c938fce6"
+[[artifacts]]
+version = "20.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.2.0/node-v20.2.0-linux-x64.tar.gz"
+checksum = "sha256:cb0eff87d37f0df1dcd176a58b9ed0be3b5c08a02fe133a5dffd11dcae29626b"
 
-[[releases]]
-version = "6.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.15.0-linux-x64.tar.gz"
-etag = "bc75fc652bb28aa07d92e99b212dd75e"
+[[artifacts]]
+version = "20.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.1.0/node-v20.1.0-linux-arm64.tar.gz"
+checksum = "sha256:b3867bda723ad3e4b1319b5584c99dde84b20d4ac557af82b26921ba6c2dc274"
 
-[[releases]]
-version = "6.15.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.15.1-linux-x64.tar.gz"
-etag = "8b6b409811ba540653b06a2f87af2b58"
+[[artifacts]]
+version = "20.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.1.0/node-v20.1.0-linux-x64.tar.gz"
+checksum = "sha256:fbc345638e3fed3b639353b2b3971bddba9e55e93b6e1848be6215787d7f20b8"
 
-[[releases]]
-version = "6.16.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.16.0-linux-x64.tar.gz"
-etag = "e4b7d1cc7c4156ae36af213795b9a2ab"
+[[artifacts]]
+version = "20.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v20.0.0/node-v20.0.0-linux-arm64.tar.gz"
+checksum = "sha256:6eeaf1e93baf82ca95e02590eec65e3187e756ddce6c23bbec1c09d49ebbff2a"
 
-[[releases]]
-version = "6.17.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.17.0-linux-x64.tar.gz"
-etag = "24b84466f5f921fa793243f87915800a"
+[[artifacts]]
+version = "20.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
+checksum = "sha256:95439a0a836fc858565c7b6a7b1e55d1741901e6f205485e496abbefe973cfce"
 
-[[releases]]
-version = "6.17.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v6.17.1-linux-x64.tar.gz"
-etag = "eb59e6ef416d02bfcd1188b4151bddcd"
+[[artifacts]]
+version = "19.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.9.0/node-v19.9.0-linux-arm64.tar.gz"
+checksum = "sha256:1ebddd6ac062270ac895233b78eb0feabc5fd08ea88502dfede626f4a1b4b037"
 
-[[releases]]
-version = "8.11.4"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.11.4-linux-x64.tar.gz"
-etag = "5764e757cee7ffa6eda727784ac2dde8"
+[[artifacts]]
+version = "19.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.9.0/node-v19.9.0-linux-x64.tar.gz"
+checksum = "sha256:15168a298d150335c098f19449f9baef0b0758466723fafc23ef209156dae604"
 
-[[releases]]
-version = "8.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.12.0-linux-x64.tar.gz"
-etag = "c2dc07f9b840abe01461328caad03179"
+[[artifacts]]
+version = "19.8.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.8.1/node-v19.8.1-linux-arm64.tar.gz"
+checksum = "sha256:aba5e0e7a109ea5ef9395d885f3ee381063de0f53ddd55c74071b83920f43e6e"
 
-[[releases]]
-version = "8.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.13.0-linux-x64.tar.gz"
-etag = "ec5e096251b6b78f508971d7038a5d14"
+[[artifacts]]
+version = "19.8.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.8.1/node-v19.8.1-linux-x64.tar.gz"
+checksum = "sha256:77b47ce0ed17ef90c1df6ef1ca6ea0f1375346ae4d5099708d9ee39d805f9d6e"
 
-[[releases]]
-version = "8.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.14.0-linux-x64.tar.gz"
-etag = "6e1117831d6dfa9cf73a998f84a70aa2"
+[[artifacts]]
+version = "19.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.8.0/node-v19.8.0-linux-arm64.tar.gz"
+checksum = "sha256:dc71b2b84dca27613d61c6c054046c96e18dc54bce9762d5fbcb22989ddefe53"
 
-[[releases]]
-version = "8.14.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.14.1-linux-x64.tar.gz"
-etag = "b62684a89bde079c53fb54dce47ff715"
+[[artifacts]]
+version = "19.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.8.0/node-v19.8.0-linux-x64.tar.gz"
+checksum = "sha256:a7f584b2f28eb18e1130ee590cf0062e4ee967412d1e8d029f3eb46c56598afc"
 
-[[releases]]
-version = "8.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.15.0-linux-x64.tar.gz"
-etag = "117139b710ca7795feda9e643ce11fe9"
+[[artifacts]]
+version = "19.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.7.0/node-v19.7.0-linux-arm64.tar.gz"
+checksum = "sha256:a9d3c9c3bfdcf7849161b56df8de652552f723144bb05e3df015269523c6e14b"
 
-[[releases]]
-version = "8.15.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.15.1-linux-x64.tar.gz"
-etag = "4c4497b86c0004401d5a93aa36c7e959"
+[[artifacts]]
+version = "19.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.7.0/node-v19.7.0-linux-x64.tar.gz"
+checksum = "sha256:f5f0ab097f4d120045a327ed2cf9afff264e10c5d304d6ec9529beedfd0c0fd6"
 
-[[releases]]
-version = "8.16.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.16.0-linux-x64.tar.gz"
-etag = "caabf1838fba99b1d228dfa66c38254f"
+[[artifacts]]
+version = "19.6.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.6.1/node-v19.6.1-linux-arm64.tar.gz"
+checksum = "sha256:1787b3795c64eac44ca6b88fe5bf29c7e7b72816ee7c1df1c64d6c323f2c1f71"
 
-[[releases]]
-version = "8.16.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.16.1-linux-x64.tar.gz"
-etag = "7208de0aad92d58374fa8f3763d6305c"
+[[artifacts]]
+version = "19.6.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.6.1/node-v19.6.1-linux-x64.tar.gz"
+checksum = "sha256:c6a64d49003861bf465a9ab8e876d5c13c59f1df4507df7cf5dc8ae6e48edf9d"
 
-[[releases]]
-version = "8.16.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.16.2-linux-x64.tar.gz"
-etag = "327ec94535ca1a5390fd2eebb970936d"
+[[artifacts]]
+version = "19.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.6.0/node-v19.6.0-linux-arm64.tar.gz"
+checksum = "sha256:6b7ca20d5fcd90a6cb1e687d31212b1db89e6816c5165995b537f495f06d8b71"
 
-[[releases]]
+[[artifacts]]
+version = "19.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.6.0/node-v19.6.0-linux-x64.tar.gz"
+checksum = "sha256:142e3caf0ea8476767d4ad006acf46b9dd059c169d3287f9d58eac964f16a4e1"
+
+[[artifacts]]
+version = "19.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.5.0/node-v19.5.0-linux-arm64.tar.gz"
+checksum = "sha256:eed8e3233359e269e0fd96ef4f493c8152136831fc77758da2335d2beeefddb9"
+
+[[artifacts]]
+version = "19.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.5.0/node-v19.5.0-linux-x64.tar.gz"
+checksum = "sha256:0df264934dadd15e7e9ba7576e88129017e62b29f259325c3fd3f1688fdf85bb"
+
+[[artifacts]]
+version = "19.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.4.0/node-v19.4.0-linux-arm64.tar.gz"
+checksum = "sha256:68417f33ca2556a73486a27a75a8214dd4532506a94bfdfcb9943474c9a7c13e"
+
+[[artifacts]]
+version = "19.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.4.0/node-v19.4.0-linux-x64.tar.gz"
+checksum = "sha256:e39635d2cb60bba7aea80801fc6524806cb6980b68bf8c9b74389c93db445f63"
+
+[[artifacts]]
+version = "19.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.3.0/node-v19.3.0-linux-arm64.tar.gz"
+checksum = "sha256:f892b536b00f780aba42b7ccc8974e57e58c4f1de3f9c85d1bbf13c60c680974"
+
+[[artifacts]]
+version = "19.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.3.0/node-v19.3.0-linux-x64.tar.gz"
+checksum = "sha256:b525028ae5bb71b5b32cb7fce903ccce261dbfef4c7dd0f3e0ffc27cd6fc0b3f"
+
+[[artifacts]]
+version = "19.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.2.0/node-v19.2.0-linux-arm64.tar.gz"
+checksum = "sha256:5010dc1b0e6417c61906de1a8d05e752c23d0493e5f419a59e8bf959a2f52628"
+
+[[artifacts]]
+version = "19.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.2.0/node-v19.2.0-linux-x64.tar.gz"
+checksum = "sha256:64cad7fb9ff6c0bc85b7f58275f23177a11c820240a0a7cb036e764a98c3527e"
+
+[[artifacts]]
+version = "19.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.1.0/node-v19.1.0-linux-arm64.tar.gz"
+checksum = "sha256:476399363945b3cf441d2e0677c50ad3a257db36c2a06a8c51c46b0bc42b4d3d"
+
+[[artifacts]]
+version = "19.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.1.0/node-v19.1.0-linux-x64.tar.gz"
+checksum = "sha256:1a42a67beb3e07289da2ad22a58717801c6ab80d09668e2da6b1c537b2a80a5e"
+
+[[artifacts]]
+version = "19.0.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.0.1/node-v19.0.1-linux-arm64.tar.gz"
+checksum = "sha256:ee1c319aaecafb6be140b64e91b0e83b90ef77657013d9c3c19bec27d5b32400"
+
+[[artifacts]]
+version = "19.0.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.0.1/node-v19.0.1-linux-x64.tar.gz"
+checksum = "sha256:7df29266d2cfd75b6e6ae59205476debac94848e29350378ece95701c13c32ee"
+
+[[artifacts]]
+version = "19.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v19.0.0/node-v19.0.0-linux-arm64.tar.gz"
+checksum = "sha256:fcfbd83208d9bc11943c070109ed615170d93d81bfaf5d45851319a33363c998"
+
+[[artifacts]]
+version = "19.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v19.0.0/node-v19.0.0-linux-x64.tar.gz"
+checksum = "sha256:857f4dde358a8b23afab47ebdc685ae736bcfeac1258c2dddae3648f6a03a77a"
+
+[[artifacts]]
+version = "18.20.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.20.2/node-v18.20.2-linux-arm64.tar.gz"
+checksum = "sha256:0b21ad5a11dd6c59a62eb34d1a0c2af28fe29187fa60da2c993b7cdf2a5a2f28"
+
+[[artifacts]]
+version = "18.20.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.20.2/node-v18.20.2-linux-x64.tar.gz"
+checksum = "sha256:a222595d353a7d1e48994a7d9c25e61ab1b8a1b0ce0652029f5cf999978b2e49"
+
+[[artifacts]]
+version = "18.20.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.20.1/node-v18.20.1-linux-arm64.tar.gz"
+checksum = "sha256:52896372b3b151f639be7efa8662d68aaeb065cae2c15d61d14e2b73ada79597"
+
+[[artifacts]]
+version = "18.20.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.20.1/node-v18.20.1-linux-x64.tar.gz"
+checksum = "sha256:d226c39c5546dca97567db8f8ca7f92fca6572d44f181b1f85af83eee5d6f9e1"
+
+[[artifacts]]
+version = "18.20.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.20.0/node-v18.20.0-linux-arm64.tar.gz"
+checksum = "sha256:93ff82497bf2ff7c0b2549637dd5098039439aa7805b08412cc71a98d437d9dd"
+
+[[artifacts]]
+version = "18.20.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.20.0/node-v18.20.0-linux-x64.tar.gz"
+checksum = "sha256:80620426d177141aa99376de2ad1cb5ed461104cc53c0a5334df91467c60cac3"
+
+[[artifacts]]
+version = "18.19.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.19.1/node-v18.19.1-linux-arm64.tar.gz"
+checksum = "sha256:2913e8544d95c8be9e6034c539ec0584014532166a088bf742629756c3ec42e2"
+
+[[artifacts]]
+version = "18.19.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.19.1/node-v18.19.1-linux-x64.tar.gz"
+checksum = "sha256:724802c45237477dbe5777923743e6c77906830cae03a82b5653ebd75b301dda"
+
+[[artifacts]]
+version = "18.19.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.19.0/node-v18.19.0-linux-arm64.tar.gz"
+checksum = "sha256:4297548671897a1ba6a9a78726cb3f53458048948b4f71d597886ccf799db603"
+
+[[artifacts]]
+version = "18.19.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.19.0/node-v18.19.0-linux-x64.tar.gz"
+checksum = "sha256:153312ae9fe8684f345100e4d141a521dc542b36d8c1e09c31ac290eae98c62a"
+
+[[artifacts]]
+version = "18.18.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.18.2/node-v18.18.2-linux-arm64.tar.gz"
+checksum = "sha256:0c9a6502b66310cb26e12615b57304e91d92ac03d4adcb91c1906351d7928f0d"
+
+[[artifacts]]
+version = "18.18.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.18.2/node-v18.18.2-linux-x64.tar.gz"
+checksum = "sha256:a44c3e7f8bf91e852c928e5d8bd67ca316b35e27eec1d8acbe3b9dbe03688dab"
+
+[[artifacts]]
+version = "18.18.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.18.1/node-v18.18.1-linux-arm64.tar.gz"
+checksum = "sha256:1d3ef02cfefc9c87a010ec9ac9a21cafc71096e8159b9f35b419d6e5f71e2f92"
+
+[[artifacts]]
+version = "18.18.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.18.1/node-v18.18.1-linux-x64.tar.gz"
+checksum = "sha256:9ce4db11f1d8399f6b58aab6858a688b2e09405127b47ebc4594dc8262a5e29f"
+
+[[artifacts]]
+version = "18.18.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.18.0/node-v18.18.0-linux-arm64.tar.gz"
+checksum = "sha256:54037e72a2676db610f0a9d66055a23241adf07f336cd0c9289a7b301eae9060"
+
+[[artifacts]]
+version = "18.18.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.18.0/node-v18.18.0-linux-x64.tar.gz"
+checksum = "sha256:8aae62b6b3a5d659459c35c51e4373b950d11595a273db16c6162c712c5533a2"
+
+[[artifacts]]
+version = "18.17.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.17.1/node-v18.17.1-linux-arm64.tar.gz"
+checksum = "sha256:8f5203f5c6dc44ea50ac918b7ecbdb1c418e4f3d9376d8232a1ef9ff38f9c480"
+
+[[artifacts]]
+version = "18.17.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.17.1/node-v18.17.1-linux-x64.tar.gz"
+checksum = "sha256:2cb75f2bc04b0a3498733fbee779b2f76fe3f655188b4ac69ef2887b6721da2d"
+
+[[artifacts]]
+version = "18.17.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.17.0/node-v18.17.0-linux-arm64.tar.gz"
+checksum = "sha256:9d586f9d8b73a121b8a5438079c7106379aaae868f945a9f1755565607607944"
+
+[[artifacts]]
+version = "18.17.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.17.0/node-v18.17.0-linux-x64.tar.gz"
+checksum = "sha256:5c4a7fd9262c0c47bafab3442de6c3fed1602be3d243cb8cf11309a201955e75"
+
+[[artifacts]]
+version = "18.16.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.16.1/node-v18.16.1-linux-arm64.tar.gz"
+checksum = "sha256:555b5c521e068acc976e672978ba0f5b1a0c030192b50639384c88143f4460bc"
+
+[[artifacts]]
+version = "18.16.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.16.1/node-v18.16.1-linux-x64.tar.gz"
+checksum = "sha256:59582f51570d0857de6333620323bdeee5ae36107318f86ce5eca24747cabf5b"
+
+[[artifacts]]
+version = "18.16.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.16.0/node-v18.16.0-linux-arm64.tar.gz"
+checksum = "sha256:dc3dfaee899ed21682e47eaf15525f85aff29013c392490e9b25219cd95b1c35"
+
+[[artifacts]]
+version = "18.16.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.16.0/node-v18.16.0-linux-x64.tar.gz"
+checksum = "sha256:fc83046a93d2189d919005a348db3b2372b598a145d84eb9781a3a4b0f032e95"
+
+[[artifacts]]
+version = "18.15.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.15.0/node-v18.15.0-linux-arm64.tar.gz"
+checksum = "sha256:8ef7aa7a679360ddbf0c7c8511881030b3de9d1f54451d92ba5c8d59a91c7073"
+
+[[artifacts]]
+version = "18.15.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.15.0/node-v18.15.0-linux-x64.tar.gz"
+checksum = "sha256:b298a73a9fc07badfa9e4a2e86ed48824fc9201327cdc43e3f3f58b273c535e7"
+
+[[artifacts]]
+version = "18.14.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.14.2/node-v18.14.2-linux-arm64.tar.gz"
+checksum = "sha256:e5c5d83e65271260ea4135330309d43fdc26c42457156ff237eeba65c6237f58"
+
+[[artifacts]]
+version = "18.14.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.14.2/node-v18.14.2-linux-x64.tar.gz"
+checksum = "sha256:95bdaaf92265eefd40d2055fb9b5cd6cbc3cb2c4495e3ebd4b1b501822d69731"
+
+[[artifacts]]
+version = "18.14.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.14.1/node-v18.14.1-linux-arm64.tar.gz"
+checksum = "sha256:608af6ad3cf5a171c889c022cb51a460bdbf57fbb8fbcd40612ea8063aa95f07"
+
+[[artifacts]]
+version = "18.14.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.14.1/node-v18.14.1-linux-x64.tar.gz"
+checksum = "sha256:6a7c6862b86cb01b892ca5967dba14bd3122dbfed9d5c9fedd30585d5974f1f6"
+
+[[artifacts]]
+version = "18.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.14.0/node-v18.14.0-linux-arm64.tar.gz"
+checksum = "sha256:29b38346f6b01e14a7582adf0132fae83410a8da21cdba936357010a065290a6"
+
+[[artifacts]]
+version = "18.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.14.0/node-v18.14.0-linux-x64.tar.gz"
+checksum = "sha256:bcdfd28bb7ab9a53c7045e0862556f77c250580c6d3d6cb960843895e024cac6"
+
+[[artifacts]]
+version = "18.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.13.0/node-v18.13.0-linux-arm64.tar.gz"
+checksum = "sha256:dc68e229425b941eeae0b1d59c66c680b56fd536d0ad2311e3fb009bd83661e4"
+
+[[artifacts]]
+version = "18.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.13.0/node-v18.13.0-linux-x64.tar.gz"
+checksum = "sha256:2d2881cf860624b9fa9866670a65708c747d458213bdccaa8e7266b105d404ad"
+
+[[artifacts]]
+version = "18.12.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.12.1/node-v18.12.1-linux-arm64.tar.gz"
+checksum = "sha256:521587df6d2b9d9c524105c8f3f9d775dcfc5e7fbf7633e4455cc2e9af7d0ced"
+
+[[artifacts]]
+version = "18.12.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.12.1/node-v18.12.1-linux-x64.tar.gz"
+checksum = "sha256:a8fcacb8033504e6d704bdee821f7005ee3774db25c799bcf2a13b5bda7de172"
+
+[[artifacts]]
+version = "18.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.12.0/node-v18.12.0-linux-arm64.tar.gz"
+checksum = "sha256:9bb70b30b9d34f2b859cfef73ec3134537408dbf7806d45f104bc1e1d3c832e9"
+
+[[artifacts]]
+version = "18.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.12.0/node-v18.12.0-linux-x64.tar.gz"
+checksum = "sha256:0699c8e02581a9c312d7157331561d36ef23963766eb47daa702edb6fd6735bd"
+
+[[artifacts]]
+version = "18.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.11.0/node-v18.11.0-linux-arm64.tar.gz"
+checksum = "sha256:48e5008774bd36471ece361e7a8795d59a0d40da7e849e13a1ed7f33cf8095a5"
+
+[[artifacts]]
+version = "18.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.11.0/node-v18.11.0-linux-x64.tar.gz"
+checksum = "sha256:5935236185a515b4beb991baabbe0084d552eb5122ab9b3fd0fad018af795cb3"
+
+[[artifacts]]
+version = "18.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.10.0/node-v18.10.0-linux-arm64.tar.gz"
+checksum = "sha256:ad536980cb4944b0d17055937c5d5170c95147765f547ce8469331a808d0c408"
+
+[[artifacts]]
+version = "18.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.10.0/node-v18.10.0-linux-x64.tar.gz"
+checksum = "sha256:f468b86031cca41ee9aa7a911e70eb624413153c7432754cbe9206c7ef3de090"
+
+[[artifacts]]
+version = "18.9.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.9.1/node-v18.9.1-linux-arm64.tar.gz"
+checksum = "sha256:a1610d6f75f45fb0dc73164231c63308d653c09a57dd14a989cf4de9b96e965b"
+
+[[artifacts]]
+version = "18.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.9.1/node-v18.9.1-linux-x64.tar.gz"
+checksum = "sha256:33ecf5f39618f4beb90a9be98880325cb4f06e33b52e315040a54fd0700f2434"
+
+[[artifacts]]
+version = "18.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.9.0/node-v18.9.0-linux-arm64.tar.gz"
+checksum = "sha256:0d0e671158e072a63c24714bfc4c19a4bb0a70c89d219b1f23d67cbea9c5ffcf"
+
+[[artifacts]]
+version = "18.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.9.0/node-v18.9.0-linux-x64.tar.gz"
+checksum = "sha256:7fdbfdb985a48db3d22a2472330db05d94c9aff59192b09d8f9ab5fcedba76d5"
+
+[[artifacts]]
+version = "18.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.8.0/node-v18.8.0-linux-arm64.tar.gz"
+checksum = "sha256:94cbe9128f1319b18fe33255f753da16ae7eca2f652afdfb1aabe75c3aa75631"
+
+[[artifacts]]
+version = "18.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.8.0/node-v18.8.0-linux-x64.tar.gz"
+checksum = "sha256:01c2060503bb42caa1c6cc2ee4b432f80c0b38ad46b4eed956774fb36302f46e"
+
+[[artifacts]]
+version = "18.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.7.0/node-v18.7.0-linux-arm64.tar.gz"
+checksum = "sha256:d971f644d3143422eb7a517e08c38a45a43cae14d977b3b96ff61b64f3a26b04"
+
+[[artifacts]]
+version = "18.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.7.0/node-v18.7.0-linux-x64.tar.gz"
+checksum = "sha256:0bef16a77faed5220c2ea1555f7bd19ea79bfbb848dba62fbe9d43eb1a36fce0"
+
+[[artifacts]]
+version = "18.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.6.0/node-v18.6.0-linux-arm64.tar.gz"
+checksum = "sha256:6ac2d56cf22b525e2e1d701718e6bae5eeb512cc249d7071b6472b7e8df491ac"
+
+[[artifacts]]
+version = "18.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.6.0/node-v18.6.0-linux-x64.tar.gz"
+checksum = "sha256:eff59cd54fdcd24dc09965b41dc8d347ab4ce367b6c395fd983cfb4c3a542e03"
+
+[[artifacts]]
+version = "18.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.5.0/node-v18.5.0-linux-arm64.tar.gz"
+checksum = "sha256:fab94abe6f88538b3a53d68582bffee37e181fbb8ac717b0a2abc25851e6616f"
+
+[[artifacts]]
+version = "18.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.5.0/node-v18.5.0-linux-x64.tar.gz"
+checksum = "sha256:deb4b0b8b82354a1b5087b724ab0d5861081302a12c0b204d799b31fea527eda"
+
+[[artifacts]]
+version = "18.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.4.0/node-v18.4.0-linux-arm64.tar.gz"
+checksum = "sha256:6926ab0721aee65b6a00f4858a307d736de5f48a511d7e5c6182f87887f76188"
+
+[[artifacts]]
+version = "18.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.4.0/node-v18.4.0-linux-x64.tar.gz"
+checksum = "sha256:4e3f5c72ec735aa23d52042be61e32e7279d26d7f05ebb5571c410e81d10c9a3"
+
+[[artifacts]]
+version = "18.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.3.0/node-v18.3.0-linux-arm64.tar.gz"
+checksum = "sha256:17753a86da5f4e37c711f7feffd08cdf3ba5c241088dab5389214d0d235ca1d1"
+
+[[artifacts]]
+version = "18.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.3.0/node-v18.3.0-linux-x64.tar.gz"
+checksum = "sha256:9b64ed313363872f83f6586ad985e793258c5ba6e569812b9dd349ec819956cf"
+
+[[artifacts]]
+version = "18.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.2.0/node-v18.2.0-linux-arm64.tar.gz"
+checksum = "sha256:9dc8ca472c79e842d4faf600876b643ab485936fe4870fbafaa7c19b2d153353"
+
+[[artifacts]]
+version = "18.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.2.0/node-v18.2.0-linux-x64.tar.gz"
+checksum = "sha256:73d3f98e96e098587c2154dcaa82a6469a510e89a4881663dc4c86985acf245e"
+
+[[artifacts]]
+version = "18.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.1.0/node-v18.1.0-linux-arm64.tar.gz"
+checksum = "sha256:95a986b1a9b393061f0976513cc543ab64f822d59d07d229bc21f472f8fad1d2"
+
+[[artifacts]]
+version = "18.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.1.0/node-v18.1.0-linux-x64.tar.gz"
+checksum = "sha256:db3819510007d29516cb45aa65a7cd967de917e40c176bb60de6c3d0cd6440af"
+
+[[artifacts]]
+version = "18.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v18.0.0/node-v18.0.0-linux-arm64.tar.gz"
+checksum = "sha256:dc59b5191e2bffcb124e80e12a323b5f700c1fa57a83a1846531008aba1e154d"
+
+[[artifacts]]
+version = "18.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v18.0.0/node-v18.0.0-linux-x64.tar.gz"
+checksum = "sha256:6260d3526dff25d43451ea8e90e0174975b4cd067e8535dc1d85a6d6b29f3043"
+
+[[artifacts]]
+version = "17.9.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.9.1/node-v17.9.1-linux-arm64.tar.gz"
+checksum = "sha256:88c65d4ae06f55dfd651ea647640b2ace9fbd469517ea58de8719d4e95618955"
+
+[[artifacts]]
+version = "17.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.9.1/node-v17.9.1-linux-x64.tar.gz"
+checksum = "sha256:efa39656f3a9761b5696dbd68efdff3a9be3ce00004171be53250a8a6f120272"
+
+[[artifacts]]
+version = "17.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.9.0/node-v17.9.0-linux-arm64.tar.gz"
+checksum = "sha256:d4acf5c0380c96c867428d0232666d3327dc5fa83a694d7b63f728a76ece84b2"
+
+[[artifacts]]
+version = "17.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.9.0/node-v17.9.0-linux-x64.tar.gz"
+checksum = "sha256:8c9f4c95c254336fcb2c768e746f4316b8176adc0fb599cbbb460d0933991d12"
+
+[[artifacts]]
+version = "17.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.8.0/node-v17.8.0-linux-arm64.tar.gz"
+checksum = "sha256:591d5c75b036fa3ce6f8d633e301c5c88124ee62eae1276b6eab9f27a53e1059"
+
+[[artifacts]]
+version = "17.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.8.0/node-v17.8.0-linux-x64.tar.gz"
+checksum = "sha256:02d3e21362ae3cf670fa4b12c6b982e2544a815a007ea96f881b89f305843dfe"
+
+[[artifacts]]
+version = "17.7.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.7.2/node-v17.7.2-linux-arm64.tar.gz"
+checksum = "sha256:577d89823ecfe5fc2008b1f2d3c8677c27385f1969ca0d1b8ba7a371a770ce54"
+
+[[artifacts]]
+version = "17.7.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.7.2/node-v17.7.2-linux-x64.tar.gz"
+checksum = "sha256:7865d88b7a07ec407ceb9a3a9aa92a1c5a07469885834a5ee56661de369a9e40"
+
+[[artifacts]]
+version = "17.7.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.7.1/node-v17.7.1-linux-arm64.tar.gz"
+checksum = "sha256:39d79bd3ba1e50d736edb680db524a3966e25d8d5ab0cb1dd7043ec281690028"
+
+[[artifacts]]
+version = "17.7.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.7.1/node-v17.7.1-linux-x64.tar.gz"
+checksum = "sha256:a88875ba97a71f77fc85890897d23bb7bbb2097bed6de5d40cca52b7b67f79d3"
+
+[[artifacts]]
+version = "17.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.7.0/node-v17.7.0-linux-arm64.tar.gz"
+checksum = "sha256:95a0db7d0c8f2fb930590f14a782fdf0824251d671575d248dd1344d63dc632b"
+
+[[artifacts]]
+version = "17.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.7.0/node-v17.7.0-linux-x64.tar.gz"
+checksum = "sha256:c807f2e7c08882a2005fce8db0820b810b2bcc4b6a872faa15fb2af193500d62"
+
+[[artifacts]]
+version = "17.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.6.0/node-v17.6.0-linux-arm64.tar.gz"
+checksum = "sha256:287b1e42aff686563ee80165c14e9246370cd2e9ae4662787493964dffed1da9"
+
+[[artifacts]]
+version = "17.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.6.0/node-v17.6.0-linux-x64.tar.gz"
+checksum = "sha256:de9596fda9cc88451d03146278806687e954c03413e8aa0ee98ad46442d6cb1c"
+
+[[artifacts]]
+version = "17.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.5.0/node-v17.5.0-linux-arm64.tar.gz"
+checksum = "sha256:82e46024637fb887f870ac4673072f7a3b3de3a8a6bf9a0945dbf28cf1a3aed8"
+
+[[artifacts]]
+version = "17.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.5.0/node-v17.5.0-linux-x64.tar.gz"
+checksum = "sha256:86fabd8177686b5f2f4ec8ac81e88a008b74a34e789080188f1c13f5d665ca6e"
+
+[[artifacts]]
+version = "17.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.4.0/node-v17.4.0-linux-arm64.tar.gz"
+checksum = "sha256:770ae5f8c6012138d877c858d1e6bcb53b65dbce4a20b3159cc58e8c4585d610"
+
+[[artifacts]]
+version = "17.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.4.0/node-v17.4.0-linux-x64.tar.gz"
+checksum = "sha256:132c61652c315a6f784167b97a53e9638bac45853f1544a84d4cbb90fe7a3bda"
+
+[[artifacts]]
+version = "17.3.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.3.1/node-v17.3.1-linux-arm64.tar.gz"
+checksum = "sha256:c9ca324368fdae2e8360cf7a22ce507c9931dc4bfe1e95723bd0fdfae616b31e"
+
+[[artifacts]]
+version = "17.3.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.3.1/node-v17.3.1-linux-x64.tar.gz"
+checksum = "sha256:7fd238a05ce8c98b19e6799103d12619f16bbab7111a6719f57b7ef190b74cfa"
+
+[[artifacts]]
+version = "17.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.3.0/node-v17.3.0-linux-arm64.tar.gz"
+checksum = "sha256:6f236f47fc68fa535bd0f769d9e12767a6b5251875aea2632c227ca55d1ab7ae"
+
+[[artifacts]]
+version = "17.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.3.0/node-v17.3.0-linux-x64.tar.gz"
+checksum = "sha256:479fb0b4b6405fb7240376187e2823cf384635a4998bdbaddc3ea826b63c8c74"
+
+[[artifacts]]
+version = "17.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.2.0/node-v17.2.0-linux-arm64.tar.gz"
+checksum = "sha256:d5fbc40f78be71007960b8490d9dc605bc006c2986d44812b4071116e6499ca4"
+
+[[artifacts]]
+version = "17.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.2.0/node-v17.2.0-linux-x64.tar.gz"
+checksum = "sha256:a26491670f11d6ef4f919d3c2678fe65292c9e1d7e9184ec551a011816d92f0d"
+
+[[artifacts]]
+version = "17.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.1.0/node-v17.1.0-linux-arm64.tar.gz"
+checksum = "sha256:738e785768b1a266c60cf9147d8b0c8fbca2a98a7b72b00ad63b39f94d0577c7"
+
+[[artifacts]]
+version = "17.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.1.0/node-v17.1.0-linux-x64.tar.gz"
+checksum = "sha256:54b387bb1b6faa436d73777343a1a2147e67ff5e33a80971df2fd030dde4fd24"
+
+[[artifacts]]
+version = "17.0.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.0.1/node-v17.0.1-linux-arm64.tar.gz"
+checksum = "sha256:b993eccc0d493065ba1e4b30e189bae43b9d7aba587625eed891125f316e1333"
+
+[[artifacts]]
+version = "17.0.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.0.1/node-v17.0.1-linux-x64.tar.gz"
+checksum = "sha256:c2aaef730245ad180d2a2b9d2d2806feca57e93e0691faabb41175d26bed9c89"
+
+[[artifacts]]
+version = "17.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v17.0.0/node-v17.0.0-linux-arm64.tar.gz"
+checksum = "sha256:d00e801d49b7419cbb07be4c8f026b43560c4e53579abce9d764edf7ebbc6554"
+
+[[artifacts]]
+version = "17.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v17.0.0/node-v17.0.0-linux-x64.tar.gz"
+checksum = "sha256:252505ade312c6c346c6b8d00e2be9e383446d81430ee4c1e5a04972e0817da4"
+
+[[artifacts]]
+version = "16.20.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.20.2/node-v16.20.2-linux-arm64.tar.gz"
+checksum = "sha256:b6945fcc9ad220386bb814bfae7137189fd17297f2959a744105e1bee006035a"
+
+[[artifacts]]
+version = "16.20.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.20.2/node-v16.20.2-linux-x64.tar.gz"
+checksum = "sha256:c9193e6c414891694759febe846f4f023bf48410a6924a8b1520c46565859665"
+
+[[artifacts]]
+version = "16.20.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.20.1/node-v16.20.1-linux-arm64.tar.gz"
+checksum = "sha256:e67a75da24bd72da5b60568774ee9814bf034959e3768fe6f16eb6cfb3fc4158"
+
+[[artifacts]]
+version = "16.20.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.20.1/node-v16.20.1-linux-x64.tar.gz"
+checksum = "sha256:c76d2aabd2d02542505fd24e18876fb8515e23638531249277272def42ab54e3"
+
+[[artifacts]]
+version = "16.20.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.20.0/node-v16.20.0-linux-arm64.tar.gz"
+checksum = "sha256:58ea2f702936832fcf7d9cf1e9249bb7d9769185f8ad2ece05a70a7f61dbf879"
+
+[[artifacts]]
+version = "16.20.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.20.0/node-v16.20.0-linux-x64.tar.gz"
+checksum = "sha256:7abc0e558fa3b3c4cc0fd3c7fa5dbe61500ba7213f5e87ed560c65a733c6a5c4"
+
+[[artifacts]]
+version = "16.19.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.19.1/node-v16.19.1-linux-arm64.tar.gz"
+checksum = "sha256:d4bfa62f5b1aacf74169e8ff58af812d0ef34ef6152c6ad812f220e9bf6cc462"
+
+[[artifacts]]
+version = "16.19.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.19.1/node-v16.19.1-linux-x64.tar.gz"
+checksum = "sha256:ca63da538e02de15b7e974f7a17ce4732cc0d63023942301d30044c472ed9ddd"
+
+[[artifacts]]
+version = "16.19.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.19.0/node-v16.19.0-linux-arm64.tar.gz"
+checksum = "sha256:1d5e66db4e23a4ab2380dfa7cfebea1f960438db6bd2a7095020acfc64545542"
+
+[[artifacts]]
+version = "16.19.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.19.0/node-v16.19.0-linux-x64.tar.gz"
+checksum = "sha256:23770ba26a52cb8fedd1096613bbc419b8a033d774a457d9024bb5a0159f3585"
+
+[[artifacts]]
+version = "16.18.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.18.1/node-v16.18.1-linux-arm64.tar.gz"
+checksum = "sha256:d6caa1439e8f3fbf4855b5cc1d09ae3eee31fc54ec29b7170603222ba6f8dfe6"
+
+[[artifacts]]
+version = "16.18.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.18.1/node-v16.18.1-linux-x64.tar.gz"
+checksum = "sha256:8949919fc52543efae3bfd057261927c616978614926682ad642915f98fe1981"
+
+[[artifacts]]
+version = "16.18.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.18.0/node-v16.18.0-linux-arm64.tar.gz"
+checksum = "sha256:7d495b6e26d26dd3dba64b567383f843f3d6211810182a22973fb83c32b5920b"
+
+[[artifacts]]
+version = "16.18.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.18.0/node-v16.18.0-linux-x64.tar.gz"
+checksum = "sha256:faca6476cb5b41aa995370fd856d16fcfbbef5c18718a6fa44cc1bae4140849d"
+
+[[artifacts]]
+version = "16.17.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-arm64.tar.gz"
+checksum = "sha256:adc7032888d4e672a4aac886baede8c04fccdd1a2e7ab4bcf325e3f336f44a3d"
+
+[[artifacts]]
+version = "16.17.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-x64.tar.gz"
+checksum = "sha256:da5658693243b3ecf6a4cba6751a71df1eb9e9703ca93b42a9404aed85f58ad0"
+
+[[artifacts]]
+version = "16.17.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.17.0/node-v16.17.0-linux-arm64.tar.gz"
+checksum = "sha256:0e83e93bd3658f4ae516b5f1f174190bd87aaae3d691eb91a8945eed04dc8491"
+
+[[artifacts]]
+version = "16.17.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.17.0/node-v16.17.0-linux-x64.tar.gz"
+checksum = "sha256:4827808e50b8ee42b4dadf056835287dac267b9cff56cea56e70843bf8cecb79"
+
+[[artifacts]]
+version = "16.16.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.16.0/node-v16.16.0-linux-arm64.tar.gz"
+checksum = "sha256:378a3998e7c4dabd0cbd96b05a1b08e834c4b607f09c0745072de9423626fca4"
+
+[[artifacts]]
+version = "16.16.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.16.0/node-v16.16.0-linux-x64.tar.gz"
+checksum = "sha256:c85b16d1a4c259d01be7111ecb0361260627e4fc245004a920521eacb28e50df"
+
+[[artifacts]]
+version = "16.15.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.15.1/node-v16.15.1-linux-arm64.tar.gz"
+checksum = "sha256:84db3f261a02c3d92558fb80a3b597b58175d713b8aa928f6b66e963340f1faf"
+
+[[artifacts]]
+version = "16.15.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.15.1/node-v16.15.1-linux-x64.tar.gz"
+checksum = "sha256:f78a49c0c9c2f546c3a44eb434c49a852125441422a1bcfc433dedc58d6a241c"
+
+[[artifacts]]
+version = "16.15.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.15.0/node-v16.15.0-linux-arm64.tar.gz"
+checksum = "sha256:2aa387e6a57ade663849efdc4fabf7431a38d975db98dcc79293840e6894d28b"
+
+[[artifacts]]
+version = "16.15.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.15.0/node-v16.15.0-linux-x64.tar.gz"
+checksum = "sha256:d1c1de461be10bfd9c70ebae47330fb1b4ab0a98ad730823fb1340e34993edee"
+
+[[artifacts]]
+version = "16.14.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.14.2/node-v16.14.2-linux-arm64.tar.gz"
+checksum = "sha256:8a792a4cb6d83a960f7bd2901225c492e40ace541fbd73ff59ac4a332c3aaafb"
+
+[[artifacts]]
+version = "16.14.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.14.2/node-v16.14.2-linux-x64.tar.gz"
+checksum = "sha256:57e02c27eb5e52f560f72d96240e898cb52818dc9fc50f45478ce39ece38583a"
+
+[[artifacts]]
+version = "16.14.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.14.1/node-v16.14.1-linux-arm64.tar.gz"
+checksum = "sha256:53aeda7118cd1991424b457907790033326f432ee6c2908a7693920124622cf4"
+
+[[artifacts]]
+version = "16.14.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.14.1/node-v16.14.1-linux-x64.tar.gz"
+checksum = "sha256:8db3d6d8ecfc2af932320fb12449de2b5b76f946ac72b47c6a9074afe82737ff"
+
+[[artifacts]]
+version = "16.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.14.0/node-v16.14.0-linux-arm64.tar.gz"
+checksum = "sha256:82d71968c82eb391f463df62ba277563a3bd01ce43bba0e7e1c533991567b8fe"
+
+[[artifacts]]
+version = "16.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.14.0/node-v16.14.0-linux-x64.tar.gz"
+checksum = "sha256:2c69e7b040c208b61ebf9735c63d2e5bcabfed32ef05a9b8dd5823489ea50d6b"
+
+[[artifacts]]
+version = "16.13.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.13.2/node-v16.13.2-linux-arm64.tar.gz"
+checksum = "sha256:e87d7c173d7c70672d71cc816ffe0baea2b0458cb7f96c248560410e9cd37522"
+
+[[artifacts]]
+version = "16.13.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.13.2/node-v16.13.2-linux-x64.tar.gz"
+checksum = "sha256:a0f23911d5d9c371e95ad19e4e538d19bffc0965700f187840eb39a91b0c3fb0"
+
+[[artifacts]]
+version = "16.13.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.13.1/node-v16.13.1-linux-arm64.tar.gz"
+checksum = "sha256:c2f2a0a5adbfc267dbe41ef9fbd83af157a64997bc7546c12717ff55ea6b57d8"
+
+[[artifacts]]
+version = "16.13.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.13.1/node-v16.13.1-linux-x64.tar.gz"
+checksum = "sha256:5f80197d654fd0b749cdeddf1f07a5eac1fcf6b423a00ffc8f2d3bea9c6dc8d1"
+
+[[artifacts]]
+version = "16.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.13.0/node-v16.13.0-linux-arm64.tar.gz"
+checksum = "sha256:46e3857f5552abd36d9548380d795b043a3ceec2504e69fe1a754fa76012daaf"
+
+[[artifacts]]
+version = "16.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.13.0/node-v16.13.0-linux-x64.tar.gz"
+checksum = "sha256:589b7e7eb22f8358797a2c14a0bd865459d0b44458b8f05d2721294dacc7f734"
+
+[[artifacts]]
+version = "16.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.12.0/node-v16.12.0-linux-arm64.tar.gz"
+checksum = "sha256:2abb224a6d9880d459ed64a02876b5843ca891978b072e7516431b15142a472c"
+
+[[artifacts]]
+version = "16.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.12.0/node-v16.12.0-linux-x64.tar.gz"
+checksum = "sha256:1f41d5b68ca39eb2e76dad4e5beb8de8b0a1498773e3e53b80c03e42202969fb"
+
+[[artifacts]]
+version = "16.11.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.11.1/node-v16.11.1-linux-arm64.tar.gz"
+checksum = "sha256:d51b372477287ee41e5bf2d90972868ed28b5c5465bc2df14e86c398926916c1"
+
+[[artifacts]]
+version = "16.11.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.11.1/node-v16.11.1-linux-x64.tar.gz"
+checksum = "sha256:48fba5e9d60e12e777994dafba7b04449c3d0cd004340970fd674220e572a39e"
+
+[[artifacts]]
+version = "16.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.11.0/node-v16.11.0-linux-arm64.tar.gz"
+checksum = "sha256:c923289edd9b251dd37bd6bb53c4fbf0476ae91d55b8703aeb95b0da39642c45"
+
+[[artifacts]]
+version = "16.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.11.0/node-v16.11.0-linux-x64.tar.gz"
+checksum = "sha256:bfc84faaa07864398edbe8bfb9d7d0e64fa20649b8c498cd299e0ff44657d9a3"
+
+[[artifacts]]
+version = "16.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.10.0/node-v16.10.0-linux-arm64.tar.gz"
+checksum = "sha256:2675ca64c50badd609907b2149f7c021cce52248e08f984a4102d4f390794f57"
+
+[[artifacts]]
+version = "16.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.10.0/node-v16.10.0-linux-x64.tar.gz"
+checksum = "sha256:bca7f42ea3e61938cc28868614bb37908111b9ff190fe8022fa9954651b5665d"
+
+[[artifacts]]
+version = "16.9.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.9.1/node-v16.9.1-linux-arm64.tar.gz"
+checksum = "sha256:efad8bf7b7f68addbd47a8268871a10011ff77c31ef33f9d2dadc2ba7939b723"
+
+[[artifacts]]
+version = "16.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.9.1/node-v16.9.1-linux-x64.tar.gz"
+checksum = "sha256:1d48c69e4141792f314d29f081501dc22218cfc22f9992c098f7e3f5e0531139"
+
+[[artifacts]]
+version = "16.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.9.0/node-v16.9.0-linux-arm64.tar.gz"
+checksum = "sha256:a5e838ab842f75a9e20275b13cdb67a8a9a10a6feec9b59097903c1a3e16351a"
+
+[[artifacts]]
+version = "16.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.9.0/node-v16.9.0-linux-x64.tar.gz"
+checksum = "sha256:f7389d3bc9efdf5ce95ff52ea880efcbf2c9de662ef7b143aedf141aeb74ab95"
+
+[[artifacts]]
+version = "16.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.8.0/node-v16.8.0-linux-arm64.tar.gz"
+checksum = "sha256:3f8cbdd3165fb9bf499f0e35bbd2ae4b301f2af5e9f349f82beacdb7278539bb"
+
+[[artifacts]]
+version = "16.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.8.0/node-v16.8.0-linux-x64.tar.gz"
+checksum = "sha256:aa1f366b522a9565332096fdc32ed0cd58a2049c0875d839703d3fe58b4c226d"
+
+[[artifacts]]
+version = "16.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.7.0/node-v16.7.0-linux-arm64.tar.gz"
+checksum = "sha256:8a1b770c81618353ca2f6fd296ccfa7d812e7f40d1e2a2b88579e6d9895ec463"
+
+[[artifacts]]
+version = "16.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.7.0/node-v16.7.0-linux-x64.tar.gz"
+checksum = "sha256:13a15e1934d356c9e8f97fcfff411d7d5236e90ed04d6aeeca5f10f529b58a57"
+
+[[artifacts]]
+version = "16.6.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.6.2/node-v16.6.2-linux-arm64.tar.gz"
+checksum = "sha256:c51a94f28a29c390d20445d9b334a9808d3166bd244ebc03852d23c0b17a93ca"
+
+[[artifacts]]
+version = "16.6.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.6.2/node-v16.6.2-linux-x64.tar.gz"
+checksum = "sha256:913913f62416b96dee5f463b54e1adebaf669dd2ff3b047d6290deadc3003d97"
+
+[[artifacts]]
+version = "16.6.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.6.1/node-v16.6.1-linux-arm64.tar.gz"
+checksum = "sha256:ecab5720035b6bb97564b05df527d49a37489dcba6a244c0f1c7c801bb2755f7"
+
+[[artifacts]]
+version = "16.6.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.6.1/node-v16.6.1-linux-x64.tar.gz"
+checksum = "sha256:e7e4149626ccd0653783ee8aef81eb50fa7ada2f9f7cbc031969b3b1ac3ffa6b"
+
+[[artifacts]]
+version = "16.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.6.0/node-v16.6.0-linux-arm64.tar.gz"
+checksum = "sha256:046a352a4ff2f986a026622dc61c0f9c38cb07099e63b643ca5a5ee12c8ac5bd"
+
+[[artifacts]]
+version = "16.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.6.0/node-v16.6.0-linux-x64.tar.gz"
+checksum = "sha256:4658500d47ab2373b9c5ffb8256bd4e514b6326a6c8a9c6186105fba4de75548"
+
+[[artifacts]]
+version = "16.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.5.0/node-v16.5.0-linux-arm64.tar.gz"
+checksum = "sha256:9447361c2b19d0f59b2f3acdcd9326bd1542c13828f9c8807ed46d3b6024fe09"
+
+[[artifacts]]
+version = "16.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.5.0/node-v16.5.0-linux-x64.tar.gz"
+checksum = "sha256:837d76357d8622aac81a5b7f27ba0fd9556faa311a44254f1ffd26aaf42b052f"
+
+[[artifacts]]
+version = "16.4.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.4.2/node-v16.4.2-linux-arm64.tar.gz"
+checksum = "sha256:5860164738d8d5403effe46b296260a599af1d4de9743555880985b1aeb2b57f"
+
+[[artifacts]]
+version = "16.4.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.4.2/node-v16.4.2-linux-x64.tar.gz"
+checksum = "sha256:710a6955f5f500030f97d0deef6c15ef25533b9a7de66796248229b37ce07704"
+
+[[artifacts]]
+version = "16.4.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.4.1/node-v16.4.1-linux-arm64.tar.gz"
+checksum = "sha256:5d50cb3ce5b5ecccead1d0cf4e18e038c580e10733ff510f73d04a711092569c"
+
+[[artifacts]]
+version = "16.4.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.4.1/node-v16.4.1-linux-x64.tar.gz"
+checksum = "sha256:21181395c11ee1d13c05c4e07b1f4e36ba501d92030ac60a901291c50915b320"
+
+[[artifacts]]
+version = "16.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.4.0/node-v16.4.0-linux-arm64.tar.gz"
+checksum = "sha256:8500c9b61717eeeb6f62ed88723dc4896b1bd0a38d8a0f8f8bfcd99e4879e921"
+
+[[artifacts]]
+version = "16.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.4.0/node-v16.4.0-linux-x64.tar.gz"
+checksum = "sha256:6fb7bc9aece48f2d94941c586ed5d541ac29c8981bc09585fcabe9e4b87d57fa"
+
+[[artifacts]]
+version = "16.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.3.0/node-v16.3.0-linux-arm64.tar.gz"
+checksum = "sha256:7040a1f2a0a1aa9cf0f66ec46d0049c6638cb4c05490c13ca71d298fa94ed8ce"
+
+[[artifacts]]
+version = "16.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.3.0/node-v16.3.0-linux-x64.tar.gz"
+checksum = "sha256:86f6d06c05021ae73b51f57bb56569a2eebd4a2ecc0b881972a0572e465b5d27"
+
+[[artifacts]]
+version = "16.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.2.0/node-v16.2.0-linux-arm64.tar.gz"
+checksum = "sha256:2880b393d5950a1fb934a7e36fcb3434d788ded6669c586c2346708a7f72368b"
+
+[[artifacts]]
+version = "16.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.2.0/node-v16.2.0-linux-x64.tar.gz"
+checksum = "sha256:c3fd89a768e40a2fd8008919100bd283e6e9aec742eddeb1d494eb2a626466dc"
+
+[[artifacts]]
+version = "16.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.1.0/node-v16.1.0-linux-arm64.tar.gz"
+checksum = "sha256:a96f07133c6a45b1287e03d4fab466436fcc6589cd9a84f6081facad02bae6d8"
+
+[[artifacts]]
+version = "16.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.1.0/node-v16.1.0-linux-x64.tar.gz"
+checksum = "sha256:50dadc0c130ff7d079d0fb4a86e40756c76edb3cd3b42b8cf2a57497116695fa"
+
+[[artifacts]]
+version = "16.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v16.0.0/node-v16.0.0-linux-arm64.tar.gz"
+checksum = "sha256:22e7d326b21195c4a0df92a7af7cfdf1743cd46fcc50e335e4086a1c1f2a9a13"
+
+[[artifacts]]
+version = "16.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v16.0.0/node-v16.0.0-linux-x64.tar.gz"
+checksum = "sha256:9268cdb3c71cec4f3dc3bef98994f310c3bef259fae8c68e3f1c605c5dfcbc58"
+
+[[artifacts]]
+version = "15.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.14.0/node-v15.14.0-linux-arm64.tar.gz"
+checksum = "sha256:6d5e0074fe4a45d444bc581aa1fd7ce7081b8491b0f785414a6e5cc30c42854a"
+
+[[artifacts]]
+version = "15.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.14.0/node-v15.14.0-linux-x64.tar.gz"
+checksum = "sha256:23f8adb7afbd9969f0f9b8b2da0ba3e0a9db57c547aa0c5e0885f0b2aae6081c"
+
+[[artifacts]]
+version = "15.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.13.0/node-v15.13.0-linux-arm64.tar.gz"
+checksum = "sha256:23a0277115cb18c994e8225552a9755811b5ebf87efec0997734b7e361dfd70a"
+
+[[artifacts]]
+version = "15.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.13.0/node-v15.13.0-linux-x64.tar.gz"
+checksum = "sha256:1cd6b2f92f826b0176039e9261bee8ae993d6167fbbe89ab2bc79d18e734267c"
+
+[[artifacts]]
+version = "15.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.12.0/node-v15.12.0-linux-arm64.tar.gz"
+checksum = "sha256:cf1e276e381bbe58998feb584f907980ad2c6cd8c88dd4662a089b177b7ab0b2"
+
+[[artifacts]]
+version = "15.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.12.0/node-v15.12.0-linux-x64.tar.gz"
+checksum = "sha256:0fa13e94e07e05b64819f44de92a81f4a95c8d952278e85eba3c7dd11fe63aea"
+
+[[artifacts]]
+version = "15.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.11.0/node-v15.11.0-linux-arm64.tar.gz"
+checksum = "sha256:bac8f957c35df2985ab10098d7ee494de28872ce8382df412ef745895f30f0d8"
+
+[[artifacts]]
+version = "15.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.11.0/node-v15.11.0-linux-x64.tar.gz"
+checksum = "sha256:74df02fbe07f280ffbd20db01cd876db2bfc3463c3620849d5b4c2b4a21216e8"
+
+[[artifacts]]
+version = "15.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.10.0/node-v15.10.0-linux-arm64.tar.gz"
+checksum = "sha256:a9f8c807ec31ed24fe6e0b2d002ce2d1b9f20b7e23a0efe10679331a44b30dba"
+
+[[artifacts]]
+version = "15.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.10.0/node-v15.10.0-linux-x64.tar.gz"
+checksum = "sha256:31554d9b2de47948a364a007031c635d3943c303e50703b5f4c41a5eead07737"
+
+[[artifacts]]
+version = "15.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.9.0/node-v15.9.0-linux-arm64.tar.gz"
+checksum = "sha256:65f3f889e6ac6952a7fa892e5d3ad19759d58771fbf4bc492d5e87117c2072d7"
+
+[[artifacts]]
+version = "15.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.9.0/node-v15.9.0-linux-x64.tar.gz"
+checksum = "sha256:4e0488824dbdea2bd2db91e93aa08e250c655fedb35f06f4ca4373cbb198d428"
+
+[[artifacts]]
+version = "15.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.8.0/node-v15.8.0-linux-arm64.tar.gz"
+checksum = "sha256:086149a16cf7a092f1e12fa2a91bb6587ce25914bd52c3bcff78b5b5c6222e30"
+
+[[artifacts]]
+version = "15.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.8.0/node-v15.8.0-linux-x64.tar.gz"
+checksum = "sha256:c2b073c4421e62aa71f0cef929e61a3334853ab211119f8ea7601612c43cd71d"
+
+[[artifacts]]
+version = "15.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.7.0/node-v15.7.0-linux-arm64.tar.gz"
+checksum = "sha256:72853eb858a93d53b0758b86eea0d466296ab275fbb73f2f4d40fad6cd1a0ff9"
+
+[[artifacts]]
+version = "15.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.7.0/node-v15.7.0-linux-x64.tar.gz"
+checksum = "sha256:8081794dc8a6a1dd46045ce5a921e227407dcf7c17ee9d1ad39e354b37526f5c"
+
+[[artifacts]]
+version = "15.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.6.0/node-v15.6.0-linux-arm64.tar.gz"
+checksum = "sha256:b0660398fe590f8588431a787e9b032c7271a2fa88306c7a26e751571df998e4"
+
+[[artifacts]]
+version = "15.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.6.0/node-v15.6.0-linux-x64.tar.gz"
+checksum = "sha256:a8b42f6f174f857b9369858b63ff136ed5b9072336e6df9f0208eddde13897dc"
+
+[[artifacts]]
+version = "15.5.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.5.1/node-v15.5.1-linux-arm64.tar.gz"
+checksum = "sha256:a2d14db86c6f8a070f227940ea44a3409966f6bed14df0ec6f676fe2e2f601c9"
+
+[[artifacts]]
+version = "15.5.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.5.1/node-v15.5.1-linux-x64.tar.gz"
+checksum = "sha256:8dd81dbd63082b24c9a1f16baf4ce743c0c8dff1e589b634119d6ebfca54457e"
+
+[[artifacts]]
+version = "15.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.5.0/node-v15.5.0-linux-arm64.tar.gz"
+checksum = "sha256:0dd46103a8a6ef1b41642d17fe2b141f1e929f6a605b853a1480a37cb44bde1d"
+
+[[artifacts]]
+version = "15.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.5.0/node-v15.5.0-linux-x64.tar.gz"
+checksum = "sha256:75160c2f307fe4ee623d911b77a7acf249fa9ac46c4e4aa5f8cade6c26161ea0"
+
+[[artifacts]]
+version = "15.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.4.0/node-v15.4.0-linux-arm64.tar.gz"
+checksum = "sha256:0dad2932f7f7e0fc21bca0690d31f065080dbbf448527e982447355ff4bb91bd"
+
+[[artifacts]]
+version = "15.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.4.0/node-v15.4.0-linux-x64.tar.gz"
+checksum = "sha256:96b801f51bf73330c65e6ee4d17c5b223fded16d8020af3b3550a548d271b1e2"
+
+[[artifacts]]
+version = "15.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.3.0/node-v15.3.0-linux-arm64.tar.gz"
+checksum = "sha256:3becebd1e981df27a16bde02b5ead6bd9e6bdc0840477721c6805f9089f6179d"
+
+[[artifacts]]
+version = "15.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.3.0/node-v15.3.0-linux-x64.tar.gz"
+checksum = "sha256:c3f6c64d98e623c783b7de7580365be74d8a2dba87529447ae66061609b5d0ec"
+
+[[artifacts]]
+version = "15.2.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.2.1/node-v15.2.1-linux-arm64.tar.gz"
+checksum = "sha256:1b7c9a5a484e4c1dc3e104d79627e65cd0e39fa84f8115e239355b5bf3b0b16d"
+
+[[artifacts]]
+version = "15.2.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.2.1/node-v15.2.1-linux-x64.tar.gz"
+checksum = "sha256:70802c27ca9f9db9a4acc2a849fb572f4cd971749f9d9a8d36bd4c37a0a64f71"
+
+[[artifacts]]
+version = "15.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.2.0/node-v15.2.0-linux-arm64.tar.gz"
+checksum = "sha256:c8203934787e3e7ab136eff96689d04abedda5e037785a55fdc26a43bbfd867d"
+
+[[artifacts]]
+version = "15.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.2.0/node-v15.2.0-linux-x64.tar.gz"
+checksum = "sha256:c23d26e9f6dce4543be39eff8e97b9871c40773d06b76c42b4b5e4f94d417962"
+
+[[artifacts]]
+version = "15.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.1.0/node-v15.1.0-linux-arm64.tar.gz"
+checksum = "sha256:292a5ed3db3ae2acc7cc88bf965c8fca3c39068e867f473f1e2c355549d653b3"
+
+[[artifacts]]
+version = "15.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.1.0/node-v15.1.0-linux-x64.tar.gz"
+checksum = "sha256:f7f5d9d313462771095fe121c0dbb95b229a6a8119cb75cace433df748438f20"
+
+[[artifacts]]
+version = "15.0.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.0.1/node-v15.0.1-linux-arm64.tar.gz"
+checksum = "sha256:138ea304781fb8f7c830f5800bea61631164b304df99f5a008cc0eeaadbe6548"
+
+[[artifacts]]
+version = "15.0.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.0.1/node-v15.0.1-linux-x64.tar.gz"
+checksum = "sha256:60d1ede0ddddaf2e47addf8cfc6955909b231d02710522341f3bf611344cd79e"
+
+[[artifacts]]
+version = "15.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v15.0.0/node-v15.0.0-linux-arm64.tar.gz"
+checksum = "sha256:2127a2627e3efe839c09d61f99cd99a58a9037dbb668abd21c279c25697522eb"
+
+[[artifacts]]
+version = "15.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v15.0.0/node-v15.0.0-linux-x64.tar.gz"
+checksum = "sha256:405cb1bdde623fe568608a4ed35f876762c65ae4ccbd8ed75de3cf170733fc33"
+
+[[artifacts]]
+version = "14.21.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-arm64.tar.gz"
+checksum = "sha256:044b7ec3fea04cd3815d26901ee37203dcc942688b72ee6eac96f6a1ca3cc63f"
+
+[[artifacts]]
+version = "14.21.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-x64.tar.gz"
+checksum = "sha256:bef2685d9469058c1229cc7789e171861044fe3f70316ec744e9bf3609cd45ed"
+
+[[artifacts]]
+version = "14.21.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.21.2/node-v14.21.2-linux-arm64.tar.gz"
+checksum = "sha256:bb7ac11ee8ff3a06773028d53443769c4b0c0f0e85ece68921645882b181cf80"
+
+[[artifacts]]
+version = "14.21.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.21.2/node-v14.21.2-linux-x64.tar.gz"
+checksum = "sha256:951d64432d1c7e026a585d1c6ec8822a268faa3c9b71e1b8d36dc812c51b661e"
+
+[[artifacts]]
+version = "14.21.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.21.1/node-v14.21.1-linux-arm64.tar.gz"
+checksum = "sha256:f3e6fb4a833c084863e7dfa3a50ac29f53b421ad070748ff9c9a81291284faf8"
+
+[[artifacts]]
+version = "14.21.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.21.1/node-v14.21.1-linux-x64.tar.gz"
+checksum = "sha256:8ae854dac7fa5e7dfd5dae8fe8e001c0599821705f650b32c4819149cfda1d0e"
+
+[[artifacts]]
+version = "14.21.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.21.0/node-v14.21.0-linux-arm64.tar.gz"
+checksum = "sha256:a06df30ae4393296872f2a80e73f2eea0634c3490edccb2d80bdee5f1449e96f"
+
+[[artifacts]]
+version = "14.21.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.21.0/node-v14.21.0-linux-x64.tar.gz"
+checksum = "sha256:ac808106e79f90bbb0ceb44c5c9c57306117f21d962f0ca54a58993266c514dc"
+
+[[artifacts]]
+version = "14.20.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.20.1/node-v14.20.1-linux-arm64.tar.gz"
+checksum = "sha256:05fe791367dbce8d76be7e18bac0c9b88a0ed6ab721c31321b96a2dbc31355ce"
+
+[[artifacts]]
+version = "14.20.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.20.1/node-v14.20.1-linux-x64.tar.gz"
+checksum = "sha256:0aab09a55c11fbd1e6c40356809a86eaaf3330fc96e26f9443f82d46d8f8da5f"
+
+[[artifacts]]
+version = "14.20.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.20.0/node-v14.20.0-linux-arm64.tar.gz"
+checksum = "sha256:d2d15363a2f3a0446983d51a90af7942fe8b1dd4a7f16128dfe718b3bf56dc07"
+
+[[artifacts]]
+version = "14.20.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.20.0/node-v14.20.0-linux-x64.tar.gz"
+checksum = "sha256:921680e244b813d6ffe06a4c22f87f05f39be635973c79486b2ded12a946cb37"
+
+[[artifacts]]
+version = "14.19.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.19.3/node-v14.19.3-linux-arm64.tar.gz"
+checksum = "sha256:a1c837c7ec8a5ab0c4d5028695b05749adf216851fe0b84ef09a9c6eab86ba5d"
+
+[[artifacts]]
+version = "14.19.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.19.3/node-v14.19.3-linux-x64.tar.gz"
+checksum = "sha256:cc9d17834eb383565a3368f4222b825f341190813537c677973fc913dcc7bdd1"
+
+[[artifacts]]
+version = "14.19.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.19.2/node-v14.19.2-linux-arm64.tar.gz"
+checksum = "sha256:b972847ccd8a699b72f8ac455d4233fa584972e2ebd3dd99768ff5c95334304d"
+
+[[artifacts]]
+version = "14.19.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.19.2/node-v14.19.2-linux-x64.tar.gz"
+checksum = "sha256:fd72086a1849a428c99d94ef1aca94686c9080792e1586a75ca031a030424544"
+
+[[artifacts]]
+version = "14.19.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.19.1/node-v14.19.1-linux-arm64.tar.gz"
+checksum = "sha256:b365659aa9f31c984668ac60b70fcfae90ffabb3dd51b031898b050e403c1794"
+
+[[artifacts]]
+version = "14.19.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.19.1/node-v14.19.1-linux-x64.tar.gz"
+checksum = "sha256:3019e0508145c4c1fc6662f0b9b1c78bb84181aeea4749fac38ca51587aaf82f"
+
+[[artifacts]]
+version = "14.19.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.19.0/node-v14.19.0-linux-arm64.tar.gz"
+checksum = "sha256:89c03d1c156c0161c891924d4a309df3308bbf245641413d72affae9b62e97e0"
+
+[[artifacts]]
+version = "14.19.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.19.0/node-v14.19.0-linux-x64.tar.gz"
+checksum = "sha256:223ca31e3440b79a3fe6828161b1843743eaa7610a88c0e1ac1d8e1d815b44cd"
+
+[[artifacts]]
+version = "14.18.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.18.3/node-v14.18.3-linux-arm64.tar.gz"
+checksum = "sha256:2d071ca1bc1d0ea1eb259e79b81ebb4387237b2f77b3cf616806534e0030eaa8"
+
+[[artifacts]]
+version = "14.18.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.18.3/node-v14.18.3-linux-x64.tar.gz"
+checksum = "sha256:bd96f88e054801d1368787f7eaf77b49cd052b9543c56bd6bc0bfc90310e2756"
+
+[[artifacts]]
+version = "14.18.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.18.2/node-v14.18.2-linux-arm64.tar.gz"
+checksum = "sha256:e78e18e01a08b2459d738fc5fec6bd79f2b3dccf85e5122cd646b3385964bc1e"
+
+[[artifacts]]
+version = "14.18.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.18.2/node-v14.18.2-linux-x64.tar.gz"
+checksum = "sha256:83fa18a0e3642235446b66653eb27c169224ae9c1a15a32d6c3d9ddefb154ed4"
+
+[[artifacts]]
+version = "14.18.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.18.1/node-v14.18.1-linux-arm64.tar.gz"
+checksum = "sha256:3fcd1c6c008c2dfddea60ede3c735696982fb038288e45c2d35ef6b2098c8220"
+
+[[artifacts]]
+version = "14.18.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.18.1/node-v14.18.1-linux-x64.tar.gz"
+checksum = "sha256:088498c67bab31871a1cab40dbc9b7b82c1abf53a2cf740e061bd6033a74839d"
+
+[[artifacts]]
+version = "14.18.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.18.0/node-v14.18.0-linux-arm64.tar.gz"
+checksum = "sha256:6261a87bf25d08e7b39017a1486b04c65be3ea0ea8442c090e1e4ec4d4cc6ebd"
+
+[[artifacts]]
+version = "14.18.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.18.0/node-v14.18.0-linux-x64.tar.gz"
+checksum = "sha256:f411b8aee36d6dc6a5435906f42bd4ea59d6f678894cf562beaf115b58a318ee"
+
+[[artifacts]]
+version = "14.17.6"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.17.6/node-v14.17.6-linux-arm64.tar.gz"
+checksum = "sha256:3355eae15582be48f6be0910e279abbf2324f4538d3ccb2da7e66edab6e6b0fe"
+
+[[artifacts]]
+version = "14.17.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.17.6/node-v14.17.6-linux-x64.tar.gz"
+checksum = "sha256:19e376214450e93e58687198070b4ab46e42357032ec65f23a7e35b0e86ad6e2"
+
+[[artifacts]]
+version = "14.17.5"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.17.5/node-v14.17.5-linux-arm64.tar.gz"
+checksum = "sha256:bee6d7fb5dbdd2931e688b33defd449afdfd9cd6e716975864406cda18daca66"
+
+[[artifacts]]
+version = "14.17.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.17.5/node-v14.17.5-linux-x64.tar.gz"
+checksum = "sha256:dc04c7e60235ff73536ba0d9e50638090f60cacabfd83184082dce3b330afc6e"
+
+[[artifacts]]
+version = "14.17.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.17.4/node-v14.17.4-linux-arm64.tar.gz"
+checksum = "sha256:88b130c8f08a2baafb4e4c953ad46ba69cc60210da7d95c558c7ae3456beb825"
+
+[[artifacts]]
+version = "14.17.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.17.4/node-v14.17.4-linux-x64.tar.gz"
+checksum = "sha256:99cc7115a30fe62abf06145d57b314092c9bf27499da85413a12f50140199619"
+
+[[artifacts]]
+version = "14.17.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.17.3/node-v14.17.3-linux-arm64.tar.gz"
+checksum = "sha256:784ede0c9faa4a71d77659918052cca39981138edde2c799ffdf2b4695c08544"
+
+[[artifacts]]
+version = "14.17.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.17.3/node-v14.17.3-linux-x64.tar.gz"
+checksum = "sha256:7ef1f7dae52a3ec99cda9cf29e655bc6e61c2c48e496532d83d9f17ea108d5d8"
+
+[[artifacts]]
+version = "14.17.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.17.2/node-v14.17.2-linux-arm64.tar.gz"
+checksum = "sha256:05117e74f424fd4ab744c3013c77906c5fe4a19fa22ce624a21986ce152fd258"
+
+[[artifacts]]
+version = "14.17.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.17.2/node-v14.17.2-linux-x64.tar.gz"
+checksum = "sha256:48cc87b7adb13f479643166a16514861556d0936761b317a3b65f4fbbb265b4d"
+
+[[artifacts]]
+version = "14.17.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.17.1/node-v14.17.1-linux-arm64.tar.gz"
+checksum = "sha256:04e25f5511408288913dd1955f6829431e5096911aa3e35c9cd0ca8b39e6c4c5"
+
+[[artifacts]]
+version = "14.17.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.17.1/node-v14.17.1-linux-x64.tar.gz"
+checksum = "sha256:4781b162129b19bdb3a7010cab12d06fc7c89421ea3fda03346ed17f09ceacd6"
+
+[[artifacts]]
+version = "14.17.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.17.0/node-v14.17.0-linux-arm64.tar.gz"
+checksum = "sha256:9d5948d4397815ce7a746618338f79ce5e7e91efec9c165140ba62fd6c17c07a"
+
+[[artifacts]]
+version = "14.17.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.17.0/node-v14.17.0-linux-x64.tar.gz"
+checksum = "sha256:3d06eabc73ec8626337bff370474306eac1c3c21122f677720d154c556ceafaf"
+
+[[artifacts]]
+version = "14.16.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.16.1/node-v14.16.1-linux-arm64.tar.gz"
+checksum = "sha256:58cb307666ed4aa751757577a563b8a1e5d4ee73a9fac2b495e5c463682a07d1"
+
+[[artifacts]]
+version = "14.16.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.16.1/node-v14.16.1-linux-x64.tar.gz"
+checksum = "sha256:068400cb9f53d195444b9260fd106f7be83af62bb187932656b68166a2f87f44"
+
+[[artifacts]]
+version = "14.16.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.16.0/node-v14.16.0-linux-arm64.tar.gz"
+checksum = "sha256:2b78771550f8a3e6e990d8e60e9ade82c7a9e2738b6222e92198bcd5ea857ea6"
+
+[[artifacts]]
+version = "14.16.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.16.0/node-v14.16.0-linux-x64.tar.gz"
+checksum = "sha256:7212031d7468718d7c8f5e1766380daaabe09d54611675338e7a88a97c3e31b6"
+
+[[artifacts]]
+version = "14.15.5"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.15.5/node-v14.15.5-linux-arm64.tar.gz"
+checksum = "sha256:a1fb6f28041198971fd95e58638c30565de4ee74bd13db7f30ffd1d1c6820599"
+
+[[artifacts]]
+version = "14.15.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.15.5/node-v14.15.5-linux-x64.tar.gz"
+checksum = "sha256:e30c1fd4807fba052c209d7577bb6b63b5096d67c1b9ac753b9d502fda43ded9"
+
+[[artifacts]]
+version = "14.15.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.15.4/node-v14.15.4-linux-arm64.tar.gz"
+checksum = "sha256:b681bda8eaa1ed2ac85e0ed2c2041a0408963c2198a24da183dc3ab60d93d975"
+
+[[artifacts]]
+version = "14.15.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.15.4/node-v14.15.4-linux-x64.tar.gz"
+checksum = "sha256:b51c033d40246cd26e52978125a3687df5cd02ee532e8614feff0ba6c13a774f"
+
+[[artifacts]]
+version = "14.15.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.15.3/node-v14.15.3-linux-arm64.tar.gz"
+checksum = "sha256:4e874aa41448bd3b38f5c7d82e94d3fe77e57382f414bda60d597abfd3b6704b"
+
+[[artifacts]]
+version = "14.15.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.15.3/node-v14.15.3-linux-x64.tar.gz"
+checksum = "sha256:439490022fed1ef0945240210c3a84725adcd24ff238325199118323462cb43d"
+
+[[artifacts]]
+version = "14.15.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.15.2/node-v14.15.2-linux-arm64.tar.gz"
+checksum = "sha256:77277dc58534fa86f56591d952e914e04156ff00e95f31b4a2a34205f7222fa8"
+
+[[artifacts]]
+version = "14.15.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.15.2/node-v14.15.2-linux-x64.tar.gz"
+checksum = "sha256:c1d1d550fa9fa50af926da9e161a9e138f5dbd821479e29cb19a9cac25333369"
+
+[[artifacts]]
+version = "14.15.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.15.1/node-v14.15.1-linux-arm64.tar.gz"
+checksum = "sha256:5ac1aafdb1e6a3c9ae5045b5fb33ae100688cb0dd3259de5b7db25bd7d7edc55"
+
+[[artifacts]]
+version = "14.15.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.15.1/node-v14.15.1-linux-x64.tar.gz"
+checksum = "sha256:fb23a14c54d7d9ba2ce233262c740f2c04b08e451d1e770ae98b17d01de82b0b"
+
+[[artifacts]]
+version = "14.15.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.15.0/node-v14.15.0-linux-arm64.tar.gz"
+checksum = "sha256:bfb59eb99ab60a673f389e8b172ab288e12c8540e0c76a0ae40d189ba5a36cec"
+
+[[artifacts]]
+version = "14.15.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.15.0/node-v14.15.0-linux-x64.tar.gz"
+checksum = "sha256:085c3b3c262fa58cbaad4f2f62eb6cea943fbbf3492ba457b5efa8f27969e04a"
+
+[[artifacts]]
+version = "14.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.14.0/node-v14.14.0-linux-arm64.tar.gz"
+checksum = "sha256:de15496b7a311b5819470cc6df5397095b4e154a3479c6ed41075f0de96ec8a1"
+
+[[artifacts]]
+version = "14.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.14.0/node-v14.14.0-linux-x64.tar.gz"
+checksum = "sha256:438cc26853b17f4aad79fb441f6dbcc1128aff9ffcd0c132ae044259f96ff6a8"
+
+[[artifacts]]
+version = "14.13.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.13.1/node-v14.13.1-linux-arm64.tar.gz"
+checksum = "sha256:5ee6da3c86591763644f40babd2bef5a2476e98ddd6f7f1c5121fc2c81d1d613"
+
+[[artifacts]]
+version = "14.13.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.13.1/node-v14.13.1-linux-x64.tar.gz"
+checksum = "sha256:872b8cf72b94109276c61182f7366c8ffdfb58986428c0f57af38cf10a5194a4"
+
+[[artifacts]]
+version = "14.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.13.0/node-v14.13.0-linux-arm64.tar.gz"
+checksum = "sha256:a9a98ef518c9e75d0a33d8f344f76b037b54e4ad8f8051fbf1506dbfccfb3f25"
+
+[[artifacts]]
+version = "14.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.13.0/node-v14.13.0-linux-x64.tar.gz"
+checksum = "sha256:f7b4001e7172a2af32743607b457844adafcdeff555685876ddabaad43b5d71a"
+
+[[artifacts]]
+version = "14.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.12.0/node-v14.12.0-linux-arm64.tar.gz"
+checksum = "sha256:bd4feec12f8a4847a9f863f8819a74c30cddcd532a358a81b5bff0fb9e453275"
+
+[[artifacts]]
+version = "14.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.12.0/node-v14.12.0-linux-x64.tar.gz"
+checksum = "sha256:f430bf1d8352c18d628771e7c5f932dbc1e48cec1c8b6417a7bdc4027518f5ed"
+
+[[artifacts]]
+version = "14.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.11.0/node-v14.11.0-linux-arm64.tar.gz"
+checksum = "sha256:52b67943f63c03a15122ecfb94e7f197be06c6c8992bdd5d77c79960411a31fd"
+
+[[artifacts]]
+version = "14.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.11.0/node-v14.11.0-linux-x64.tar.gz"
+checksum = "sha256:b2e7ac8741ac5eb95b0d074568b3f2691a3913488a9f96b7b7957e22f424a5a1"
+
+[[artifacts]]
+version = "14.10.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.10.1/node-v14.10.1-linux-arm64.tar.gz"
+checksum = "sha256:a4d6562d9b4efe577b31381a78595e0417badc0ec44268a159d2bfdae4d8e529"
+
+[[artifacts]]
+version = "14.10.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.10.1/node-v14.10.1-linux-x64.tar.gz"
+checksum = "sha256:fed6ea3b400a2d1f4da69bae2a0bdfd15393e61c07d313799a342be4fa9c0188"
+
+[[artifacts]]
+version = "14.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.10.0/node-v14.10.0-linux-arm64.tar.gz"
+checksum = "sha256:842811feed3177bef73b16b24e2b2d2b27f6223ea65da6a397d86b670fd35766"
+
+[[artifacts]]
+version = "14.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.10.0/node-v14.10.0-linux-x64.tar.gz"
+checksum = "sha256:4a91b15ae7e8bdb7594211ef0e6a4733f06e97fe9a54711805321b21142f02fc"
+
+[[artifacts]]
+version = "14.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.9.0/node-v14.9.0-linux-arm64.tar.gz"
+checksum = "sha256:6619a69ffe95c602105484bdecbdccb319e1c0db861203bffb9b6aedfae2c2df"
+
+[[artifacts]]
+version = "14.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.9.0/node-v14.9.0-linux-x64.tar.gz"
+checksum = "sha256:78b9e06c40a34ae1b7e0540bc3667459ed6439bbc4deff0bbe13f32817e8ac9c"
+
+[[artifacts]]
+version = "14.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.8.0/node-v14.8.0-linux-arm64.tar.gz"
+checksum = "sha256:ab2e44354f7032a9b3f2e02d078596afb6d9822df8a1e672634d66126d17df7a"
+
+[[artifacts]]
+version = "14.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.8.0/node-v14.8.0-linux-x64.tar.gz"
+checksum = "sha256:4bc595057f51ce04fdb25a5ef0cee2b7a567e7380806c281294727a4d9bfcfb0"
+
+[[artifacts]]
+version = "14.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.7.0/node-v14.7.0-linux-arm64.tar.gz"
+checksum = "sha256:64bb4171ad823fafef3d36eea416e8a5ebefa60ce7043eb52a3ece1060b1a115"
+
+[[artifacts]]
+version = "14.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.7.0/node-v14.7.0-linux-x64.tar.gz"
+checksum = "sha256:9c40796c5d1bbbbc27c80b692473a254933fe0b19697d007728b6cf397a2b306"
+
+[[artifacts]]
+version = "14.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.6.0/node-v14.6.0-linux-arm64.tar.gz"
+checksum = "sha256:eb4f98efe22057a831415c2367416330878f0e1ad9a9bb5c25a6631031588075"
+
+[[artifacts]]
+version = "14.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.6.0/node-v14.6.0-linux-x64.tar.gz"
+checksum = "sha256:5e2c59200c86c37a0c800fe2cd2cfabc459f8a3ae3f83c3611483c485ad32e4f"
+
+[[artifacts]]
+version = "14.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.5.0/node-v14.5.0-linux-arm64.tar.gz"
+checksum = "sha256:1429266d4f22148dfd6060fb5964c167852ae9b8f4efab47ff6a7656ed94fee5"
+
+[[artifacts]]
+version = "14.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.5.0/node-v14.5.0-linux-x64.tar.gz"
+checksum = "sha256:d5a05bbf5ef7f49752eca0d4fc946834dfda86088627248856795a61c81df1a2"
+
+[[artifacts]]
+version = "14.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.4.0/node-v14.4.0-linux-arm64.tar.gz"
+checksum = "sha256:5c7d88985ea82ca8ed3453b5bdf36391cf6f8fe63aabfb7661a6040c43769f89"
+
+[[artifacts]]
+version = "14.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.4.0/node-v14.4.0-linux-x64.tar.gz"
+checksum = "sha256:8e219f15f496d975910c3964d7ccb7b88d4dc68992b52a18396e05280b1cd642"
+
+[[artifacts]]
+version = "14.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.3.0/node-v14.3.0-linux-arm64.tar.gz"
+checksum = "sha256:b6541c22d25880cf0ec03a41838d763e50a7632761b9e7c49bd1809944eba3dd"
+
+[[artifacts]]
+version = "14.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.3.0/node-v14.3.0-linux-x64.tar.gz"
+checksum = "sha256:ea08acdf403d13ab67303d503eab080a5285c005c75c0710551d928f3cc74057"
+
+[[artifacts]]
+version = "14.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.2.0/node-v14.2.0-linux-arm64.tar.gz"
+checksum = "sha256:2fd9bf7b3fc8a0e72ec27f1d274b8eedd1c81e8af3f82739c787ddc288037a4c"
+
+[[artifacts]]
+version = "14.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.2.0/node-v14.2.0-linux-x64.tar.gz"
+checksum = "sha256:3307d8b95014e78b43f85242a03fe3b28edfb90cc15e1d26393dcbbc51d05c8e"
+
+[[artifacts]]
+version = "14.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.1.0/node-v14.1.0-linux-arm64.tar.gz"
+checksum = "sha256:5f6462c004460673618033efe319c060a9c53b55715cb9aefb7fc5f733aa9d5c"
+
+[[artifacts]]
+version = "14.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.1.0/node-v14.1.0-linux-x64.tar.gz"
+checksum = "sha256:0edca22822d86a1626707e19a5b2e17f1dbf4f3ac553ac3368aab3bb24de68bf"
+
+[[artifacts]]
+version = "14.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v14.0.0/node-v14.0.0-linux-arm64.tar.gz"
+checksum = "sha256:4da6fd45e7a26037c82f931f173695547f774b780986d545efc266a5a9b80906"
+
+[[artifacts]]
+version = "14.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v14.0.0/node-v14.0.0-linux-x64.tar.gz"
+checksum = "sha256:0c3224a9e946e46793e81bced623bb7c0c06538aebea6383ca318a62ac1f49fd"
+
+[[artifacts]]
+version = "13.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.14.0/node-v13.14.0-linux-arm64.tar.gz"
+checksum = "sha256:4603cc724f3f0551407f1ea41b8fbae83492e80c02d16360cb9722500364f447"
+
+[[artifacts]]
+version = "13.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.14.0/node-v13.14.0-linux-x64.tar.gz"
+checksum = "sha256:230717f6e14f4acbb0846d58c224be6acb8da59b0db1de52c77d2bf90315cfaa"
+
+[[artifacts]]
+version = "13.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.13.0/node-v13.13.0-linux-arm64.tar.gz"
+checksum = "sha256:fd1a25910a77084ecd2f092f74a0bfb68526f219fbd07cec64beaf29c91619a1"
+
+[[artifacts]]
+version = "13.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.13.0/node-v13.13.0-linux-x64.tar.gz"
+checksum = "sha256:8272d2825b68be55ac48e6270ab9179a126306c914a6dfdf1f175d04e006131e"
+
+[[artifacts]]
+version = "13.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.12.0/node-v13.12.0-linux-arm64.tar.gz"
+checksum = "sha256:9c28226e84bd44f7309ffdd4deb022fb59479ef0386e82890cd19b02162940f3"
+
+[[artifacts]]
+version = "13.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.12.0/node-v13.12.0-linux-x64.tar.gz"
+checksum = "sha256:3e66b14bbeb9ea1ba129fae7c65374844f4ddaf1e48e2bc19b3b2570e158e362"
+
+[[artifacts]]
+version = "13.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.11.0/node-v13.11.0-linux-arm64.tar.gz"
+checksum = "sha256:c20c89664b5f06559f0aa2f0ad334d6d8157599b01101719e455b2b500a13c1a"
+
+[[artifacts]]
+version = "13.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.11.0/node-v13.11.0-linux-x64.tar.gz"
+checksum = "sha256:db9592a3e54c34fcf2252e6cf49780dda93cc175d7a27654a8971e1eb5f1f989"
+
+[[artifacts]]
+version = "13.10.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.10.1/node-v13.10.1-linux-arm64.tar.gz"
+checksum = "sha256:2106cf90ddbe47957b7782caed787cf4927656087d28ec7eb11f0d44c49234e9"
+
+[[artifacts]]
+version = "13.10.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.10.1/node-v13.10.1-linux-x64.tar.gz"
+checksum = "sha256:985cc834f3d95c0dc99ac6d7fa6ec7fd7aca74ec71ccc706650f59aec37b6384"
+
+[[artifacts]]
+version = "13.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.10.0/node-v13.10.0-linux-arm64.tar.gz"
+checksum = "sha256:48b18003d75abb10acee432a9bfa2de8bc8e2ec4c8a3cf08a69ff7f9c2afc1ea"
+
+[[artifacts]]
+version = "13.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.10.0/node-v13.10.0-linux-x64.tar.gz"
+checksum = "sha256:83cb0b1060830fd18b702462ccb6935d5346b33bfc1cad5fc59cb52686374e3a"
+
+[[artifacts]]
+version = "13.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.9.0/node-v13.9.0-linux-arm64.tar.gz"
+checksum = "sha256:8d253978fec837a6cd9d2ba9665bda14d62e7453d44123438971d0026df469dd"
+
+[[artifacts]]
+version = "13.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.9.0/node-v13.9.0-linux-x64.tar.gz"
+checksum = "sha256:5cd26d58edabb7b636c3f1c6e62ea074849bd0f077f870066aaac485572cacef"
+
+[[artifacts]]
+version = "13.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.8.0/node-v13.8.0-linux-arm64.tar.gz"
+checksum = "sha256:69a51fa98a9543f09f2a3838a04b49fd774005398de9732caf337e027145c988"
+
+[[artifacts]]
+version = "13.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.8.0/node-v13.8.0-linux-x64.tar.gz"
+checksum = "sha256:bf30432175ea8a95fa3e5fe09e96d9fc17b07099742d5c83c4cf9d0edfc411ff"
+
+[[artifacts]]
+version = "13.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.7.0/node-v13.7.0-linux-arm64.tar.gz"
+checksum = "sha256:fb492b493e13ddad73533f5b06318b7f46120ff4289475e0e91445370be1b13c"
+
+[[artifacts]]
+version = "13.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.7.0/node-v13.7.0-linux-x64.tar.gz"
+checksum = "sha256:49ecb710e29c3ea0617803f450e2dc9b229688f1576190826ffdd5a9eaae7869"
+
+[[artifacts]]
+version = "13.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.6.0/node-v13.6.0-linux-arm64.tar.gz"
+checksum = "sha256:65c648bdcb0efa5d2be4a660903a535a1ffb959079276152d076d89906242d87"
+
+[[artifacts]]
+version = "13.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.6.0/node-v13.6.0-linux-x64.tar.gz"
+checksum = "sha256:89ab4fe0db3309592924194133901b7340607d77cb5f12592325746fcdba1568"
+
+[[artifacts]]
+version = "13.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.5.0/node-v13.5.0-linux-arm64.tar.gz"
+checksum = "sha256:77713ce2b7f78ac96887d338e593eda27c739e95de7e896333198da8909edf40"
+
+[[artifacts]]
+version = "13.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.5.0/node-v13.5.0-linux-x64.tar.gz"
+checksum = "sha256:796bbcad96fbeb9f4731fef1e8788ce4f9c5507288d0a502aaeffd0d056e7c1d"
+
+[[artifacts]]
+version = "13.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.4.0/node-v13.4.0-linux-arm64.tar.gz"
+checksum = "sha256:bd0c4511126bafeadf46079c3bd3c9e143859a509d3d5e0ac119342391ff93ae"
+
+[[artifacts]]
+version = "13.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.4.0/node-v13.4.0-linux-x64.tar.gz"
+checksum = "sha256:63411f61d4156b1f3ee6f088b855a1cebea3ab32a0cabc28419f8b6cc3ffa161"
+
+[[artifacts]]
+version = "13.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.3.0/node-v13.3.0-linux-arm64.tar.gz"
+checksum = "sha256:7df90bda5d21337c7793b481ee71fd89811c26cd0d6124665a79cd8bffb2f7ba"
+
+[[artifacts]]
+version = "13.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.3.0/node-v13.3.0-linux-x64.tar.gz"
+checksum = "sha256:155b0510732d2f48150dc6bc4b25eb44ce5cd54d21c70d2ca7f31be3b9ab7fa6"
+
+[[artifacts]]
+version = "13.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.2.0/node-v13.2.0-linux-arm64.tar.gz"
+checksum = "sha256:b1634a1c9eb8735b25ad21bce3ab5a86d7471982fe2523eeeaf9d831f807864b"
+
+[[artifacts]]
+version = "13.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.2.0/node-v13.2.0-linux-x64.tar.gz"
+checksum = "sha256:dcf3954ecf6a34d65cab277d3565c654996b1d3e6d07cbbd98939cee0792c668"
+
+[[artifacts]]
+version = "13.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.1.0/node-v13.1.0-linux-arm64.tar.gz"
+checksum = "sha256:dd36c7846f7713b6e55baf0b6ab7882c18b129d83a3d0f7ef62790d181461d22"
+
+[[artifacts]]
+version = "13.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.1.0/node-v13.1.0-linux-x64.tar.gz"
+checksum = "sha256:490e998198e152450e79bb65178813ce0c81708954697f91cfd82537acfcb588"
+
+[[artifacts]]
+version = "13.0.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.0.1/node-v13.0.1-linux-arm64.tar.gz"
+checksum = "sha256:437dc656d94e295d9200425b0d0dd000eed67fbc090334a5da51c77a8895b136"
+
+[[artifacts]]
+version = "13.0.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.0.1/node-v13.0.1-linux-x64.tar.gz"
+checksum = "sha256:7476f43e45a896c95c5995c6f904aa5fb5d7347a25eaa95ce80043892b3926a4"
+
+[[artifacts]]
+version = "13.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v13.0.0/node-v13.0.0-linux-arm64.tar.gz"
+checksum = "sha256:18e28a5ed3a474e8d0619c5b17c14b88c72a55630e637d4547485d88863dc1a9"
+
+[[artifacts]]
+version = "13.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v13.0.0/node-v13.0.0-linux-x64.tar.gz"
+checksum = "sha256:807a617fa1363d5bac9775afda0610a0e55d2e78b976e3c97d3e25a94de27dfd"
+
+[[artifacts]]
+version = "12.22.12"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.12/node-v12.22.12-linux-arm64.tar.gz"
+checksum = "sha256:91aefa690914b7f24250f3c0b560b42c6d306315d40009c96b5a6940115895fe"
+
+[[artifacts]]
+version = "12.22.12"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.12/node-v12.22.12-linux-x64.tar.gz"
+checksum = "sha256:ff92a45c4d03e8e270bec1ab337b8fff6e9de293dabfe7e8936a41f2fb0b202e"
+
+[[artifacts]]
+version = "12.22.11"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.11/node-v12.22.11-linux-arm64.tar.gz"
+checksum = "sha256:6efd2770a6d73ef631d1b7a8aecf50361c5cf1858080dbc29e56c8ddf0a981af"
+
+[[artifacts]]
+version = "12.22.11"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.11/node-v12.22.11-linux-x64.tar.gz"
+checksum = "sha256:d98da55241ad2a1359e4785e24be0788a331782f5d14a2ba40284eb2153bbb7f"
+
+[[artifacts]]
+version = "12.22.10"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.10/node-v12.22.10-linux-arm64.tar.gz"
+checksum = "sha256:1c2e82099a7b1e2c43327f2e5d2ced22b69738870272a2cbc8c92dea4299980a"
+
+[[artifacts]]
+version = "12.22.10"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.10/node-v12.22.10-linux-x64.tar.gz"
+checksum = "sha256:a8c284754fa7f21bfbd6d15bf94df83285bf009fd0f3e33227d768fd1f6d6593"
+
+[[artifacts]]
+version = "12.22.9"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.9/node-v12.22.9-linux-arm64.tar.gz"
+checksum = "sha256:307aa26c68600e2f73d699e58a15c59ea06928e4a348cd5a216278d9f2ee0d6c"
+
+[[artifacts]]
+version = "12.22.9"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.9/node-v12.22.9-linux-x64.tar.gz"
+checksum = "sha256:860c481f0e7963cbe5afa669d9e5deefa773fb67da571823945ac79a3ea76d3c"
+
+[[artifacts]]
+version = "12.22.8"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.8/node-v12.22.8-linux-arm64.tar.gz"
+checksum = "sha256:64b9d84cf202ce73f5a87d3dbbc56791f65ec31f3f77c7210713eeffb58d5dd5"
+
+[[artifacts]]
+version = "12.22.8"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.8/node-v12.22.8-linux-x64.tar.gz"
+checksum = "sha256:d3dbcdb0141ebdb923eec3245962ebaf2245052c9f2987195d8ac118f5abdd1c"
+
+[[artifacts]]
+version = "12.22.7"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.7/node-v12.22.7-linux-arm64.tar.gz"
+checksum = "sha256:76fa99531cc57982e9a469babb03a7bd1c47d9392cb6d4b0d55f55858c4ed5a0"
+
+[[artifacts]]
+version = "12.22.7"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.7/node-v12.22.7-linux-x64.tar.gz"
+checksum = "sha256:0c650e494a0ce293fb1220cc81ab5b6b819c249439c392b5ee2e8b812eec5592"
+
+[[artifacts]]
+version = "12.22.6"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.6/node-v12.22.6-linux-arm64.tar.gz"
+checksum = "sha256:f65bf376b6b074b78240ea84d0ab7ca6cacb34c1c066b6653d76045a38565bc2"
+
+[[artifacts]]
+version = "12.22.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.6/node-v12.22.6-linux-x64.tar.gz"
+checksum = "sha256:6e5ce9cc7dcd31b182730cd662b1813c201fa98089e1013db4abd141716852dc"
+
+[[artifacts]]
+version = "12.22.5"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.5/node-v12.22.5-linux-arm64.tar.gz"
+checksum = "sha256:bfb436a87142e9dc73ed675c81c267490e575f9abfbbc7fa5db227a2ab6b555c"
+
+[[artifacts]]
+version = "12.22.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.5/node-v12.22.5-linux-x64.tar.gz"
+checksum = "sha256:89eaf038c41439dcbc543d1783adc0e9f38ddf07c993c08e111d55fe35dadc21"
+
+[[artifacts]]
+version = "12.22.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.4/node-v12.22.4-linux-arm64.tar.gz"
+checksum = "sha256:c104dff52409d27836f7c4529c7f3cce6c76a521b8b834e338bcbf6eed4abc18"
+
+[[artifacts]]
+version = "12.22.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.4/node-v12.22.4-linux-x64.tar.gz"
+checksum = "sha256:2dde8a22ad15b8e270fee42ab40de71aed7bd97c10e7d04cd826430400fff601"
+
+[[artifacts]]
+version = "12.22.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.3/node-v12.22.3-linux-arm64.tar.gz"
+checksum = "sha256:fea8d7801dbea6aa45d8fe58351f758a9262e187b8e86eaf500bbe01c7f02362"
+
+[[artifacts]]
+version = "12.22.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.3/node-v12.22.3-linux-x64.tar.gz"
+checksum = "sha256:948249f40252c65080ee311404353960226fdd8847f575d3118df6656e0d8fea"
+
+[[artifacts]]
+version = "12.22.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.2/node-v12.22.2-linux-arm64.tar.gz"
+checksum = "sha256:40f4a6a887e3ab8675e71bdc544353e078775074ec9f7911cfe3827ad68007fb"
+
+[[artifacts]]
+version = "12.22.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.2/node-v12.22.2-linux-x64.tar.gz"
+checksum = "sha256:2898ac962602443fedeaaccf61b33f127c97f7c9d7b23fbe0d78a4d20b69db0b"
+
+[[artifacts]]
+version = "12.22.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.1/node-v12.22.1-linux-arm64.tar.gz"
+checksum = "sha256:917c582b7f7ae5ff8b2d97e05d00598011f9fbfcc4f76952da3ed477405c9c1a"
+
+[[artifacts]]
+version = "12.22.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.1/node-v12.22.1-linux-x64.tar.gz"
+checksum = "sha256:d315c5dea4d96658164cdb257bd8dbb5e44bdd2a7c1d747841f06515f23a0042"
+
+[[artifacts]]
+version = "12.22.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.22.0/node-v12.22.0-linux-arm64.tar.gz"
+checksum = "sha256:844d0ea80f0b71b015800d2089fe13a0dee1dd46b2957c458d06a5231bf6ac0b"
+
+[[artifacts]]
+version = "12.22.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.22.0/node-v12.22.0-linux-x64.tar.gz"
+checksum = "sha256:d941cb38b023a1c53a629c49425105f68069937569edd72c6fafab2221fc4533"
+
+[[artifacts]]
+version = "12.21.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.21.0/node-v12.21.0-linux-arm64.tar.gz"
+checksum = "sha256:5748bfc5bbf7d9c1c8e79bd4f71d8f049c7fc7bc5b52e04685633319843c4f93"
+
+[[artifacts]]
+version = "12.21.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.21.0/node-v12.21.0-linux-x64.tar.gz"
+checksum = "sha256:ab121de3c472d76ec425480b0594e43109ee607bd57c3d5314bdb65fa816bf1c"
+
+[[artifacts]]
+version = "12.20.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.20.2/node-v12.20.2-linux-arm64.tar.gz"
+checksum = "sha256:cd7a83dd8d9e00953079b09520647d474431f5aaad1a67200005ddff9166d55d"
+
+[[artifacts]]
+version = "12.20.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.20.2/node-v12.20.2-linux-x64.tar.gz"
+checksum = "sha256:e85d6866ae036782b0f5f53419a941fd742c5d5dc83fff86428b629570caa703"
+
+[[artifacts]]
+version = "12.20.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.20.1/node-v12.20.1-linux-arm64.tar.gz"
+checksum = "sha256:3154628c02f2c920fed77e8dce1a8ae32333260666ebaaa7a3cd230f45d13e42"
+
+[[artifacts]]
+version = "12.20.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.20.1/node-v12.20.1-linux-x64.tar.gz"
+checksum = "sha256:c4d45bf46d4ef4b6a72384dfb0ab6c07aed5750bcd1c2fc9f29c0aaccc6a4363"
+
+[[artifacts]]
+version = "12.20.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.20.0/node-v12.20.0-linux-arm64.tar.gz"
+checksum = "sha256:4c44beb80f08bd815c813a2acd3a8736593022b5a1d53ec779be0e9df0ab32ff"
+
+[[artifacts]]
+version = "12.20.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.20.0/node-v12.20.0-linux-x64.tar.gz"
+checksum = "sha256:3e25dc786fed5b3799613a9dfb8b1cea99b1208476fa06115f15e4539b333d82"
+
+[[artifacts]]
+version = "12.19.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.19.1/node-v12.19.1-linux-arm64.tar.gz"
+checksum = "sha256:a716fca03eb7ba6e07c6a05595e152e177ad3435e58df8120cf615836bcd00b4"
+
+[[artifacts]]
+version = "12.19.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.19.1/node-v12.19.1-linux-x64.tar.gz"
+checksum = "sha256:858c5201c9572a8ec797f6cb966669cd38d5b5181b93eb5917f9ebdf89471b9f"
+
+[[artifacts]]
+version = "12.19.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.19.0/node-v12.19.0-linux-arm64.tar.gz"
+checksum = "sha256:09f2a675f209f7af8d346b2a0ceb2cb9248515a50207276cef13038ec103d552"
+
+[[artifacts]]
+version = "12.19.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.19.0/node-v12.19.0-linux-x64.tar.gz"
+checksum = "sha256:f37a5bf0965e8ab7b1b078392638778286ceee8fdb895c050889a61772944bda"
+
+[[artifacts]]
+version = "12.18.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.18.4/node-v12.18.4-linux-arm64.tar.gz"
+checksum = "sha256:69a419a08b6e2d0dffc5b0659e16adfd315074fc0e93e382ee6052546ad789ff"
+
+[[artifacts]]
+version = "12.18.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.18.4/node-v12.18.4-linux-x64.tar.gz"
+checksum = "sha256:b1745bf45aab8d92ebb78d6c4f07c66ad770e94ca2cab1b8f31b3cc361143d8e"
+
+[[artifacts]]
+version = "12.18.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.18.3/node-v12.18.3-linux-arm64.tar.gz"
+checksum = "sha256:f2b8b7f34966a03f03fcd89fa4924fb97ea680eae4c4e02ff1aafd9ea89ecad8"
+
+[[artifacts]]
+version = "12.18.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.18.3/node-v12.18.3-linux-x64.tar.gz"
+checksum = "sha256:8cdacecc43c35bcfa5474c793b9e7a01835e4171264f7b13f3e57093371872e9"
+
+[[artifacts]]
+version = "12.18.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.18.2/node-v12.18.2-linux-arm64.tar.gz"
+checksum = "sha256:f6413c83c3a5ab0935f0ca8653a81b9b180462db078ea49478fa4e843b074eff"
+
+[[artifacts]]
+version = "12.18.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.18.2/node-v12.18.2-linux-x64.tar.gz"
+checksum = "sha256:2d316e55994086e41761b0c657e0027e9d16d7160d3f8854cc9dc7615b99a526"
+
+[[artifacts]]
+version = "12.18.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.18.1/node-v12.18.1-linux-arm64.tar.gz"
+checksum = "sha256:b78fc542858b83a96d712d6a2f493ae87e1af55040bc55fb68671af191016d19"
+
+[[artifacts]]
+version = "12.18.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.18.1/node-v12.18.1-linux-x64.tar.gz"
+checksum = "sha256:b89a0d497674f388705c877ad4f57766695cfe26ea6c6c9d3ad6ff98827edbfe"
+
+[[artifacts]]
+version = "12.18.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.18.0/node-v12.18.0-linux-arm64.tar.gz"
+checksum = "sha256:11860778b886b9771980ba04774d18496fe6bd1f4a6181189f7b6be61b1e7c79"
+
+[[artifacts]]
+version = "12.18.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.18.0/node-v12.18.0-linux-x64.tar.gz"
+checksum = "sha256:9526c0ee225037fc49a00e4bd5c5e2db26053f3f7c9ad124f5763d2eb80cff16"
+
+[[artifacts]]
+version = "12.17.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.17.0/node-v12.17.0-linux-arm64.tar.gz"
+checksum = "sha256:498eda4d6089544ec7be795fd43cb5e9ff5e7f25fc10f0ce81646990ff3163b7"
+
+[[artifacts]]
+version = "12.17.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.17.0/node-v12.17.0-linux-x64.tar.gz"
+checksum = "sha256:582b66031fafdb77b0c897eaac522d55721df49555fe45de7bc207af443c4f73"
+
+[[artifacts]]
+version = "12.16.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.16.3/node-v12.16.3-linux-arm64.tar.gz"
+checksum = "sha256:f91f92bd690f457ced9faa81bef8eeb8706abea33a349358299e30f1c2522f30"
+
+[[artifacts]]
+version = "12.16.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.16.3/node-v12.16.3-linux-x64.tar.gz"
+checksum = "sha256:66518c31ea7735ae5a0bb8ea27edfee846702dbdc708fea6ad4a308d43ef5652"
+
+[[artifacts]]
+version = "12.16.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.16.2/node-v12.16.2-linux-arm64.tar.gz"
+checksum = "sha256:0beb78161a02eed9fc2a97e9cf95e1aecfdff61da6a695a26a66880528f1f53f"
+
+[[artifacts]]
+version = "12.16.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.16.2/node-v12.16.2-linux-x64.tar.gz"
+checksum = "sha256:ffc92b8d9f53a10a2a734c93e78a3be74af7b0034bddd6f034a700c430eb94c1"
+
+[[artifacts]]
+version = "12.16.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.16.1/node-v12.16.1-linux-arm64.tar.gz"
+checksum = "sha256:22750695d432e22f2a1faadfcd534a88a18933ffd658d45b08a5afa61acbc24a"
+
+[[artifacts]]
+version = "12.16.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.16.1/node-v12.16.1-linux-x64.tar.gz"
+checksum = "sha256:b2d9787da97d6c0d5cbf24c69fdbbf376b19089f921432c5a61aa323bc070bea"
+
+[[artifacts]]
+version = "12.16.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.16.0/node-v12.16.0-linux-arm64.tar.gz"
+checksum = "sha256:d899593fc516357bf1ad9e28fbb5b2beb5ade25c81a45c1f5499b9320709793f"
+
+[[artifacts]]
+version = "12.16.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.16.0/node-v12.16.0-linux-x64.tar.gz"
+checksum = "sha256:fe8eca839b702f1ca47e9aabfd833cfa3e68952450d1f4c893cdfb0650ecd3c2"
+
+[[artifacts]]
+version = "12.15.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.15.0/node-v12.15.0-linux-arm64.tar.gz"
+checksum = "sha256:9349bb00a522da9ecd0d2f9453b500904ccd56e271852ab2defb51a8c77a1aca"
+
+[[artifacts]]
+version = "12.15.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.15.0/node-v12.15.0-linux-x64.tar.gz"
+checksum = "sha256:218279a33603b8bc958c46cce04c14851fd9d685bd21f5a39d6b98d08d80aae5"
+
+[[artifacts]]
+version = "12.14.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.14.1/node-v12.14.1-linux-arm64.tar.gz"
+checksum = "sha256:fb1a20f37ef918033b0f2f9436b4a82e15128ce61e0de2378a4306ba7667cf4a"
+
+[[artifacts]]
+version = "12.14.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.14.1/node-v12.14.1-linux-x64.tar.gz"
+checksum = "sha256:e21be7dd07cc143c480695d6214f40873a7791f437c1ca12fc94d45f539a47d9"
+
+[[artifacts]]
+version = "12.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.14.0/node-v12.14.0-linux-arm64.tar.gz"
+checksum = "sha256:63e9c96712868addef76a694852f54ea279479949669275dab506aa8ce4e0b73"
+
+[[artifacts]]
+version = "12.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.14.0/node-v12.14.0-linux-x64.tar.gz"
+checksum = "sha256:52207f643ab0fba66d5189a51aac280c4834c81f24a7297446896386ec93a5ed"
+
+[[artifacts]]
+version = "12.13.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.13.1/node-v12.13.1-linux-arm64.tar.gz"
+checksum = "sha256:a1c183f175344f492188543fa789576ed266b7542763ad07d880f9819d9f23d3"
+
+[[artifacts]]
+version = "12.13.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.13.1/node-v12.13.1-linux-x64.tar.gz"
+checksum = "sha256:074a6129da34b768b791f39e8b74c6e4ab3349d1296f1a303ef3547a7f9cf9be"
+
+[[artifacts]]
+version = "12.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.13.0/node-v12.13.0-linux-arm64.tar.gz"
+checksum = "sha256:92371c7f1edd384a8acb0d2b9f2deac76e911588669b71de9f6453012196c970"
+
+[[artifacts]]
+version = "12.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.13.0/node-v12.13.0-linux-x64.tar.gz"
+checksum = "sha256:c69671c89d0faa47b64bd5f37079e4480852857a9a9366ee86cdd8bc9670074a"
+
+[[artifacts]]
+version = "12.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.12.0/node-v12.12.0-linux-arm64.tar.gz"
+checksum = "sha256:9c6ff84ad3be0fc79188cfa68b3fab9aedadf219ffb3821d4bf6d01308ed6621"
+
+[[artifacts]]
+version = "12.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.12.0/node-v12.12.0-linux-x64.tar.gz"
+checksum = "sha256:4b46ffa368bc909fae2611a16daffd1d8c35a5284aea0bb7c45269e72f6638a2"
+
+[[artifacts]]
+version = "12.11.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.11.1/node-v12.11.1-linux-arm64.tar.gz"
+checksum = "sha256:a9973aeb9f942b4ffa8fe40149dfb3e0ddf9377049fc3cc7e789c5dfdc22ffd0"
+
+[[artifacts]]
+version = "12.11.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.11.1/node-v12.11.1-linux-x64.tar.gz"
+checksum = "sha256:ac6c76af7c13cc3688aba072c4c728cb6fa2c40b340b1dcc4795e2705b1869dc"
+
+[[artifacts]]
+version = "12.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.11.0/node-v12.11.0-linux-arm64.tar.gz"
+checksum = "sha256:8988bf487317766b3d84f9b9075c302eaa2a35c768640c99d1f7b0c4ba10bbda"
+
+[[artifacts]]
+version = "12.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.11.0/node-v12.11.0-linux-x64.tar.gz"
+checksum = "sha256:66f99ceb83128fae568659caaa8f2202680c2e89296513605883f81e88d75dc3"
+
+[[artifacts]]
+version = "12.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.10.0/node-v12.10.0-linux-arm64.tar.gz"
+checksum = "sha256:fd117a6ed22f493900fabdc7881fee50c7661c0eed88ae10c1139fa0d6c72535"
+
+[[artifacts]]
+version = "12.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.10.0/node-v12.10.0-linux-x64.tar.gz"
+checksum = "sha256:3de23fd9f2145ff76d0583e7f57aa4ccead58b3fb991e215f862e779c9cdf151"
+
+[[artifacts]]
+version = "12.9.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.9.1/node-v12.9.1-linux-arm64.tar.gz"
+checksum = "sha256:a09e7c54f05036ddf260f9a6762d72669e428810f814ad189519fe5adad0bd2d"
+
+[[artifacts]]
+version = "12.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.9.1/node-v12.9.1-linux-x64.tar.gz"
+checksum = "sha256:5488e9d9e860eb344726aabdc8f90d09e36602da38da3d16a7ee852fd9fbd91f"
+
+[[artifacts]]
+version = "12.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.9.0/node-v12.9.0-linux-arm64.tar.gz"
+checksum = "sha256:703134352854e3501023cda8eba68f1f992a426f1cda649dc6b38e248b07fcf1"
+
+[[artifacts]]
+version = "12.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.9.0/node-v12.9.0-linux-x64.tar.gz"
+checksum = "sha256:3991e5b65fbaab8d70cda813b9bc73dd3b4201aeef42bcb1c000a03869aa0610"
+
+[[artifacts]]
+version = "12.8.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.8.1/node-v12.8.1-linux-arm64.tar.gz"
+checksum = "sha256:3ad6e53bcf8a3b92b10504fa70d83f69eab85a8603c2fbe210121278dd19920b"
+
+[[artifacts]]
+version = "12.8.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.8.1/node-v12.8.1-linux-x64.tar.gz"
+checksum = "sha256:8758a131cac2e8a373153b9eb53696d2e823b910dbf175af7ec4a0592b065c22"
+
+[[artifacts]]
+version = "12.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.8.0/node-v12.8.0-linux-arm64.tar.gz"
+checksum = "sha256:9eb01fe3ff86210f19d03929d0a7c59713a05fd686334ecc8843c8f0d0321de6"
+
+[[artifacts]]
+version = "12.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.8.0/node-v12.8.0-linux-x64.tar.gz"
+checksum = "sha256:bc56ec3ee0e6b2945682fdfeb80187dbc1f67e59a78dc73ef225b4357509424f"
+
+[[artifacts]]
+version = "12.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.7.0/node-v12.7.0-linux-arm64.tar.gz"
+checksum = "sha256:4eb18db42c36ac535ab306894f0bd6bf1058e61ef9702108b11fca7c1b44a484"
+
+[[artifacts]]
+version = "12.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.7.0/node-v12.7.0-linux-x64.tar.gz"
+checksum = "sha256:bc232791d839dd2159173ebedfdc22376e582a5f51a546e0f01de7182720e174"
+
+[[artifacts]]
+version = "12.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.6.0/node-v12.6.0-linux-arm64.tar.gz"
+checksum = "sha256:966951924e08c6e1107a46396dd661a827d9473d2b503fe9e6383bbfa68881b3"
+
+[[artifacts]]
+version = "12.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.6.0/node-v12.6.0-linux-x64.tar.gz"
+checksum = "sha256:ed54fb02a3e9544d9b86a1afbb526b429ae565214d54275c3c5cbfc5e5ea4691"
+
+[[artifacts]]
+version = "12.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.5.0/node-v12.5.0-linux-arm64.tar.gz"
+checksum = "sha256:a6d226bf486453d2f58df14ec71dd08f18383af582e2fc992fa8cc96cd7925b4"
+
+[[artifacts]]
+version = "12.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.5.0/node-v12.5.0-linux-x64.tar.gz"
+checksum = "sha256:2d7a0a0cd840adc3b58536f84176308e5fc9d94048e035fe190f99c49436d04b"
+
+[[artifacts]]
+version = "12.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.4.0/node-v12.4.0-linux-arm64.tar.gz"
+checksum = "sha256:312a7942f5fbd0aa83d6e624a06681275db2cb3c3eeaf3e452ad04aac17b6de5"
+
+[[artifacts]]
+version = "12.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.4.0/node-v12.4.0-linux-x64.tar.gz"
+checksum = "sha256:9a16909157e68d4e409a73b008994ed05b4b6bc952b65ffa7fbc5abb973d31e9"
+
+[[artifacts]]
+version = "12.3.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.3.1/node-v12.3.1-linux-arm64.tar.gz"
+checksum = "sha256:5926be88109c8efe048eedd875487041174fadd470fed4fe6ffb5eadfa50cb6b"
+
+[[artifacts]]
+version = "12.3.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.3.1/node-v12.3.1-linux-x64.tar.gz"
+checksum = "sha256:78c12398128e79dfec3092325da026d422d296c9d3089a9b2ee7bf7bd2e3be87"
+
+[[artifacts]]
+version = "12.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.3.0/node-v12.3.0-linux-arm64.tar.gz"
+checksum = "sha256:ffb57ec86f4f279e75e755515fb74149702f3467c4841c47c18cfb5d89e67c6d"
+
+[[artifacts]]
+version = "12.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.3.0/node-v12.3.0-linux-x64.tar.gz"
+checksum = "sha256:1159739eb0e77d874bcbb59809b504c790ff275506c7a855dd8cabb495e93cc1"
+
+[[artifacts]]
+version = "12.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.2.0/node-v12.2.0-linux-arm64.tar.gz"
+checksum = "sha256:abc9adedbbbd48f46163399c0f7a7948c14df184cb500b925c6980c921988d13"
+
+[[artifacts]]
+version = "12.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.2.0/node-v12.2.0-linux-x64.tar.gz"
+checksum = "sha256:ba6afb9967ea6934d0807e0f79da80e063601d91c98da12bda3cf4675720bfb2"
+
+[[artifacts]]
+version = "12.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.1.0/node-v12.1.0-linux-arm64.tar.gz"
+checksum = "sha256:e0ca3fe82c35d7e03b6a4c9983cf6797677f797148777b61c2bb3c01257026f2"
+
+[[artifacts]]
+version = "12.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.1.0/node-v12.1.0-linux-x64.tar.gz"
+checksum = "sha256:d23587e3dbb2baebb1d5f1418a64f1c8ce6a9315a2281bff7cf87c9d1ed34ee4"
+
+[[artifacts]]
+version = "12.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v12.0.0/node-v12.0.0-linux-arm64.tar.gz"
+checksum = "sha256:835265539497708b4daf68175614fbe57ed21374f3717b4754971551a06c5efb"
+
+[[artifacts]]
+version = "12.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v12.0.0/node-v12.0.0-linux-x64.tar.gz"
+checksum = "sha256:3268466af05464a7aa698df7cc8bbeec0b8728d8779e12130ef441bb730a8059"
+
+[[artifacts]]
+version = "11.15.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.15.0/node-v11.15.0-linux-arm64.tar.gz"
+checksum = "sha256:78237456386d66ac2143a25530dd5b39326a874079ba7c0676a4639e894567c4"
+
+[[artifacts]]
+version = "11.15.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.15.0/node-v11.15.0-linux-x64.tar.gz"
+checksum = "sha256:98bd18051cbdb39bbcda1ab169ca3fd3935d87e9cfc36e1b6fd6f609d46856bb"
+
+[[artifacts]]
+version = "11.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.14.0/node-v11.14.0-linux-arm64.tar.gz"
+checksum = "sha256:9ab9a285fe4b24809f787e4cb4b48f6f482246902981d10fa604fdb1c90b16b7"
+
+[[artifacts]]
+version = "11.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.14.0/node-v11.14.0-linux-x64.tar.gz"
+checksum = "sha256:0d5c078137c992a919898c8fda7e5af40118f355bb938fccfd5aecddaf2dc123"
+
+[[artifacts]]
+version = "11.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.13.0/node-v11.13.0-linux-arm64.tar.gz"
+checksum = "sha256:f7ca6b4ad6944dc6b76356eb4d6116485445d78b294ea10e97e8ec7907436384"
+
+[[artifacts]]
+version = "11.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.13.0/node-v11.13.0-linux-x64.tar.gz"
+checksum = "sha256:23cafb97f7e299c125b3c45cef3f7cb08ffd37e1aa9372367e715d89a1fa33ca"
+
+[[artifacts]]
+version = "11.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.12.0/node-v11.12.0-linux-arm64.tar.gz"
+checksum = "sha256:044360cc730d90b579fecea7d49861a23c326f058b39e9ac18c391d77073736d"
+
+[[artifacts]]
+version = "11.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.12.0/node-v11.12.0-linux-x64.tar.gz"
+checksum = "sha256:58be8912097b93098bbbc3c1b536b2f9e70efdca64d63d7e4cdb4dbd40b3e751"
+
+[[artifacts]]
+version = "11.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.11.0/node-v11.11.0-linux-arm64.tar.gz"
+checksum = "sha256:2eeebc2323bdc91493cc2f485b140e4034bb37e52ce3ea0caa6e80f4a9fb64b0"
+
+[[artifacts]]
+version = "11.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.11.0/node-v11.11.0-linux-x64.tar.gz"
+checksum = "sha256:f749e64a56dc71938fa5d2774b4e53068d19ad9f48b4a62257633b25459bffa6"
+
+[[artifacts]]
+version = "11.10.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.10.1/node-v11.10.1-linux-arm64.tar.gz"
+checksum = "sha256:3438c8f94af3e53b83ceca1162ac3841718207a75d3c8e4d79bbb2c0653a690e"
+
+[[artifacts]]
+version = "11.10.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.10.1/node-v11.10.1-linux-x64.tar.gz"
+checksum = "sha256:c84fe17ceb999ecd5d0a1ad5b70b502779a22e433f96e0b6a0ddf6d99f954975"
+
+[[artifacts]]
+version = "11.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.10.0/node-v11.10.0-linux-arm64.tar.gz"
+checksum = "sha256:9407ff7019f1d6048134443638bb9473543ebdd8de268057eb929aaa044e6180"
+
+[[artifacts]]
+version = "11.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.10.0/node-v11.10.0-linux-x64.tar.gz"
+checksum = "sha256:4117de50800ecc6d5f7a9c3989d5497fa9dd37df87a904ac4d49948ab10d39ba"
+
+[[artifacts]]
+version = "11.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.9.0/node-v11.9.0-linux-arm64.tar.gz"
+checksum = "sha256:d5b984cc2ad734617ebb46e36ffbe6a60adc4308fb52edc594fb02d68f573a7c"
+
+[[artifacts]]
+version = "11.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.9.0/node-v11.9.0-linux-x64.tar.gz"
+checksum = "sha256:0e872c288724e7de72eaa89d1fbc29979a60cdc8c4c0bc1ea65339328bbaaf4c"
+
+[[artifacts]]
+version = "11.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.8.0/node-v11.8.0-linux-arm64.tar.gz"
+checksum = "sha256:ff3f49fc6da1cd1e9792862dab0774fc83578201fcd414f90af09f4cb5ac3c38"
+
+[[artifacts]]
+version = "11.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.8.0/node-v11.8.0-linux-x64.tar.gz"
+checksum = "sha256:5787b70b35eb5c819be4475d3aedd332d68d01dc12651374a209961b7202a6bc"
+
+[[artifacts]]
+version = "11.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.7.0/node-v11.7.0-linux-arm64.tar.gz"
+checksum = "sha256:cbbc6f68d74433e1b8975606d2f83f3c3fff264466db1c14082d2e16a1951abf"
+
+[[artifacts]]
+version = "11.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.7.0/node-v11.7.0-linux-x64.tar.gz"
+checksum = "sha256:d2ab60b497b59c415dc1d1c0ab3f64da3083a746fb15ec82d917ca7f4743028d"
+
+[[artifacts]]
+version = "11.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.6.0/node-v11.6.0-linux-arm64.tar.gz"
+checksum = "sha256:a112c89390965356036597e712ec3939c37090bbafd513b90ab2a524bd29190a"
+
+[[artifacts]]
+version = "11.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.6.0/node-v11.6.0-linux-x64.tar.gz"
+checksum = "sha256:ee5b070caa8e812ee763b65e75c6f4f120a65e40fdef807b075e39dc8916fa9c"
+
+[[artifacts]]
+version = "11.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.5.0/node-v11.5.0-linux-arm64.tar.gz"
+checksum = "sha256:fb4fe801f1e69ddde351a72ae8c6bfe61f017c607e69db0a2464264181142b5e"
+
+[[artifacts]]
+version = "11.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.5.0/node-v11.5.0-linux-x64.tar.gz"
+checksum = "sha256:17775508531fd1d47db6e905c039cb563a65943f9d7c847f70380f87d8ae9675"
+
+[[artifacts]]
+version = "11.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.4.0/node-v11.4.0-linux-arm64.tar.gz"
+checksum = "sha256:d92963d7999fb8bcd3c373f8c6c0ab84e19477c0615e5185c527ac0f4ba36aee"
+
+[[artifacts]]
+version = "11.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.4.0/node-v11.4.0-linux-x64.tar.gz"
+checksum = "sha256:4ef7dea131453da3a93cc1f32bff948da8953958dcbe3b413debae8bb41aa7a0"
+
+[[artifacts]]
+version = "11.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.3.0/node-v11.3.0-linux-arm64.tar.gz"
+checksum = "sha256:e6e90080b95f780102980059ac3b2b2f7f6465f13ffa78d946f4c4df9ce97ff1"
+
+[[artifacts]]
+version = "11.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.3.0/node-v11.3.0-linux-x64.tar.gz"
+checksum = "sha256:aac519aac1814e8590cd6b55fb2c6ddc1bbb825fc8c097abce5f5361aea61108"
+
+[[artifacts]]
+version = "11.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.2.0/node-v11.2.0-linux-arm64.tar.gz"
+checksum = "sha256:dda16cf93a365e5f853ca29dfc7be8866881558a44fd751ff5843015f4ad93ff"
+
+[[artifacts]]
+version = "11.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.2.0/node-v11.2.0-linux-x64.tar.gz"
+checksum = "sha256:2528f860cb0d33fe2f807f56dac347730f32772b9f987f8ec379af9277cae71f"
+
+[[artifacts]]
+version = "11.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.1.0/node-v11.1.0-linux-arm64.tar.gz"
+checksum = "sha256:4bdada732428603e215ca3b6a4e06814706bc48a2681ec48446319312bff2489"
+
+[[artifacts]]
+version = "11.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.1.0/node-v11.1.0-linux-x64.tar.gz"
+checksum = "sha256:52289a646a27511f5808290357798c7ebd4b5132a8fc3bf7d5bf53183b89c668"
+
+[[artifacts]]
+version = "11.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v11.0.0/node-v11.0.0-linux-arm64.tar.gz"
+checksum = "sha256:e1b32dd0b41360dba18cc9919f359fd4df644cf8fc2a7687afe4454182fb4129"
+
+[[artifacts]]
+version = "11.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v11.0.0/node-v11.0.0-linux-x64.tar.gz"
+checksum = "sha256:e571de4e9b42fc411314d51ff730de37e3cef4d1d31cf4b84854e7a34a454cc7"
+
+[[artifacts]]
+version = "10.24.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.24.1/node-v10.24.1-linux-arm64.tar.gz"
+checksum = "sha256:0ae4931d0ea779ecb237c1fc9f4a27271b0054b1efabc783863478913fe6caa6"
+
+[[artifacts]]
+version = "10.24.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.24.1/node-v10.24.1-linux-x64.tar.gz"
+checksum = "sha256:7a70083a73719a3c7846533923d5c4e955405c2b4ba1c1abd95ed21ae8b52775"
+
+[[artifacts]]
+version = "10.24.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.24.0/node-v10.24.0-linux-arm64.tar.gz"
+checksum = "sha256:65e6255c6f95b6dcf87f13c21994bc80205b4bd7c7d9a3fe1f8f2a18daec576d"
+
+[[artifacts]]
+version = "10.24.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.24.0/node-v10.24.0-linux-x64.tar.gz"
+checksum = "sha256:d8d7ecb0667a9b86b7ce1994731f9c9d313b46f04de59f724259a6fda685617a"
+
+[[artifacts]]
+version = "10.23.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.23.3/node-v10.23.3-linux-arm64.tar.gz"
+checksum = "sha256:483a4b609fe406b87da290bc0aa582b863e725321d71c6207f050ebe06baec8d"
+
+[[artifacts]]
+version = "10.23.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.23.3/node-v10.23.3-linux-x64.tar.gz"
+checksum = "sha256:08e225a3581ca45b8c00d5561cf68ec7c53fe9022a30a1d167b9544789477f5b"
+
+[[artifacts]]
+version = "10.23.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.23.2/node-v10.23.2-linux-arm64.tar.gz"
+checksum = "sha256:83a15dc442916c55fc033c4395fb72d27d27c16fdea05fc23f952cba88023d81"
+
+[[artifacts]]
+version = "10.23.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.23.2/node-v10.23.2-linux-x64.tar.gz"
+checksum = "sha256:d9fe68f0c36daf97df53c7be7d3395caec0f95b09d135aad8a45f12106ba5759"
+
+[[artifacts]]
+version = "10.23.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.23.1/node-v10.23.1-linux-arm64.tar.gz"
+checksum = "sha256:e7d0476b1e9add7b21297698517356bb7c7d7f10e75f5abad6ab5806518a6cd6"
+
+[[artifacts]]
+version = "10.23.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.23.1/node-v10.23.1-linux-x64.tar.gz"
+checksum = "sha256:2a5f9d862468a4c677630923531e52339526cfd075cc6df30da4636782eb7bda"
+
+[[artifacts]]
+version = "10.23.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.23.0/node-v10.23.0-linux-arm64.tar.gz"
+checksum = "sha256:d66f4912a0cb84678124d9a311bee7b204665fc62f83b0fc0d10b2f385feb524"
+
+[[artifacts]]
+version = "10.23.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.23.0/node-v10.23.0-linux-x64.tar.gz"
+checksum = "sha256:19cccb78f0881a78051291a50200200a0303649ee84e5489c771d3b4e4bd0e51"
+
+[[artifacts]]
+version = "10.22.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.22.1/node-v10.22.1-linux-arm64.tar.gz"
+checksum = "sha256:f38e3e8cd00fe480a3b6a4a78d381f6880f755af08f0566df2bdf26006e44812"
+
+[[artifacts]]
+version = "10.22.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.22.1/node-v10.22.1-linux-x64.tar.gz"
+checksum = "sha256:3c5378a6d9511c807b54ed7639a6bf94b03490906fb2c838ecf9156c78a4e0e6"
+
+[[artifacts]]
+version = "10.22.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.22.0/node-v10.22.0-linux-arm64.tar.gz"
+checksum = "sha256:8e59eb6865f704785a9aa53ccf9f4cb10412caaf778cee617241a0d0684e008d"
+
+[[artifacts]]
+version = "10.22.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.22.0/node-v10.22.0-linux-x64.tar.gz"
+checksum = "sha256:aa7e9e1d8abcc169119bf5c56ede515689f2644ccc4d40ca0fc33756a3deb1f7"
+
+[[artifacts]]
+version = "10.21.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.21.0/node-v10.21.0-linux-arm64.tar.gz"
+checksum = "sha256:43f821147c18367c227ea63ce173ee3acfd3da1fa3ea0581f6de1a27ca5b7d4e"
+
+[[artifacts]]
+version = "10.21.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.21.0/node-v10.21.0-linux-x64.tar.gz"
+checksum = "sha256:d0bac246001eed9268ba9cadbfc6cfd8b6eb0728ad000a0f9fa7ce29e66c2be4"
+
+[[artifacts]]
+version = "10.20.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.20.1/node-v10.20.1-linux-arm64.tar.gz"
+checksum = "sha256:e0073e46fe85e389e7ddca990c99b27fbc1e833d00b1ee32561f0d104ab277f9"
+
+[[artifacts]]
+version = "10.20.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.20.1/node-v10.20.1-linux-x64.tar.gz"
+checksum = "sha256:528643b0fc293ff32cf450dc2e5443a354967029d1536d96f9da4b34418e1e7a"
+
+[[artifacts]]
+version = "10.20.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.20.0/node-v10.20.0-linux-arm64.tar.gz"
+checksum = "sha256:96a26b897d120806c80115bb484160daae3e86944d0c1ffecf1b4be0a8e09501"
+
+[[artifacts]]
+version = "10.20.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.20.0/node-v10.20.0-linux-x64.tar.gz"
+checksum = "sha256:63f7fe148dece366c79a4daf06d38ab06e979cf6d7c3ea7153887e4d65a5f85e"
+
+[[artifacts]]
+version = "10.19.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.19.0/node-v10.19.0-linux-arm64.tar.gz"
+checksum = "sha256:3510172797b63bb6a7247f62a241bdfcf51fef8b1134eb7d3a27973e2008e482"
+
+[[artifacts]]
+version = "10.19.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.19.0/node-v10.19.0-linux-x64.tar.gz"
+checksum = "sha256:36d90bc58f0418f31dceda5b18eb260019fcc91e59b0820ffa66700772a8804b"
+
+[[artifacts]]
+version = "10.18.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.18.1/node-v10.18.1-linux-arm64.tar.gz"
+checksum = "sha256:554b42da76877a9c5ab0054b492fef0d5847b06217e466728b1e73547e55c7da"
+
+[[artifacts]]
+version = "10.18.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.18.1/node-v10.18.1-linux-x64.tar.gz"
+checksum = "sha256:812fe7d421894b792027d19c78c919faad3bf32d8bc16bde67f5c7eea2469eac"
+
+[[artifacts]]
+version = "10.18.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.18.0/node-v10.18.0-linux-arm64.tar.gz"
+checksum = "sha256:3f9d6c5e7f5781518fb46e9f86081c03e97fb052ff397345be1acc658997174a"
+
+[[artifacts]]
+version = "10.18.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.18.0/node-v10.18.0-linux-x64.tar.gz"
+checksum = "sha256:78a46d1e1f6db68c0732981fc9a1fe8583eabb4e232f1ed742f7dedc5bed3ddd"
+
+[[artifacts]]
+version = "10.17.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.17.0/node-v10.17.0-linux-arm64.tar.gz"
+checksum = "sha256:fca7862a435c48d634fd74464057edef0e6ed854678c4b1fee3f21f126f2d7c7"
+
+[[artifacts]]
+version = "10.17.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.17.0/node-v10.17.0-linux-x64.tar.gz"
+checksum = "sha256:417bdc5402f6510fe1a5a898a9cdf1d67bd0202b5f014051c382f05358999534"
+
+[[artifacts]]
+version = "10.16.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.16.3/node-v10.16.3-linux-arm64.tar.gz"
+checksum = "sha256:3bab16e7107092e43426e082ee9fd88ef0a43a35816f662f14563bcc5152600d"
+
+[[artifacts]]
+version = "10.16.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.16.3/node-v10.16.3-linux-x64.tar.gz"
+checksum = "sha256:2f0397bb81c1d0c9901b9aff82a933257bf60f3992227b86107111a75b9030d9"
+
+[[artifacts]]
+version = "10.16.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.16.2/node-v10.16.2-linux-arm64.tar.gz"
+checksum = "sha256:5c496fc4392f34d9f2515212f58088448e121cbe9b732a64e9757f021b6b675f"
+
+[[artifacts]]
+version = "10.16.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.16.2/node-v10.16.2-linux-x64.tar.gz"
+checksum = "sha256:2779d04b1a9744bbb003a1a4476db2444b5f697034bc902a07dde4a8669ae6d0"
+
+[[artifacts]]
+version = "10.16.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.16.1/node-v10.16.1-linux-arm64.tar.gz"
+checksum = "sha256:c5f1df1ae559a9e40fc7216f4c82379d4e8ce64a96921ab0bed216c82cf9a1f3"
+
+[[artifacts]]
+version = "10.16.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.16.1/node-v10.16.1-linux-x64.tar.gz"
+checksum = "sha256:32db9700d2ba926e774c17e7cd8952499e64e241b095d22e05d3d62ebe4cb6d4"
+
+[[artifacts]]
+version = "10.16.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.16.0/node-v10.16.0-linux-arm64.tar.gz"
+checksum = "sha256:2d84a777318bc95dd2a201ab8d700aea7e20641b3ece0c048399398dc645cbd7"
+
+[[artifacts]]
+version = "10.16.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.16.0/node-v10.16.0-linux-x64.tar.gz"
+checksum = "sha256:2e2cddf805112bd0b5769290bf2d1bc4bdd55ee44327e826fa94c459835a9d9a"
+
+[[artifacts]]
+version = "10.15.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.15.3/node-v10.15.3-linux-arm64.tar.gz"
+checksum = "sha256:c82cd99e01f6e26830f0b3e0465f12f92957ebd69a68c91c03228c2669104359"
+
+[[artifacts]]
+version = "10.15.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.15.3/node-v10.15.3-linux-x64.tar.gz"
+checksum = "sha256:6c35b85a7cd4188ab7578354277b2b2ca43eacc864a2a16b3669753ec2369d52"
+
+[[artifacts]]
+version = "10.15.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.15.2/node-v10.15.2-linux-arm64.tar.gz"
+checksum = "sha256:2988f31a07f54a80442166574b01ecfa92f2c6a8094ca4c2d820f464df0b5ce1"
+
+[[artifacts]]
+version = "10.15.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.15.2/node-v10.15.2-linux-x64.tar.gz"
+checksum = "sha256:65e66599b275e2c41a882610a841a990e0570ed03bfccc378e031c475a3dae52"
+
+[[artifacts]]
+version = "10.15.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.15.1/node-v10.15.1-linux-arm64.tar.gz"
+checksum = "sha256:d1cc9b84befd7b001e61bb40c96b8b9d0776f186ebc4e7993fcc0d5c2631b24c"
+
+[[artifacts]]
+version = "10.15.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.15.1/node-v10.15.1-linux-x64.tar.gz"
+checksum = "sha256:ca1dfa9790876409c8d9ecab7b4cdb93e3276cedfc64d56ef1a4ff1778a40214"
+
+[[artifacts]]
+version = "10.15.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.15.0/node-v10.15.0-linux-arm64.tar.gz"
+checksum = "sha256:69a86c71df32320dc8dfccd1aca124c73dc2b274c7ce50104dad733a06dc26f3"
+
+[[artifacts]]
+version = "10.15.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.15.0/node-v10.15.0-linux-x64.tar.gz"
+checksum = "sha256:f0b4ff9a74cbc0106bbf3ee7715f970101ac5b1bbe814404d7a0673d1da9f674"
+
+[[artifacts]]
+version = "10.14.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.14.2/node-v10.14.2-linux-arm64.tar.gz"
+checksum = "sha256:23c82e8a3569bb463a0ed40602195c4280041a30a68858fd84ede7cd532e555e"
+
+[[artifacts]]
+version = "10.14.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.14.2/node-v10.14.2-linux-x64.tar.gz"
+checksum = "sha256:0552b0f6fc9c0cd078bbb794c876e2546ba63a1dfcf8e3c206387936696ca128"
+
+[[artifacts]]
+version = "10.14.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.14.1/node-v10.14.1-linux-arm64.tar.gz"
+checksum = "sha256:87ecffc9fc643de85ca821f87c150a98596eaa3092a7f9469555e2a8625b6c92"
+
+[[artifacts]]
+version = "10.14.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.14.1/node-v10.14.1-linux-x64.tar.gz"
+checksum = "sha256:2cc1a9b118e5d660cd6611c808f0cd80821c79ea5990c221b78124770f4dc38e"
+
+[[artifacts]]
+version = "10.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.14.0/node-v10.14.0-linux-arm64.tar.gz"
+checksum = "sha256:848868d24f1b237afd2d71b1749a21bdabafda2346bf404b1d4fa941d3d35982"
+
+[[artifacts]]
+version = "10.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.14.0/node-v10.14.0-linux-x64.tar.gz"
+checksum = "sha256:2f10d1a5d211a150d6813bdca8f3b1fe673a68fd534b1f547befec1314244596"
+
+[[artifacts]]
+version = "10.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.13.0/node-v10.13.0-linux-arm64.tar.gz"
+checksum = "sha256:de4e92103d228f5a5d0e67f8a681b1bce63036776bb7a46e014fae072d188036"
+
+[[artifacts]]
+version = "10.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.13.0/node-v10.13.0-linux-x64.tar.gz"
+checksum = "sha256:b4b5d8f73148dcf277df413bb16827be476f4fa117cbbec2aaabc8cc0a8588e1"
+
+[[artifacts]]
+version = "10.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.12.0/node-v10.12.0-linux-arm64.tar.gz"
+checksum = "sha256:35108e762de4d449ae012c69c5927023806b2e447070d712630e78ab1f1d2cd5"
+
+[[artifacts]]
+version = "10.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.12.0/node-v10.12.0-linux-x64.tar.gz"
+checksum = "sha256:8d13d57aaf95177e97d29c0944d79a17de8c3a31ba3fe88d1846cfd907e52111"
+
+[[artifacts]]
+version = "10.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.11.0/node-v10.11.0-linux-arm64.tar.gz"
+checksum = "sha256:d9a5072e0bbb90793ce9e90b9b0b12d9955806dd19cbdeba97cfc978b8c87e5d"
+
+[[artifacts]]
+version = "10.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.11.0/node-v10.11.0-linux-x64.tar.gz"
+checksum = "sha256:4d8aaf8c1c51acbbb46bbd4e3c924a573884603b1c4e35cc02982bbda9779c8b"
+
+[[artifacts]]
+version = "10.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.10.0/node-v10.10.0-linux-arm64.tar.gz"
+checksum = "sha256:0b83a3e427d076947b1deca943a48fba0258772f9c037de19d8b1261632d1385"
+
+[[artifacts]]
+version = "10.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.10.0/node-v10.10.0-linux-x64.tar.gz"
+checksum = "sha256:789994b9ad5d2b274e949c268480a197d2af8861cb00911fc1d2ce4a01631e0d"
+
+[[artifacts]]
+version = "10.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.9.0/node-v10.9.0-linux-arm64.tar.gz"
+checksum = "sha256:de3f9625fd15acefce6123e7ac7e51f26b965315f0f64f00aef359d68677ec82"
+
+[[artifacts]]
+version = "10.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.9.0/node-v10.9.0-linux-x64.tar.gz"
+checksum = "sha256:d061760884e4705adfc858eb669c44eb66cd57e8cdf6d5d57a190e76723af416"
+
+[[artifacts]]
+version = "10.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.8.0/node-v10.8.0-linux-arm64.tar.gz"
+checksum = "sha256:c0af4dfb2eb2b0abf45a0c96bbf00ffc059e4afe7feb9a8611ecfd2442847323"
+
+[[artifacts]]
+version = "10.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.8.0/node-v10.8.0-linux-x64.tar.gz"
+checksum = "sha256:d83ea37e53f534996b4477e9a616bfe367f90a62fc50714dcf495f8802090f7b"
+
+[[artifacts]]
+version = "10.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.7.0/node-v10.7.0-linux-arm64.tar.gz"
+checksum = "sha256:98211277500f39c10f71417bfb77e422190ff9aa46707cc5d2fd18a8a8b50691"
+
+[[artifacts]]
+version = "10.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.7.0/node-v10.7.0-linux-x64.tar.gz"
+checksum = "sha256:7324a356b31833c3a978705640d3736a88ec0146bcc1c7ae8875c41d89d4b4da"
+
+[[artifacts]]
+version = "10.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.6.0/node-v10.6.0-linux-arm64.tar.gz"
+checksum = "sha256:354dc8b855faf57c7561633538a63224aeb19e109144396fae466f570feeb69e"
+
+[[artifacts]]
+version = "10.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.6.0/node-v10.6.0-linux-x64.tar.gz"
+checksum = "sha256:c9be65055b9492bad9539acdf31a37f75785f1ad58b6659166233b520a4a9290"
+
+[[artifacts]]
+version = "10.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.5.0/node-v10.5.0-linux-arm64.tar.gz"
+checksum = "sha256:2708f77f12966cdf13046c7ac8513fc430be5cbeacc02711d242d65044580d91"
+
+[[artifacts]]
+version = "10.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.5.0/node-v10.5.0-linux-x64.tar.gz"
+checksum = "sha256:5d77d2c68c06404028f063dca0947315570ff5e52e46f67f93ef9f6cdcb1b4a8"
+
+[[artifacts]]
+version = "10.4.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.4.1/node-v10.4.1-linux-arm64.tar.gz"
+checksum = "sha256:f61110447544b5ada4b5523b4ccd8a2f5000709e2f9dc6f1f3594f556a068627"
+
+[[artifacts]]
+version = "10.4.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.4.1/node-v10.4.1-linux-x64.tar.gz"
+checksum = "sha256:1271aa1d889ffe5b9d0ccdb51faabeb60bf27859a5e9401d47f9eead4644991c"
+
+[[artifacts]]
+version = "10.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.4.0/node-v10.4.0-linux-arm64.tar.gz"
+checksum = "sha256:e54af0d3046c45fa45ce3f207a8f652969489c17b8328110e626aab19d8ab430"
+
+[[artifacts]]
+version = "10.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.4.0/node-v10.4.0-linux-x64.tar.gz"
+checksum = "sha256:cc237ba4bf23dc351d22972983d934a5775a6380792db000045fcd834de32ac9"
+
+[[artifacts]]
+version = "10.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.3.0/node-v10.3.0-linux-arm64.tar.gz"
+checksum = "sha256:a4e8be9d186e6f0506088bf5121c1d0fb72b5d9eb5add6a75b466c140d6eb476"
+
+[[artifacts]]
+version = "10.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.3.0/node-v10.3.0-linux-x64.tar.gz"
+checksum = "sha256:b9565d47f5cb95c9d01133b4266a3717f0ee7d3ccaff6d53275462eab40413f2"
+
+[[artifacts]]
+version = "10.2.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.2.1/node-v10.2.1-linux-arm64.tar.gz"
+checksum = "sha256:2af75c6f14f27b1ff8d5c4f31f380a1be7f22cf56577826a1cc40178c7d4e4ea"
+
+[[artifacts]]
+version = "10.2.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.2.1/node-v10.2.1-linux-x64.tar.gz"
+checksum = "sha256:497ecb2705d2171dbc235dbd2246bb2608e75c15fb120aa4c57a73aee6440f2b"
+
+[[artifacts]]
+version = "10.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.2.0/node-v10.2.0-linux-arm64.tar.gz"
+checksum = "sha256:77a9e159c303faa12c85a0cffd3cf8a3a1134ef781a7bc52787f49e97116540f"
+
+[[artifacts]]
+version = "10.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.2.0/node-v10.2.0-linux-x64.tar.gz"
+checksum = "sha256:75195a61d029819ad9ce77cbb13d3a29362c07cf73f2dc52da8a3f14839554cb"
+
+[[artifacts]]
+version = "10.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.1.0/node-v10.1.0-linux-arm64.tar.gz"
+checksum = "sha256:62c395fd3ffca1671dd0b7a84e7250485e484e7d62f9be13fd45879e9ef45290"
+
+[[artifacts]]
+version = "10.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.1.0/node-v10.1.0-linux-x64.tar.gz"
+checksum = "sha256:a750eaa8dd2abf175216377da86ed24d1265597b86c542fcf9cdf7b8043e006e"
+
+[[artifacts]]
+version = "10.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v10.0.0/node-v10.0.0-linux-arm64.tar.gz"
+checksum = "sha256:36adc17e9cceab32179d3314da9cb9c737ffb11f0de4e688f407ad6d9ca32201"
+
+[[artifacts]]
+version = "10.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v10.0.0/node-v10.0.0-linux-x64.tar.gz"
+checksum = "sha256:763a7b03ba2a3db56f3f59d104e7283161979b36e36479dc7bf68f6a471b2e33"
+
+[[artifacts]]
+version = "9.11.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.11.2/node-v9.11.2-linux-arm64.tar.gz"
+checksum = "sha256:78f600a8690ae34aac8079142c77bb0f0f09c6ddea2272b9a135285610ad71d1"
+
+[[artifacts]]
+version = "9.11.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.11.2/node-v9.11.2-linux-x64.tar.gz"
+checksum = "sha256:bbb46f86c64abe96ee98faa733424fc76f20a38d12f59bdcd60057efa5f1ce89"
+
+[[artifacts]]
+version = "9.11.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.11.1/node-v9.11.1-linux-arm64.tar.gz"
+checksum = "sha256:2284e7cb3a50f39b3e673c6ac91856279a0f7c1ea66fa4628954d124eebfd8b6"
+
+[[artifacts]]
+version = "9.11.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.11.1/node-v9.11.1-linux-x64.tar.gz"
+checksum = "sha256:ba7b97e116cbdc80676fca0f1e7a38ffa259f1c175970a97fc42df0fdc053078"
+
+[[artifacts]]
+version = "9.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.11.0/node-v9.11.0-linux-arm64.tar.gz"
+checksum = "sha256:5fe73dc5951c8400dcde594a8cc35068bee2933f2902760c0ad49fe6ec1cbca2"
+
+[[artifacts]]
+version = "9.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.11.0/node-v9.11.0-linux-x64.tar.gz"
+checksum = "sha256:c6208bc9e74b67369192b329ae48915541dc6144bbb39e53551b81ef7cbe73b4"
+
+[[artifacts]]
+version = "9.10.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.10.1/node-v9.10.1-linux-arm64.tar.gz"
+checksum = "sha256:aa8d1141808b1178b50c472726f0f278fba41b7b8a3230bc09c952bd648495cc"
+
+[[artifacts]]
+version = "9.10.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.10.1/node-v9.10.1-linux-x64.tar.gz"
+checksum = "sha256:43242c84ec4c266b986c51fa00c28ad8f3eb7740a9894d39e63a83196ed5b291"
+
+[[artifacts]]
+version = "9.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.10.0/node-v9.10.0-linux-arm64.tar.gz"
+checksum = "sha256:2ff3351616e58d1355b643f6013cb45b30bf84aad523de05cdbf01d6c7b68e30"
+
+[[artifacts]]
+version = "9.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.10.0/node-v9.10.0-linux-x64.tar.gz"
+checksum = "sha256:21a69c0f0181ec451444739d5c2f1df27cb96e7f328461dfa658e65846dc99ef"
+
+[[artifacts]]
+version = "9.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.9.0/node-v9.9.0-linux-arm64.tar.gz"
+checksum = "sha256:ebc0f4cc33fb8ee11c9d6d8bca6962aabe3ae4c88207b301ca4a692726e9e125"
+
+[[artifacts]]
+version = "9.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.9.0/node-v9.9.0-linux-x64.tar.gz"
+checksum = "sha256:887cb4db6207f303b5ba15b6e15298f19d288fce2064e8caa7bb7cae170cbe85"
+
+[[artifacts]]
+version = "9.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.8.0/node-v9.8.0-linux-arm64.tar.gz"
+checksum = "sha256:2999cfe889aa75aaf0b98fdcb90ebfc32cf55fcafe6149264b302a67394964a7"
+
+[[artifacts]]
+version = "9.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.8.0/node-v9.8.0-linux-x64.tar.gz"
+checksum = "sha256:4e519de3507f810b6567d995169c4b36f433bf5731340ebc1fbbd0b6b6e6c310"
+
+[[artifacts]]
+version = "9.7.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.7.1/node-v9.7.1-linux-arm64.tar.gz"
+checksum = "sha256:efd375f4b6b30429e7efb404a608e83f6022a02770a96f3a4124465304742fe8"
+
+[[artifacts]]
+version = "9.7.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.7.1/node-v9.7.1-linux-x64.tar.gz"
+checksum = "sha256:3c075a25db6a5280ddd7d0edc6958a78597fa2ee9471eafca66cd1c6d5620ec5"
+
+[[artifacts]]
+version = "9.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.7.0/node-v9.7.0-linux-arm64.tar.gz"
+checksum = "sha256:036d7113d7cab9cfc7543bf675676bf2144b477d52f6b1d9c38bf1696d54e49c"
+
+[[artifacts]]
+version = "9.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.7.0/node-v9.7.0-linux-x64.tar.gz"
+checksum = "sha256:c490ef08cfcf048229ccd99b17fe7fcd2b3d6e063ac9de4f14b603914ad6dbe0"
+
+[[artifacts]]
+version = "9.6.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.6.1/node-v9.6.1-linux-arm64.tar.gz"
+checksum = "sha256:b97dc8ebf084dea630b876e96e6838f735dd412a4b56c501c9c1e56ecfe9946c"
+
+[[artifacts]]
+version = "9.6.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.6.1/node-v9.6.1-linux-x64.tar.gz"
+checksum = "sha256:fe9417e39248928e48a0db3befc7b65534998a8117faa4713970f5a156af286c"
+
+[[artifacts]]
+version = "9.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.6.0/node-v9.6.0-linux-arm64.tar.gz"
+checksum = "sha256:8a96c6facbf9ddbd840e5d34664c5cd2835dbd4081fda4dba8a818c1766410ca"
+
+[[artifacts]]
+version = "9.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.6.0/node-v9.6.0-linux-x64.tar.gz"
+checksum = "sha256:90628529c45623b312dde6b4dfdd18dc7f94fcc0e4db9cbd21b5d5f2fa80c005"
+
+[[artifacts]]
+version = "9.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.5.0/node-v9.5.0-linux-arm64.tar.gz"
+checksum = "sha256:08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617"
+
+[[artifacts]]
+version = "9.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.5.0/node-v9.5.0-linux-x64.tar.gz"
+checksum = "sha256:1002312e51cc8dcae788962d1971355f559bfbf7caef36cafda84339c0cd3dc6"
+
+[[artifacts]]
+version = "9.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.4.0/node-v9.4.0-linux-arm64.tar.gz"
+checksum = "sha256:a0d4ac74d607b58755848e871a86ae76ae69cb75f56fa77b3c26fec34db781eb"
+
+[[artifacts]]
+version = "9.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.4.0/node-v9.4.0-linux-x64.tar.gz"
+checksum = "sha256:ca0dc28e45f300c10a0a75dee65439f50014ed710550f2d1246891503627a278"
+
+[[artifacts]]
+version = "9.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.3.0/node-v9.3.0-linux-arm64.tar.gz"
+checksum = "sha256:7b11f47f695d3be97b5b69c6546b7af005f9b66f093bda497310546e2dd5605c"
+
+[[artifacts]]
+version = "9.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.3.0/node-v9.3.0-linux-x64.tar.gz"
+checksum = "sha256:c7e86cc0e01102ce3eaff0e8e9d8ed8d046aa5bae2464bd80efb233c8720322a"
+
+[[artifacts]]
+version = "9.2.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.2.1/node-v9.2.1-linux-arm64.tar.gz"
+checksum = "sha256:6731cc1cae080f98f0cace9922b1d019d63b3eed10aa99e8eec52fdda01432b0"
+
+[[artifacts]]
+version = "9.2.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.2.1/node-v9.2.1-linux-x64.tar.gz"
+checksum = "sha256:b8507b17277b1582320667605acde79a00a2a947182db2db9614ae0917235686"
+
+[[artifacts]]
+version = "9.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.2.0/node-v9.2.0-linux-arm64.tar.gz"
+checksum = "sha256:39c2e7a40fcf219d322232c1fe86e6db6eb45361969fb9a2314abbe494207d33"
+
+[[artifacts]]
+version = "9.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.2.0/node-v9.2.0-linux-x64.tar.gz"
+checksum = "sha256:36ef2b3d1a99555390835d6fd4ad194a769df6841cbcc46cba0dffbaf6e6aa34"
+
+[[artifacts]]
+version = "9.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.1.0/node-v9.1.0-linux-arm64.tar.gz"
+checksum = "sha256:fa28790ec02834a41dda046fed64edce8551b0ee488d2c74dc7e018475fff831"
+
+[[artifacts]]
+version = "9.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.1.0/node-v9.1.0-linux-x64.tar.gz"
+checksum = "sha256:5a05b32e677c6d5c2e85df30663aa1898aa8fe45ac6b797554069c97b9a5d228"
+
+[[artifacts]]
+version = "9.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v9.0.0/node-v9.0.0-linux-arm64.tar.gz"
+checksum = "sha256:c866c8e67f0f3f9be7e7195c6109cda4cf5a91fdd5e881920557b70924521034"
+
+[[artifacts]]
+version = "9.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v9.0.0/node-v9.0.0-linux-x64.tar.gz"
+checksum = "sha256:9bd9ef8c2df8dc0a2cd66cdbb7b6a1c62a12912efd9218e307ce63db871b813d"
+
+[[artifacts]]
 version = "8.17.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v8.17.0-linux-x64.tar.gz"
-etag = "6218e59c4e3632a4b4eae5214aceeb08"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.17.0/node-v8.17.0-linux-arm64.tar.gz"
+checksum = "sha256:a01ac6b731f78a65de73ac8b750cb945c1fd7b5465cddd1c72453c020b703ff3"
 
+[[artifacts]]
+version = "8.17.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.17.0/node-v8.17.0-linux-x64.tar.gz"
+checksum = "sha256:8b2c9e1f84317c4b02736c4c50db4dd2cd6c4f0ba910fa81f887c8c9294af596"
+
+[[artifacts]]
+version = "8.16.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.16.2/node-v8.16.2-linux-arm64.tar.gz"
+checksum = "sha256:19b8c246dd12840ee6a94c89df683f853ed91cbbf6a133820fb163181d77202d"
+
+[[artifacts]]
+version = "8.16.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.16.2/node-v8.16.2-linux-x64.tar.gz"
+checksum = "sha256:722d07291a8886384388c6795a747ec2055073f83dc73c0a97efba0022cc23ff"
+
+[[artifacts]]
+version = "8.16.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.16.1/node-v8.16.1-linux-arm64.tar.gz"
+checksum = "sha256:880cdfba7072398b2f7ca84474d3a689a9325182b866e6705f04f1cde10fea94"
+
+[[artifacts]]
+version = "8.16.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.16.1/node-v8.16.1-linux-x64.tar.gz"
+checksum = "sha256:8ef575b64edbb6c04e506d8c8e0c5f92b90f4752841892c5adbb3a1e02863f46"
+
+[[artifacts]]
+version = "8.16.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.16.0/node-v8.16.0-linux-arm64.tar.gz"
+checksum = "sha256:c0678bc942efe04805e229b557a5b4f82671f05f3325cc33d7c6ea2531d3ce96"
+
+[[artifacts]]
+version = "8.16.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.16.0/node-v8.16.0-linux-x64.tar.gz"
+checksum = "sha256:b391450e0fead11f61f119ed26c713180cfe64b363cd945bac229130dfab64fa"
+
+[[artifacts]]
+version = "8.15.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.15.1/node-v8.15.1-linux-arm64.tar.gz"
+checksum = "sha256:0fcb30bc508097c0a13e7001a55f410802eda155c070cd5d125cd321332cc9f1"
+
+[[artifacts]]
+version = "8.15.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.15.1/node-v8.15.1-linux-x64.tar.gz"
+checksum = "sha256:16e203f2440cffe90522f1e1855d5d7e2e658e759057db070a3dafda445d6d1f"
+
+[[artifacts]]
+version = "8.15.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.15.0/node-v8.15.0-linux-arm64.tar.gz"
+checksum = "sha256:02ce5c6551c0252c74b12c217d4e4f331147dc605990d6bbfb2fa247f356b5b0"
+
+[[artifacts]]
+version = "8.15.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.15.0/node-v8.15.0-linux-x64.tar.gz"
+checksum = "sha256:dc004e5c0f39c6534232a73100c194bc1446f25e3a6a39b29e2000bb3d139d52"
+
+[[artifacts]]
+version = "8.14.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.14.1/node-v8.14.1-linux-arm64.tar.gz"
+checksum = "sha256:a1b2747be945637ae2155f4b7118a06206f0e9245762142f965d1b34a50e25c7"
+
+[[artifacts]]
+version = "8.14.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.14.1/node-v8.14.1-linux-x64.tar.gz"
+checksum = "sha256:ae9b04e0ad806dc31242ca02b84a84ea67c978e41f60d94ffca010ed3fe32735"
+
+[[artifacts]]
+version = "8.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.14.0/node-v8.14.0-linux-arm64.tar.gz"
+checksum = "sha256:ce522ad9331428195899ff3f94d23592aadc7d7752eaee0bf35607fa6df24501"
+
+[[artifacts]]
+version = "8.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.14.0/node-v8.14.0-linux-x64.tar.gz"
+checksum = "sha256:bbf81603a924bf86c64da520f6b2a923e6f78e987bb36a58bdb8ff2606d7f995"
+
+[[artifacts]]
+version = "8.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.13.0/node-v8.13.0-linux-arm64.tar.gz"
+checksum = "sha256:ef3fe95d79ced4882b7bf2d94cf05186fdf352e752598d94747bcbbe49877ed8"
+
+[[artifacts]]
+version = "8.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.13.0/node-v8.13.0-linux-x64.tar.gz"
+checksum = "sha256:0c5ff3e3223cd1aaa6ca4aad30fb7c94596422d5c1a4dcc4b1a5b4e118a00273"
+
+[[artifacts]]
+version = "8.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.12.0/node-v8.12.0-linux-arm64.tar.gz"
+checksum = "sha256:781ecf1ecb14b4c671ef0732988636282d6fb7071c4bd52567f663b008796bc9"
+
+[[artifacts]]
+version = "8.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.12.0/node-v8.12.0-linux-x64.tar.gz"
+checksum = "sha256:3df19b748ee2b6dfe3a03448ebc6186a3a86aeab557018d77a0f7f3314594ef6"
+
+[[artifacts]]
+version = "8.11.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.11.4/node-v8.11.4-linux-arm64.tar.gz"
+checksum = "sha256:667b9935e9aab43cd0eab492ec15a0330797cb261ab2df4e18e5a9548817a1c6"
+
+[[artifacts]]
+version = "8.11.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.11.4/node-v8.11.4-linux-x64.tar.gz"
+checksum = "sha256:c69abe770f002a7415bd00f7ea13b086650c1dd925ef0c3bf8de90eabecc8790"
+
+[[artifacts]]
+version = "8.11.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.11.3/node-v8.11.3-linux-arm64.tar.gz"
+checksum = "sha256:27bbee0710a798f61fab945dc22d4680926d0a679e293f285ff06bb86142b086"
+
+[[artifacts]]
+version = "8.11.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.11.3/node-v8.11.3-linux-x64.tar.gz"
+checksum = "sha256:1ea408e9a467ed4571730e160993f67a100e8c347f6f9891c9a83350df2bf2be"
+
+[[artifacts]]
+version = "8.11.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.11.2/node-v8.11.2-linux-arm64.tar.gz"
+checksum = "sha256:8b376554ea7dc4ae3e2bfbd407b45ee4f978c199b1764430a40802dd6019d882"
+
+[[artifacts]]
+version = "8.11.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.11.2/node-v8.11.2-linux-x64.tar.gz"
+checksum = "sha256:67dc4c06a58d4b23c5378325ad7e0a2ec482b48cea802252b99ebe8538a3ab79"
+
+[[artifacts]]
+version = "8.11.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.11.1/node-v8.11.1-linux-arm64.tar.gz"
+checksum = "sha256:68546c94a730a8d546e37a9bbae919f4a0f864220ce3aa160461a4f3e779a6af"
+
+[[artifacts]]
+version = "8.11.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.11.1/node-v8.11.1-linux-x64.tar.gz"
+checksum = "sha256:0e20787e2eda4cc31336d8327556ebc7417e8ee0a6ba0de96a09b0ec2b841f60"
+
+[[artifacts]]
+version = "8.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.11.0/node-v8.11.0-linux-arm64.tar.gz"
+checksum = "sha256:2241f9eef968308fc4e25662ed49faf9fa1aa5dd513400197c2a15f3494b3388"
+
+[[artifacts]]
+version = "8.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.11.0/node-v8.11.0-linux-x64.tar.gz"
+checksum = "sha256:93ab3ee41ac0731497e1c0fdd3de587dd7fa9e80b149d48c385b7756c9b3bb36"
+
+[[artifacts]]
+version = "8.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.10.0/node-v8.10.0-linux-arm64.tar.gz"
+checksum = "sha256:0776fd38fec6e739c9b4ae18dbdabd09a763b1b6fb7deb12ea2863046350d6a9"
+
+[[artifacts]]
+version = "8.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.10.0/node-v8.10.0-linux-x64.tar.gz"
+checksum = "sha256:c1302439aee9791d70d3ab4194a612e6131d37fa0e3452072e847e212ed77867"
+
+[[artifacts]]
+version = "8.9.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.9.4/node-v8.9.4-linux-arm64.tar.gz"
+checksum = "sha256:2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65"
+
+[[artifacts]]
+version = "8.9.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.9.4/node-v8.9.4-linux-x64.tar.gz"
+checksum = "sha256:21fb4690e349f82d708ae766def01d7fec1b085ce1f5ab30d9bda8ee126ca8fc"
+
+[[artifacts]]
+version = "8.9.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.9.3/node-v8.9.3-linux-arm64.tar.gz"
+checksum = "sha256:df32e87060f5426fc6c6b1af8e3e130ae08ee36f570ac3728442c7833e53d7c3"
+
+[[artifacts]]
+version = "8.9.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.9.3/node-v8.9.3-linux-x64.tar.gz"
+checksum = "sha256:df3f1480dddb27ba5ca72bcaae48cb1a4446f341648c87338979fff35eb9fb27"
+
+[[artifacts]]
+version = "8.9.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.9.2/node-v8.9.2-linux-arm64.tar.gz"
+checksum = "sha256:1aaadf2e0a44bd49dbf528fb918032dcdbc3b450dc91e8cbd92b28afbb1e004a"
+
+[[artifacts]]
+version = "8.9.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.9.2/node-v8.9.2-linux-x64.tar.gz"
+checksum = "sha256:bb649307300622133dbf147f24e1e695d7570f1b265c6fd2c1e36406226d1e88"
+
+[[artifacts]]
+version = "8.9.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.9.1/node-v8.9.1-linux-arm64.tar.gz"
+checksum = "sha256:47521340ff82617c1e6ba63ce300685e1b8b7cf5c0ec2e71628bcdb398085b29"
+
+[[artifacts]]
+version = "8.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.9.1/node-v8.9.1-linux-x64.tar.gz"
+checksum = "sha256:0e49da19cdf4c89b52656e858346775af21f1953c308efbc803b665d6069c15c"
+
+[[artifacts]]
+version = "8.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.9.0/node-v8.9.0-linux-arm64.tar.gz"
+checksum = "sha256:468af2d1936cc9daca02949774680a0d1fd24b6169561598bae71a0bc90c5c3d"
+
+[[artifacts]]
+version = "8.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.9.0/node-v8.9.0-linux-x64.tar.gz"
+checksum = "sha256:34b544cdda86bcc201568822fd20c1eaf8dadc53227f928cbfc45865677db7f6"
+
+[[artifacts]]
+version = "8.8.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.8.1/node-v8.8.1-linux-arm64.tar.gz"
+checksum = "sha256:bfd5293f23f51601decb3521a8fdc62fbc6633d6eab9d8c3f406cdd7da68fb96"
+
+[[artifacts]]
+version = "8.8.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.8.1/node-v8.8.1-linux-x64.tar.gz"
+checksum = "sha256:df83beb05af3e7aee4d16b74dd6d05967f47ee4ab6d6789ca0ed7f2b22c22c92"
+
+[[artifacts]]
+version = "8.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.8.0/node-v8.8.0-linux-arm64.tar.gz"
+checksum = "sha256:58bb50e792f60651f48b26a9e7e68bd10f51ecc254a2be6ea759f26ebe6b1a21"
+
+[[artifacts]]
+version = "8.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.8.0/node-v8.8.0-linux-x64.tar.gz"
+checksum = "sha256:3d988ec9d7e50a030b5aa3f36840a6d37219ff0f5bcd7da255dc9475e7d99813"
+
+[[artifacts]]
+version = "8.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.7.0/node-v8.7.0-linux-arm64.tar.gz"
+checksum = "sha256:e60bd4b3082e2f75d16bd23654f21e2c4652e180273d7e9c836528c26dee2e40"
+
+[[artifacts]]
+version = "8.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.7.0/node-v8.7.0-linux-x64.tar.gz"
+checksum = "sha256:115c7bd133170fd7a1bf408b2e293021e4b5a80a66a4962829ce5d362ce43762"
+
+[[artifacts]]
+version = "8.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.6.0/node-v8.6.0-linux-arm64.tar.gz"
+checksum = "sha256:f5e9ca49e8f8c10f7f583c829191cbfab53216f5b5b6ec158b5eeb749d7079a2"
+
+[[artifacts]]
+version = "8.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.6.0/node-v8.6.0-linux-x64.tar.gz"
+checksum = "sha256:86d06a2ae2763cb68b17d77c889fa5d49975c653a85f3c4517bdbecdec165fbb"
+
+[[artifacts]]
+version = "8.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.5.0/node-v8.5.0-linux-arm64.tar.gz"
+checksum = "sha256:09004f9cc8039918e48ce846173dbd37e8673c9a6ada34bdb2e073534c70c9af"
+
+[[artifacts]]
+version = "8.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.5.0/node-v8.5.0-linux-x64.tar.gz"
+checksum = "sha256:0000710235e04553147b9c18deadc7cefa4297d4dce190de94cc625d2cf6b9ba"
+
+[[artifacts]]
+version = "8.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.4.0/node-v8.4.0-linux-arm64.tar.gz"
+checksum = "sha256:a85225930dadf0b8161f95fe7e0e81e8840a8e20623cb5a7b5c61fced10ed7f0"
+
+[[artifacts]]
+version = "8.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.4.0/node-v8.4.0-linux-x64.tar.gz"
+checksum = "sha256:d12bf2389a6b57341528a33de62561edd7ef25c23fbf258d48758fbe3d1d8578"
+
+[[artifacts]]
+version = "8.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.3.0/node-v8.3.0-linux-arm64.tar.gz"
+checksum = "sha256:508dfca5031aa8929ce22bfd43514ccbdbcf65623634a9973e51973e37f451b3"
+
+[[artifacts]]
+version = "8.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.3.0/node-v8.3.0-linux-x64.tar.gz"
+checksum = "sha256:b8dd14b3576681e8071ee59e5e1e8ac77e7ca335c12d7f584d9ab083e1fd4fd5"
+
+[[artifacts]]
+version = "8.2.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.2.1/node-v8.2.1-linux-arm64.tar.gz"
+checksum = "sha256:914a031d02cbf759238fa1c051bc21739abfa15572eae77c03cc34c37031b3ef"
+
+[[artifacts]]
+version = "8.2.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.2.1/node-v8.2.1-linux-x64.tar.gz"
+checksum = "sha256:c082cf6e7011d4222d476c86421ae6a656d7d34d3d34133260e19a7718de88c9"
+
+[[artifacts]]
+version = "8.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.2.0/node-v8.2.0-linux-arm64.tar.gz"
+checksum = "sha256:87c7d40bbf374c2d5f17804a8a1158e171e1cec97bb040def6cd1c27ba16b79a"
+
+[[artifacts]]
+version = "8.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.2.0/node-v8.2.0-linux-x64.tar.gz"
+checksum = "sha256:efffb62d6c595aed358fa01eafe122031269e4f3248c093d4b5bc5b01cdc2f54"
+
+[[artifacts]]
+version = "8.1.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.1.4/node-v8.1.4-linux-arm64.tar.gz"
+checksum = "sha256:fdbed111bb66c603c0b41dbcab2db1cb16c569acfb3da28325896084b4b3c165"
+
+[[artifacts]]
+version = "8.1.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.1.4/node-v8.1.4-linux-x64.tar.gz"
+checksum = "sha256:618f1a4eabc67de7372b68427c925274ba6b54c3951235077bca5d7e1d87e422"
+
+[[artifacts]]
+version = "8.1.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.1.3/node-v8.1.3-linux-arm64.tar.gz"
+checksum = "sha256:5a7837cc31f2d2e0a8db081f5cb856276a6da3bb7b7cae364a36918763816ced"
+
+[[artifacts]]
+version = "8.1.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.1.3/node-v8.1.3-linux-x64.tar.gz"
+checksum = "sha256:1a526c56fb0fe0f4e91892874d89be2c8920a9d51eb6ed8bd68f66162b7a6b9e"
+
+[[artifacts]]
+version = "8.1.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.1.2/node-v8.1.2-linux-arm64.tar.gz"
+checksum = "sha256:555f826cc3507462ce8f4b0f42301dd43ac9ec1640af99ab73c302945d45be18"
+
+[[artifacts]]
+version = "8.1.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.1.2/node-v8.1.2-linux-x64.tar.gz"
+checksum = "sha256:73b116238dd930efbed7c2f6ba24c5c04f27223fcc44d1d35305e22d70c4bb87"
+
+[[artifacts]]
+version = "8.1.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.1.1/node-v8.1.1-linux-arm64.tar.gz"
+checksum = "sha256:69cc375ef84ea79736b491ff779e8ed07359cf27c943dcae41292094e0b0b79f"
+
+[[artifacts]]
+version = "8.1.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.1.1/node-v8.1.1-linux-x64.tar.gz"
+checksum = "sha256:7717495688c8e332b916cfc51fdb4773d468018ccd0b104ae524ae5050426d4d"
+
+[[artifacts]]
+version = "8.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.1.0/node-v8.1.0-linux-arm64.tar.gz"
+checksum = "sha256:33c09d04b5e2637feda241e1c727b10249ed7114ad7807f8b70cbd8414747649"
+
+[[artifacts]]
+version = "8.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.1.0/node-v8.1.0-linux-x64.tar.gz"
+checksum = "sha256:b53d6ad443f970d62a61d927bd28d63dcd2e19520e6e767bc6cc44f2cd8a4885"
+
+[[artifacts]]
+version = "8.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v8.0.0/node-v8.0.0-linux-arm64.tar.gz"
+checksum = "sha256:ee10913aa14e1c22fe3567b957d1e77a47905f78812976a7b4199d33984e871b"
+
+[[artifacts]]
+version = "8.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v8.0.0/node-v8.0.0-linux-x64.tar.gz"
+checksum = "sha256:1944f0ead4c9dbdf92a97041cb2ec34cc08ea873958c7009befaa56a7ccea4c2"
+
+[[artifacts]]
+version = "7.10.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.10.1/node-v7.10.1-linux-arm64.tar.gz"
+checksum = "sha256:157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920"
+
+[[artifacts]]
+version = "7.10.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.10.1/node-v7.10.1-linux-x64.tar.gz"
+checksum = "sha256:3e3609a836257eb9be9b6425fc398239ed023f11aacbbea12fb4d291cf64a196"
+
+[[artifacts]]
+version = "7.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.10.0/node-v7.10.0-linux-arm64.tar.gz"
+checksum = "sha256:62566c5c588d86942a076c596bfc504c337ba0db9ac4e6e6bbff3ed15e2ad404"
+
+[[artifacts]]
+version = "7.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.10.0/node-v7.10.0-linux-x64.tar.gz"
+checksum = "sha256:9da0e99091897795491d21d58c40186f75ca7bf505d145d1a2e558f8c754a81b"
+
+[[artifacts]]
+version = "7.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.9.0/node-v7.9.0-linux-arm64.tar.gz"
+checksum = "sha256:97a4fdf9bdce13e6ff42109ac75564b480586203dbd9c621fa801f53db94484d"
+
+[[artifacts]]
+version = "7.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.9.0/node-v7.9.0-linux-x64.tar.gz"
+checksum = "sha256:62b35635c648befde8bf534b6086f7416b8c1a3ac0ff8a99c2d6773722829a0e"
+
+[[artifacts]]
+version = "7.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.8.0/node-v7.8.0-linux-arm64.tar.gz"
+checksum = "sha256:513ffbd9abc1c1c9de0ae2d872f5483c45f055989b0e697913e7963f15d26fee"
+
+[[artifacts]]
+version = "7.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.8.0/node-v7.8.0-linux-x64.tar.gz"
+checksum = "sha256:0bd86f2a39221b532172c7d1acb57f0b0cba88c7b82ea74ba9d1208b9f6f9697"
+
+[[artifacts]]
+version = "7.7.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.7.4/node-v7.7.4-linux-arm64.tar.gz"
+checksum = "sha256:3c56a567f42a8a409b505459acae5c3dbd08daa8c8f8da71876a4511f55f57a9"
+
+[[artifacts]]
+version = "7.7.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.7.4/node-v7.7.4-linux-x64.tar.gz"
+checksum = "sha256:419dab870cb5c5bff95a08d7ef90a07717457e9a0eba8efff72d6ff6b91a01cb"
+
+[[artifacts]]
+version = "7.7.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.7.3/node-v7.7.3-linux-arm64.tar.gz"
+checksum = "sha256:e4c65c664ff074a6ddd07ffc41ac0fe01b421a31164713d668ebb46519b04c88"
+
+[[artifacts]]
+version = "7.7.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.7.3/node-v7.7.3-linux-x64.tar.gz"
+checksum = "sha256:e53409d3104eaa4a9129dce043b3c2f9c4dceb85ab0ca7ebeaf7ee1385abc875"
+
+[[artifacts]]
+version = "7.7.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.7.2/node-v7.7.2-linux-arm64.tar.gz"
+checksum = "sha256:586f012550d7c7c415267656477648d38595af75f9a4218000fece98e01c4a65"
+
+[[artifacts]]
+version = "7.7.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.7.2/node-v7.7.2-linux-x64.tar.gz"
+checksum = "sha256:ecd653c9bfb1f95f12135b20ddfe5cdbc203e7a329ca82b6f7b35b6154836c66"
+
+[[artifacts]]
+version = "7.7.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.7.1/node-v7.7.1-linux-arm64.tar.gz"
+checksum = "sha256:3eb8d507eaa4ea1e01b863d95c268e0d55b780563696867d682adbad968cc18e"
+
+[[artifacts]]
+version = "7.7.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.7.1/node-v7.7.1-linux-x64.tar.gz"
+checksum = "sha256:26524c315f20062d625410357415e1b5069cabedfe51ebb3a0c7ad5d01420068"
+
+[[artifacts]]
+version = "7.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.7.0/node-v7.7.0-linux-arm64.tar.gz"
+checksum = "sha256:339a9e9602114a84420bcb0b732cf2ce0a76b983f6f1569808a5c5668911441e"
+
+[[artifacts]]
+version = "7.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.7.0/node-v7.7.0-linux-x64.tar.gz"
+checksum = "sha256:67c21170ed0a19da6f859666510ebc19b24f79a1f6b4acc5fc0d7af233d5dab3"
+
+[[artifacts]]
+version = "7.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.6.0/node-v7.6.0-linux-arm64.tar.gz"
+checksum = "sha256:5d45b0990200431d95696db51094198eeb6a90bdcbd38c317e8fe420d63552d9"
+
+[[artifacts]]
+version = "7.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.6.0/node-v7.6.0-linux-x64.tar.gz"
+checksum = "sha256:0a8da7b260a93dae7c43a6f49b81fed5a3c19689feee67ce711e85b5a218b44e"
+
+[[artifacts]]
+version = "7.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.5.0/node-v7.5.0-linux-arm64.tar.gz"
+checksum = "sha256:101e89fd4547569bbc4bcf1081bf6bb6c8410bdfe913ffbf35f25789eda9bca9"
+
+[[artifacts]]
+version = "7.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.5.0/node-v7.5.0-linux-x64.tar.gz"
+checksum = "sha256:901cc6ef6a12e6807d21090868b16bd41df3e9c41a92065bd0dfea1ef1a35730"
+
+[[artifacts]]
+version = "7.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.4.0/node-v7.4.0-linux-arm64.tar.gz"
+checksum = "sha256:0de18242da7e54a0e69673b58b39268141309937998a9ab3c2c0453fb988b3d7"
+
+[[artifacts]]
+version = "7.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.4.0/node-v7.4.0-linux-x64.tar.gz"
+checksum = "sha256:8f663492bd288c8f8d978fad61ac412ea648476e2223346a7326180d937171fa"
+
+[[artifacts]]
+version = "7.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.3.0/node-v7.3.0-linux-arm64.tar.gz"
+checksum = "sha256:b7187533653eafbbb791fd911afecf0e025a9c62d5a8433a929fb0ebe420ca97"
+
+[[artifacts]]
+version = "7.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.3.0/node-v7.3.0-linux-x64.tar.gz"
+checksum = "sha256:0c1bb08c574c8d0e7e9ecd6b43d3ae2c069eaea45a5dea54a31d87cc1c0a1eee"
+
+[[artifacts]]
+version = "7.2.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.2.1/node-v7.2.1-linux-arm64.tar.gz"
+checksum = "sha256:bd9639fd159ae8c93b9ecfb50412f35aaefd46fa9111fd661f80a0e0203edcdc"
+
+[[artifacts]]
+version = "7.2.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.2.1/node-v7.2.1-linux-x64.tar.gz"
+checksum = "sha256:661b26736bd5a63df632d47a54c7ca9004f7e7a0603e635571335c54529d0241"
+
+[[artifacts]]
+version = "7.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.2.0/node-v7.2.0-linux-arm64.tar.gz"
+checksum = "sha256:679e6b0ef4b8286eaa698bf1db21a66ec7d930dfa505badd8b38253d13e865b1"
+
+[[artifacts]]
+version = "7.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.2.0/node-v7.2.0-linux-x64.tar.gz"
+checksum = "sha256:f3b8451924b36e289a7113ad42fa36bb95d0dd471fed3e2e6822caad3ee871e6"
+
+[[artifacts]]
+version = "7.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.1.0/node-v7.1.0-linux-arm64.tar.gz"
+checksum = "sha256:fcaa2281b2ea4e0a6b598fae4fbee3708aded5b1b0b2397f8fab18c13e3ea3be"
+
+[[artifacts]]
+version = "7.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.1.0/node-v7.1.0-linux-x64.tar.gz"
+checksum = "sha256:0d2f13477ba991950bd9938e38c8d943b9bf2e899adcd4a28e98532f029e9910"
+
+[[artifacts]]
+version = "7.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v7.0.0/node-v7.0.0-linux-arm64.tar.gz"
+checksum = "sha256:375e897d16956b80e6c7b298f17d5b6b4a3bac1a50b297575bd50f34ce4c612c"
+
+[[artifacts]]
+version = "7.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v7.0.0/node-v7.0.0-linux-x64.tar.gz"
+checksum = "sha256:4bc5ce31d2485f0b25e55bf8691d5dabf72c61f0c06b363728b70bfc0292ce7f"
+
+[[artifacts]]
+version = "6.17.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.17.1/node-v6.17.1-linux-arm64.tar.gz"
+checksum = "sha256:50b2d01026afc361925836ed4fa7ddd948d3102f1c2872a078fbce5ec7cceb8b"
+
+[[artifacts]]
+version = "6.17.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.17.1/node-v6.17.1-linux-x64.tar.gz"
+checksum = "sha256:6b2b0613f56e1630edcfc8e7800f87d5538cef09fce6a08f1cc35983181d96b2"
+
+[[artifacts]]
+version = "6.17.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.17.0/node-v6.17.0-linux-arm64.tar.gz"
+checksum = "sha256:443f7656c541ba66b4aa50a5fa81e34e38714851006194ed63fee9cf48936c73"
+
+[[artifacts]]
+version = "6.17.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.17.0/node-v6.17.0-linux-x64.tar.gz"
+checksum = "sha256:547422724489a5391d4a137cd130020c73f8f8c721754c67c7692003fe2b6015"
+
+[[artifacts]]
+version = "6.16.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.16.0/node-v6.16.0-linux-arm64.tar.gz"
+checksum = "sha256:6b94c3c0e807f5350f4e973cece77f373d637f7d7c3c24f90e583407beee916a"
+
+[[artifacts]]
+version = "6.16.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.16.0/node-v6.16.0-linux-x64.tar.gz"
+checksum = "sha256:7f26cd9a2845df23773755a428d61b74fd80d48a991e964d12e85ae90ced81a0"
+
+[[artifacts]]
+version = "6.15.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.15.1/node-v6.15.1-linux-arm64.tar.gz"
+checksum = "sha256:436bbf8467418afb8d505cbaf9203dba27103020f8289975d383c3e97872428d"
+
+[[artifacts]]
+version = "6.15.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.15.1/node-v6.15.1-linux-x64.tar.gz"
+checksum = "sha256:aa8ef47382853d7124110203c3773515cff00737f1cd7bce98bd388603141c6d"
+
+[[artifacts]]
+version = "6.15.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.15.0/node-v6.15.0-linux-arm64.tar.gz"
+checksum = "sha256:73653a567279be4b29f94f53f831cf886016ce200fd147d1c243838d4a96633d"
+
+[[artifacts]]
+version = "6.15.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.15.0/node-v6.15.0-linux-x64.tar.gz"
+checksum = "sha256:4ef04373b2005a55aeaff24bc896f2045951d1909e7c1ac38ba4d1e5c9e85626"
+
+[[artifacts]]
+version = "6.14.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.14.4/node-v6.14.4-linux-arm64.tar.gz"
+checksum = "sha256:08d5af19fb0abe879ee9a62a1243cb027acbedae1b4fa5498a6183cc458773ee"
+
+[[artifacts]]
+version = "6.14.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.14.4/node-v6.14.4-linux-x64.tar.gz"
+checksum = "sha256:1b80ddc7847e85ae31c5eb515ee76230fed1e2e70303a7db9891404a830128ba"
+
+[[artifacts]]
+version = "6.14.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.14.3/node-v6.14.3-linux-arm64.tar.gz"
+checksum = "sha256:07d516d5ba2dca3e66cc034338bd4a68c4c8d3b6c1976feb22c508543f9bffa0"
+
+[[artifacts]]
+version = "6.14.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.14.3/node-v6.14.3-linux-x64.tar.gz"
+checksum = "sha256:28fc7aaf900b8985fd1577b133889d1207505d0f7cf56aac147220a41a1da163"
+
+[[artifacts]]
+version = "6.14.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.14.2/node-v6.14.2-linux-arm64.tar.gz"
+checksum = "sha256:0208689114ad9cd52b02abc2edda2d36df74fb963e07a0ad05d5d54aaeae9cd3"
+
+[[artifacts]]
+version = "6.14.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.14.2/node-v6.14.2-linux-x64.tar.gz"
+checksum = "sha256:d96b8e43d035890dfd2145a71a95edc2b3ed58e56c5134666bd6a7e5f841d4c3"
+
+[[artifacts]]
+version = "6.14.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.14.1/node-v6.14.1-linux-arm64.tar.gz"
+checksum = "sha256:8f73b9a9a9816cc2b7f3b18947da0d644c6ea2c74c0e95101814e4e951a4f270"
+
+[[artifacts]]
+version = "6.14.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.14.1/node-v6.14.1-linux-x64.tar.gz"
+checksum = "sha256:f3d943fc6b16d86827bbe74e4fe243c2a9414f4bd04d9273aed58bb55f0906c8"
+
+[[artifacts]]
+version = "6.14.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.14.0/node-v6.14.0-linux-arm64.tar.gz"
+checksum = "sha256:8a3ff08a103b74bb25bce8ec549157945a4c800e02d1fa2a38e13665facbc834"
+
+[[artifacts]]
+version = "6.14.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.14.0/node-v6.14.0-linux-x64.tar.gz"
+checksum = "sha256:272bb9a1937a8372420a2bd98bea4d1c152b961c1b3fb3493f626a9de162d4bd"
+
+[[artifacts]]
+version = "6.13.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.13.1/node-v6.13.1-linux-arm64.tar.gz"
+checksum = "sha256:27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3"
+
+[[artifacts]]
+version = "6.13.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.13.1/node-v6.13.1-linux-x64.tar.gz"
+checksum = "sha256:b8eb262c8a0713da7c56736a7e28533303369dae8f0cbdbe901dd3c5f6a19829"
+
+[[artifacts]]
+version = "6.13.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.13.0/node-v6.13.0-linux-arm64.tar.gz"
+checksum = "sha256:c27cdca9a7d6bff7242c9e87f0ccd2c052f562409110173dcf0138006e4c331c"
+
+[[artifacts]]
+version = "6.13.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.13.0/node-v6.13.0-linux-x64.tar.gz"
+checksum = "sha256:467472d9adafd067588f2a20f9edcd7493d973fe107502c55d6fabfa0d3f91af"
+
+[[artifacts]]
+version = "6.12.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.12.3/node-v6.12.3-linux-arm64.tar.gz"
+checksum = "sha256:b25af85958456d64b4793dddc894701d5b0dfa74144dad444705e901d46480c1"
+
+[[artifacts]]
+version = "6.12.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.12.3/node-v6.12.3-linux-x64.tar.gz"
+checksum = "sha256:0f8144c84c4379cb35ae409779c062a65680cf163b52c4660932eb58cfa1d065"
+
+[[artifacts]]
+version = "6.12.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.12.2/node-v6.12.2-linux-arm64.tar.gz"
+checksum = "sha256:8a1aa367e8bdc95a56837b0e96620bd6f68fba56a1773607f3199bf191bdf1e7"
+
+[[artifacts]]
+version = "6.12.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.12.2/node-v6.12.2-linux-x64.tar.gz"
+checksum = "sha256:05c29ffd17a4d5e0c1c6d4a09244e43e7af7a70ec11e67eecbffdf5ec1e1b45a"
+
+[[artifacts]]
+version = "6.12.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.12.1/node-v6.12.1-linux-arm64.tar.gz"
+checksum = "sha256:6f88ed709061f55622beb07bcab40ce855eb6bc30fe77041269152d3cdaf0f6a"
+
+[[artifacts]]
+version = "6.12.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.12.1/node-v6.12.1-linux-x64.tar.gz"
+checksum = "sha256:0868c3e3b6a49500ae3185f80ab04b2526c88dbdb39b324b9d71870c62d1f785"
+
+[[artifacts]]
+version = "6.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.12.0/node-v6.12.0-linux-arm64.tar.gz"
+checksum = "sha256:64622078a1c61aff123de2c7d62c339a6a8e98d3d1ca58c0172e21539bc62387"
+
+[[artifacts]]
+version = "6.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.12.0/node-v6.12.0-linux-x64.tar.gz"
+checksum = "sha256:f011baf02e10e2d006a191501b21bb9bbd600f0fa6873783917bf8c5e5b037d1"
+
+[[artifacts]]
+version = "6.11.5"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.11.5/node-v6.11.5-linux-arm64.tar.gz"
+checksum = "sha256:b879b852c3588f3ce7d748273ede959306268e5b2ca199d76b4592c2fb4a0d43"
+
+[[artifacts]]
+version = "6.11.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.11.5/node-v6.11.5-linux-x64.tar.gz"
+checksum = "sha256:fffd25c9e9b6d2235e97ba8be1dd6ea5f31e32ea445c5cc704ca84ef44db66c1"
+
+[[artifacts]]
+version = "6.11.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.11.4/node-v6.11.4-linux-arm64.tar.gz"
+checksum = "sha256:a0942b7b2cd0e79c63fc9d5c6ae62863e0752b185769b71c6b54f5313dcb07b1"
+
+[[artifacts]]
+version = "6.11.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.11.4/node-v6.11.4-linux-x64.tar.gz"
+checksum = "sha256:31af453105ab3eaf0f266de083374a98c25e9bdc4c14a7d449e6a97e5814df0f"
+
+[[artifacts]]
+version = "6.11.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.11.3/node-v6.11.3-linux-arm64.tar.gz"
+checksum = "sha256:1a7712fa64989809a6949b08d449af00f93116ccc44e10789ea1615df806ca96"
+
+[[artifacts]]
+version = "6.11.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.11.3/node-v6.11.3-linux-x64.tar.gz"
+checksum = "sha256:610705d45eb2846a9e10690678a078d9159e5f941487aca20c6f53b33104358c"
+
+[[artifacts]]
+version = "6.11.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.11.2/node-v6.11.2-linux-arm64.tar.gz"
+checksum = "sha256:914465dd907d2d785a6cb2e166ada7ce1e070f212267ce88ba7a326fe549a076"
+
+[[artifacts]]
+version = "6.11.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.11.2/node-v6.11.2-linux-x64.tar.gz"
+checksum = "sha256:1ca74833ff79e6a3a713a88bba8e7f5f5cda5d4008a6ffeb2293a1bf98f83e04"
+
+[[artifacts]]
+version = "6.11.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.11.1/node-v6.11.1-linux-arm64.tar.gz"
+checksum = "sha256:f8c898c39ecc9806fd6b5a3b49f037fee3cfe823238b8c119b4f6f8b7869168e"
+
+[[artifacts]]
+version = "6.11.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.11.1/node-v6.11.1-linux-x64.tar.gz"
+checksum = "sha256:175e00ad504f0dca5a4d2af0f941e27ea0bd3178529fd1a9c3d67f3d75afd864"
+
+[[artifacts]]
+version = "6.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.11.0/node-v6.11.0-linux-arm64.tar.gz"
+checksum = "sha256:9f843c115fbcb8bb0f9ac4f0f1bd20156e0cd15dcea490b352ca10ddadc75de2"
+
+[[artifacts]]
+version = "6.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.11.0/node-v6.11.0-linux-x64.tar.gz"
+checksum = "sha256:2b0e1b06bf8658ce02c16239eb6a74b55ad92d4fb7888608af1d52b383642c3c"
+
+[[artifacts]]
+version = "6.10.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.10.3/node-v6.10.3-linux-arm64.tar.gz"
+checksum = "sha256:c2ff51d8a824d5d2ca8ba7a2e8e4306c4c356edf5c0aa7f4cb2f93091c0e1310"
+
+[[artifacts]]
+version = "6.10.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.10.3/node-v6.10.3-linux-x64.tar.gz"
+checksum = "sha256:c6a60f823a4df31f1ed3a4044d250e322f2f2794d97798d47c6ee4af9376f927"
+
+[[artifacts]]
+version = "6.10.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.10.2/node-v6.10.2-linux-arm64.tar.gz"
+checksum = "sha256:97de0340b6dbf38e3d995df880a94c58d403c3054676d8fc9192b83a3735f0b8"
+
+[[artifacts]]
+version = "6.10.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.10.2/node-v6.10.2-linux-x64.tar.gz"
+checksum = "sha256:35accd2d9ccac747eff0f236e2843bc2198ba7765e2340441d6230861bae4e1b"
+
+[[artifacts]]
+version = "6.10.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.10.1/node-v6.10.1-linux-arm64.tar.gz"
+checksum = "sha256:8d3955523e2f25e8f62aefb1181f500a6e1458d4decbda95b147f3e3f4598081"
+
+[[artifacts]]
+version = "6.10.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.10.1/node-v6.10.1-linux-x64.tar.gz"
+checksum = "sha256:31ad1731f4375da2f3ee739f23b0d92c54402eefcc7f98595010395178dde047"
+
+[[artifacts]]
+version = "6.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.10.0/node-v6.10.0-linux-arm64.tar.gz"
+checksum = "sha256:5f4024d2df1708ef80c5e7b1606d972e8f9779b350df832932174ce651e7795f"
+
+[[artifacts]]
+version = "6.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.10.0/node-v6.10.0-linux-x64.tar.gz"
+checksum = "sha256:20b144da9bc3c314abfb760e90580a94091037257fc0b2c32871bc29257f7545"
+
+[[artifacts]]
+version = "6.9.5"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.9.5/node-v6.9.5-linux-arm64.tar.gz"
+checksum = "sha256:f60799f0e15b61b900450c4bc36684885c57d5e0e9d34790bffbc5558944e6da"
+
+[[artifacts]]
+version = "6.9.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.9.5/node-v6.9.5-linux-x64.tar.gz"
+checksum = "sha256:a4b464068cf2c2cc8ffba9ca0a6ee1ebf146509a86d46a4f92e761c31adebd29"
+
+[[artifacts]]
+version = "6.9.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.9.4/node-v6.9.4-linux-arm64.tar.gz"
+checksum = "sha256:cdc4340006a818eb576aad5f81ebe1977e3a91814fa89549f3c903a8b283bb1b"
+
+[[artifacts]]
+version = "6.9.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.9.4/node-v6.9.4-linux-x64.tar.gz"
+checksum = "sha256:a1faed4afbbdbdddeae17a24b873b5d6b13950c36fabcb86327a001d24316ffb"
+
+[[artifacts]]
+version = "6.9.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.9.3/node-v6.9.3-linux-arm64.tar.gz"
+checksum = "sha256:2b0aec9caf1afb5b4cb417dafb2701a2a104e669a0dcb2005497c7f636211ed8"
+
+[[artifacts]]
+version = "6.9.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.9.3/node-v6.9.3-linux-x64.tar.gz"
+checksum = "sha256:5957fd9b65c346f0d0afb1adc8bde98fa04bf613ee51ef9570d287bda73314a2"
+
+[[artifacts]]
+version = "6.9.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.9.2/node-v6.9.2-linux-arm64.tar.gz"
+checksum = "sha256:05d00c80967e2765eb3edd2bbbe7410c1153323c0dcfe7c7d12c9cad0b32c587"
+
+[[artifacts]]
+version = "6.9.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.9.2/node-v6.9.2-linux-x64.tar.gz"
+checksum = "sha256:cbf6a35b035c56f991c2e6a4aedbcd9f09555234ac0dd5b2c15128e2b5f4eb50"
+
+[[artifacts]]
+version = "6.9.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.9.1/node-v6.9.1-linux-arm64.tar.gz"
+checksum = "sha256:8a8da2c3aad9da2d80035eeba0b9aae41230bec394729224fafcfae152fa5f66"
+
+[[artifacts]]
+version = "6.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.9.1/node-v6.9.1-linux-x64.tar.gz"
+checksum = "sha256:a9d9e6308931fa2a2b0cada070516d45b76d752430c31c9198933c78f8d54b17"
+
+[[artifacts]]
+version = "6.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.9.0/node-v6.9.0-linux-arm64.tar.gz"
+checksum = "sha256:e9ff08e622436007594dcbff1b528023aaa2397c38fdc961d130730b90fdc814"
+
+[[artifacts]]
+version = "6.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.9.0/node-v6.9.0-linux-x64.tar.gz"
+checksum = "sha256:a9aafa2499097b315e1554b882923a6e2f9c446d24eaea53630f0fdbe075b226"
+
+[[artifacts]]
+version = "6.8.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.8.1/node-v6.8.1-linux-arm64.tar.gz"
+checksum = "sha256:d68acdedba79bb0cca9ccdb985323d18b6edbd85ee8cf896e02433c09cad1da9"
+
+[[artifacts]]
+version = "6.8.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.8.1/node-v6.8.1-linux-x64.tar.gz"
+checksum = "sha256:8d004e6990926508460495450a4083d40836e81710afca303d6a298e032c6b18"
+
+[[artifacts]]
+version = "6.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.8.0/node-v6.8.0-linux-arm64.tar.gz"
+checksum = "sha256:c7524e35bfc1fd4961dfac6bd6d602f474e909d63e3e48f892906a183bd9aa04"
+
+[[artifacts]]
+version = "6.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.8.0/node-v6.8.0-linux-x64.tar.gz"
+checksum = "sha256:9ddd118262cbe27fd668bc17c9c786cdd27c6a291cc712b4937013e4665f6e6d"
+
+[[artifacts]]
+version = "6.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.7.0/node-v6.7.0-linux-arm64.tar.gz"
+checksum = "sha256:45ffd727bcab41a544ad7862fe985f6beac4fcd96c63e116ca467d1147ba6454"
+
+[[artifacts]]
+version = "6.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.7.0/node-v6.7.0-linux-x64.tar.gz"
+checksum = "sha256:abe81b4150917cdbbeebc6c6b85003b80c972d32c8f5dfd2970d32e52a6877af"
+
+[[artifacts]]
+version = "6.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.6.0/node-v6.6.0-linux-arm64.tar.gz"
+checksum = "sha256:9abae64e411d8ea1541a4776e78d9cf53ad8e20e8b34cf77d9b3579e8edb6f65"
+
+[[artifacts]]
+version = "6.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.6.0/node-v6.6.0-linux-x64.tar.gz"
+checksum = "sha256:c22ab0dfa9d0b8d9de02ef7c0d860298a5d1bf6cae7413fb18b99e8a3d25648a"
+
+[[artifacts]]
+version = "6.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.5.0/node-v6.5.0-linux-arm64.tar.gz"
+checksum = "sha256:e3d208d3b054301e2bd572d71c7c325ddc0a7e4c2cc4278053e2375e841f6d99"
+
+[[artifacts]]
+version = "6.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.5.0/node-v6.5.0-linux-x64.tar.gz"
+checksum = "sha256:575638830e4ba11c5afba5c222934bc5e338e74df2f27ca09bad09014b4aa415"
+
+[[artifacts]]
+version = "6.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.4.0/node-v6.4.0-linux-arm64.tar.gz"
+checksum = "sha256:42493fcd0266949b219bb4a0f36e1e765f266aed104c594cff012b906dcc53c1"
+
+[[artifacts]]
+version = "6.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.4.0/node-v6.4.0-linux-x64.tar.gz"
+checksum = "sha256:990636e44b9f7a270cf82f988e5faecb5850fcda9580da65e5721b90ed3dddb2"
+
+[[artifacts]]
+version = "6.3.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.3.1/node-v6.3.1-linux-arm64.tar.gz"
+checksum = "sha256:66ef087709f7709f0bf066904df06815ac7ad213181d6dcc2adb4f9dc831704f"
+
+[[artifacts]]
+version = "6.3.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.3.1/node-v6.3.1-linux-x64.tar.gz"
+checksum = "sha256:eccc530696d18b07c5785e317b2babbea9c1dd14dbab80be734b820fc241ddea"
+
+[[artifacts]]
+version = "6.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.3.0/node-v6.3.0-linux-arm64.tar.gz"
+checksum = "sha256:58995c3f91962fc4383696f9c64763b3cd27d9b5903b4cf2a5ccfe86c8258e9f"
+
+[[artifacts]]
+version = "6.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.3.0/node-v6.3.0-linux-x64.tar.gz"
+checksum = "sha256:d26c09fc95ebb457b79fcb0a2890fe8417b2c04f4016dadf2d165c07af762764"
+
+[[artifacts]]
+version = "6.2.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.2.2/node-v6.2.2-linux-arm64.tar.gz"
+checksum = "sha256:1eaac04e632e633197c764a65817909667a700a657b1de463a45efcd40d236c7"
+
+[[artifacts]]
+version = "6.2.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.2.2/node-v6.2.2-linux-x64.tar.gz"
+checksum = "sha256:7a6df881183e70839857b51653811aaabc49a2ffb93416a1c9bd333dcef84ea3"
+
+[[artifacts]]
+version = "6.2.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.2.1/node-v6.2.1-linux-arm64.tar.gz"
+checksum = "sha256:86f7498f0c355e8f8c17cecaf7e0bd6f68e189e00e0adb6700560e291edce08d"
+
+[[artifacts]]
+version = "6.2.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.2.1/node-v6.2.1-linux-x64.tar.gz"
+checksum = "sha256:c6ae9c90858fb47a2915ad6494e5eb8e6f34f4512de1d5a461e5fb0c003590b1"
+
+[[artifacts]]
+version = "6.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.2.0/node-v6.2.0-linux-arm64.tar.gz"
+checksum = "sha256:bac296f56d071e147e33e7f027efc8b0422a786e3943b18c64c8c8fbf2abae96"
+
+[[artifacts]]
+version = "6.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.2.0/node-v6.2.0-linux-x64.tar.gz"
+checksum = "sha256:661dba369c277603fa6d0182c4ea7ff074ba6bacd19171826271f872afd6aaa7"
+
+[[artifacts]]
+version = "6.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.1.0/node-v6.1.0-linux-arm64.tar.gz"
+checksum = "sha256:87670387877d1cbe36642970e3ca84a77121d3200771b80ec2286bc261e060f7"
+
+[[artifacts]]
+version = "6.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.1.0/node-v6.1.0-linux-x64.tar.gz"
+checksum = "sha256:ce46dd0188181b70661b9162feffdbd8a860cb75cb6661c37d6d61982e3f72c5"
+
+[[artifacts]]
+version = "6.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v6.0.0/node-v6.0.0-linux-arm64.tar.gz"
+checksum = "sha256:c4d7da92f76e77d27ef5650ad01085baad74439fab15e5143a8e9fc6cad13101"
+
+[[artifacts]]
+version = "6.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v6.0.0/node-v6.0.0-linux-x64.tar.gz"
+checksum = "sha256:78fa76c77a1168095cf5b8a5018e00e7212d11e485cf10c77ce1c8af4955cdd3"
+
+[[artifacts]]
+version = "5.12.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.12.0/node-v5.12.0-linux-arm64.tar.gz"
+checksum = "sha256:db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3"
+
+[[artifacts]]
+version = "5.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.12.0/node-v5.12.0-linux-x64.tar.gz"
+checksum = "sha256:c0f459152aa87aba8a019a95899352170db0d8d52c860715c88356cb253fe2c4"
+
+[[artifacts]]
+version = "5.11.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.11.1/node-v5.11.1-linux-arm64.tar.gz"
+checksum = "sha256:8df5fa56ea1f79efc6f8baa9a6784bb1b0596fb7ef1d631694e35a89b3840de6"
+
+[[artifacts]]
+version = "5.11.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.11.1/node-v5.11.1-linux-x64.tar.gz"
+checksum = "sha256:d8e30e79a1e4ad56f55ef59facdf913c950e9664528f59f4388e85fdd899dfde"
+
+[[artifacts]]
+version = "5.11.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.11.0/node-v5.11.0-linux-arm64.tar.gz"
+checksum = "sha256:b6cc0dd471f07b607367b76a3f2ec1f11d9bc05f2fccbcda7b85ce76d31a3e2a"
+
+[[artifacts]]
+version = "5.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.11.0/node-v5.11.0-linux-x64.tar.gz"
+checksum = "sha256:92602b815ce1c64c63b94d6f72f9b96b427415d023d5f9466c7ffef334bf0386"
+
+[[artifacts]]
+version = "5.10.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.10.1/node-v5.10.1-linux-arm64.tar.gz"
+checksum = "sha256:98e4f003818968d5b9bcf17c921d33a5e3d6866be63d80510ae7ff8877e817db"
+
+[[artifacts]]
+version = "5.10.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.10.1/node-v5.10.1-linux-x64.tar.gz"
+checksum = "sha256:897506e1e83cba9b780b030c9cc7299b0ae8872c0b8b0081a86996079025cea5"
+
+[[artifacts]]
+version = "5.10.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.10.0/node-v5.10.0-linux-arm64.tar.gz"
+checksum = "sha256:df88803bda234b32240906b620315c8f6d6200332047a88cb0ec83009cf25dd5"
+
+[[artifacts]]
+version = "5.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.10.0/node-v5.10.0-linux-x64.tar.gz"
+checksum = "sha256:a458ddab5f8d071c9b4f24ccfa685aedd57ccf7338c3ea0e2b99546cf35a3958"
+
+[[artifacts]]
+version = "5.9.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.9.1/node-v5.9.1-linux-arm64.tar.gz"
+checksum = "sha256:09fd524d987e3c70aed7aa52d21f6448fe06cdd05c627a6de326384b98a3bb0e"
+
+[[artifacts]]
+version = "5.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.9.1/node-v5.9.1-linux-x64.tar.gz"
+checksum = "sha256:4b9951e6afd75010f53264fc1a61e2d92ae23a590bbb58fea3e62d6f0104f657"
+
+[[artifacts]]
+version = "5.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.9.0/node-v5.9.0-linux-arm64.tar.gz"
+checksum = "sha256:8ce0653a98a7507dc15bd7425154af1113685d054b6dee2c9701fed401feb12a"
+
+[[artifacts]]
+version = "5.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.9.0/node-v5.9.0-linux-x64.tar.gz"
+checksum = "sha256:99c4136cf61761fac5ac57f80544140a3793b63e00a65d4a0e528c9db328bf40"
+
+[[artifacts]]
+version = "5.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.8.0/node-v5.8.0-linux-arm64.tar.gz"
+checksum = "sha256:0c2c0fa859c5be13cd1404f3fb14d37e38a67fb2fc075c7a37d4ae70374544bf"
+
+[[artifacts]]
+version = "5.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.8.0/node-v5.8.0-linux-x64.tar.gz"
+checksum = "sha256:3d33efa2421ed0769cc23ac172203b7db9fe4914a186009ddbac28c9aadb0896"
+
+[[artifacts]]
+version = "5.7.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.7.1/node-v5.7.1-linux-arm64.tar.gz"
+checksum = "sha256:b075aa249eb1e00e1e84e6f5964d4f93c39aa6d817c25280bf885bfcf906c7fc"
+
+[[artifacts]]
+version = "5.7.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.7.1/node-v5.7.1-linux-x64.tar.gz"
+checksum = "sha256:fcded78b45549e2195eecb36138ba29b6f353d0d136d4e8b80648770418f1e5b"
+
+[[artifacts]]
+version = "5.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.7.0/node-v5.7.0-linux-arm64.tar.gz"
+checksum = "sha256:2b4de1cca92da4aaec0aec0bc767d7a60d8378e830987abc668176d9b6603ccd"
+
+[[artifacts]]
+version = "5.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.7.0/node-v5.7.0-linux-x64.tar.gz"
+checksum = "sha256:ae24ae3076393e7968316098ddbb0221bde0830a0e9d878c6493604e1cc553c1"
+
+[[artifacts]]
+version = "5.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.6.0/node-v5.6.0-linux-arm64.tar.gz"
+checksum = "sha256:3b22bb5e1579d6e45f31da88c17baeb17a12ecb297c1c69447de6030d626b08d"
+
+[[artifacts]]
+version = "5.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.6.0/node-v5.6.0-linux-x64.tar.gz"
+checksum = "sha256:6b10e446b5a1227673b87d840e9a500f5d2dbd2b806d96e2d81d634c3381a5f1"
+
+[[artifacts]]
+version = "5.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.5.0/node-v5.5.0-linux-arm64.tar.gz"
+checksum = "sha256:a9ebfce36675cc8d5e1bea6fa57de7fd80e8016f5957340831fcd03560e59845"
+
+[[artifacts]]
+version = "5.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.5.0/node-v5.5.0-linux-x64.tar.gz"
+checksum = "sha256:3e593d91b6d2ad871efaaf8e9a17b3608ca98904959bcfb7c42e6acce89e80f4"
+
+[[artifacts]]
+version = "5.4.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.4.1/node-v5.4.1-linux-arm64.tar.gz"
+checksum = "sha256:362ae4539b6be075b6757ba689f0ae522cfc9340c81061aca880f92fce9595c7"
+
+[[artifacts]]
+version = "5.4.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.4.1/node-v5.4.1-linux-x64.tar.gz"
+checksum = "sha256:1880f3421da5579678803a523c314b345f5db00799b51b7fd9484a3248efc068"
+
+[[artifacts]]
+version = "5.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.4.0/node-v5.4.0-linux-arm64.tar.gz"
+checksum = "sha256:0cb2c093e75090281423a2b3681629c663c83dac4587a12b77022afccd7aedc0"
+
+[[artifacts]]
+version = "5.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.4.0/node-v5.4.0-linux-x64.tar.gz"
+checksum = "sha256:f037e2734f52b9de63e6d4a4e80756477b843e6f106e0be05591a16b71ec2bd0"
+
+[[artifacts]]
+version = "5.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.3.0/node-v5.3.0-linux-arm64.tar.gz"
+checksum = "sha256:0a37c919cb2e2511ee7ff60e4fc80266afa3dad7cffa9204dc73da244c3a308a"
+
+[[artifacts]]
+version = "5.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.3.0/node-v5.3.0-linux-x64.tar.gz"
+checksum = "sha256:75b029b30d4a4147d67cf75bf6e034291fb5919c6935ec23f8365cee2d463f12"
+
+[[artifacts]]
+version = "5.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.2.0/node-v5.2.0-linux-arm64.tar.gz"
+checksum = "sha256:3517d9ba80217985cac970272d387f4a905f17e5b87a7c7243efcc1173751531"
+
+[[artifacts]]
+version = "5.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.2.0/node-v5.2.0-linux-x64.tar.gz"
+checksum = "sha256:7f31f5db97e1def61454d268d5206a6826385d157f444c21a36230a6c18f40d2"
+
+[[artifacts]]
+version = "5.1.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.1.1/node-v5.1.1-linux-arm64.tar.gz"
+checksum = "sha256:1723abf50ee9b2b2209af06374523ae657c5562166bdc44b7b8d32801484c572"
+
+[[artifacts]]
+version = "5.1.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.1.1/node-v5.1.1-linux-x64.tar.gz"
+checksum = "sha256:0c1a0788dfc07d1cfac08b9789f0e52950e80e61944e1684b27600463a5d2623"
+
+[[artifacts]]
+version = "5.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.1.0/node-v5.1.0-linux-arm64.tar.gz"
+checksum = "sha256:8e6eb18b4499c4c509b4132d3393121a7d344d4053400798614c843977696ff3"
+
+[[artifacts]]
+version = "5.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.1.0/node-v5.1.0-linux-x64.tar.gz"
+checksum = "sha256:510e7a2e8639a3ea036f5f6a9f7a66037e3acf8d0c953aeac8d093dea7e41d4c"
+
+[[artifacts]]
+version = "5.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v5.0.0/node-v5.0.0-linux-arm64.tar.gz"
+checksum = "sha256:2c4517d3fdefc29b5c61aa6ea3386a0dafca831357d3bcd30fc14e97b49139d1"
+
+[[artifacts]]
+version = "5.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v5.0.0/node-v5.0.0-linux-x64.tar.gz"
+checksum = "sha256:ef73b59048a0ed11d01633f0061627b7a9879257deb9add2255e4d0808f8b671"
+
+[[artifacts]]
+version = "4.9.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.9.1/node-v4.9.1-linux-arm64.tar.gz"
+checksum = "sha256:b61b9b19f584cdd198a7342966a269393e6ef79e1273e4f4940d872b929d8403"
+
+[[artifacts]]
+version = "4.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.9.1/node-v4.9.1-linux-x64.tar.gz"
+checksum = "sha256:7c86fac1b2dfd837396b716c3313eb4dd04da315d254dd2f0c8bdcaf41dc5de6"
+
+[[artifacts]]
+version = "4.9.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.9.0/node-v4.9.0-linux-arm64.tar.gz"
+checksum = "sha256:58c47ff94cb79ec8dd3c2c5d21a1836df00914e6306201503baffbf584012171"
+
+[[artifacts]]
+version = "4.9.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.9.0/node-v4.9.0-linux-x64.tar.gz"
+checksum = "sha256:31967377cece1bfb30a16f7d6b2535434e3e2c56d894ed60de7a9fab7930f767"
+
+[[artifacts]]
+version = "4.8.7"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.8.7/node-v4.8.7-linux-arm64.tar.gz"
+checksum = "sha256:2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f"
+
+[[artifacts]]
+version = "4.8.7"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.8.7/node-v4.8.7-linux-x64.tar.gz"
+checksum = "sha256:d3a1501a426a8d8bec3fa4ddd7364a5d160d50237527fbfce5e76a97b55d3f75"
+
+[[artifacts]]
+version = "4.8.6"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.8.6/node-v4.8.6-linux-arm64.tar.gz"
+checksum = "sha256:b132ab051b1a48db3e9385b086c77fc4438f888a236b7e9cbe998171196592cb"
+
+[[artifacts]]
+version = "4.8.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.8.6/node-v4.8.6-linux-x64.tar.gz"
+checksum = "sha256:3d4c29e5dceafa68a7a326079c160cf58e5443b4be199ba9595f8e8fa6f58fdb"
+
+[[artifacts]]
+version = "4.8.5"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.8.5/node-v4.8.5-linux-arm64.tar.gz"
+checksum = "sha256:9133ba0865f1d15c52a6fe550fb7a8df81ac81083661dd28ce0bec5fb97be6bf"
+
+[[artifacts]]
+version = "4.8.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.8.5/node-v4.8.5-linux-x64.tar.gz"
+checksum = "sha256:8a82f320795cf0874ccefb3e7890dffb02d59127ab8c5da1d6c96db1364baeaf"
+
+[[artifacts]]
+version = "4.8.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.8.4/node-v4.8.4-linux-arm64.tar.gz"
+checksum = "sha256:1eb8f8cadc8024fcb01f333ca8cac1db39735491a35122bf5ab1a40ee6bedced"
+
+[[artifacts]]
+version = "4.8.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.8.4/node-v4.8.4-linux-x64.tar.gz"
+checksum = "sha256:d1297b6ddec12498f19589c0f44768a9f250ad36ea17f1f715b44aeb89cd32b2"
+
+[[artifacts]]
+version = "4.8.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.8.3/node-v4.8.3-linux-arm64.tar.gz"
+checksum = "sha256:6bcc2285ea06fd6096027367a6bea6b9c44f1f7ce7cf0700172663217ef1423f"
+
+[[artifacts]]
+version = "4.8.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.8.3/node-v4.8.3-linux-x64.tar.gz"
+checksum = "sha256:52382b93865a5edd834db10e8f60822680d26dc2b8cadccafc351b0082a9052a"
+
+[[artifacts]]
+version = "4.8.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.8.2/node-v4.8.2-linux-arm64.tar.gz"
+checksum = "sha256:f12a9e347da6ffdac6598164831198714a6ef7e0587d10fce21e5312629f2ed8"
+
+[[artifacts]]
+version = "4.8.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.8.2/node-v4.8.2-linux-x64.tar.gz"
+checksum = "sha256:150c468f67a84c343503864a037cb8f4decd375279f3c20afe7c4f21f7aa3164"
+
+[[artifacts]]
+version = "4.8.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.8.1/node-v4.8.1-linux-arm64.tar.gz"
+checksum = "sha256:40a29ae4f59de7b195ba0cc0334c179f834968af0e7e57e7c685cd02d9cdb5be"
+
+[[artifacts]]
+version = "4.8.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.8.1/node-v4.8.1-linux-x64.tar.gz"
+checksum = "sha256:8eed258da756c77618c03b780eb15743726aedd260b3696e98ced313c57155b9"
+
+[[artifacts]]
+version = "4.8.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.8.0/node-v4.8.0-linux-arm64.tar.gz"
+checksum = "sha256:f796af7ea3c2ac085ba4d24b367c4a9ec73a0d6f469628470a8b7ac14e05d0a4"
+
+[[artifacts]]
+version = "4.8.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.8.0/node-v4.8.0-linux-x64.tar.gz"
+checksum = "sha256:43e50dfa950ccd0caf03ad71c65f8235aca6fe173596f2804b2f9dfaa45cabf1"
+
+[[artifacts]]
+version = "4.7.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.7.3/node-v4.7.3-linux-arm64.tar.gz"
+checksum = "sha256:4d3199e69259452d1e1cfc06da851e8c26590613f845a997d613228954225124"
+
+[[artifacts]]
+version = "4.7.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.7.3/node-v4.7.3-linux-x64.tar.gz"
+checksum = "sha256:720b62ed3a733578c429448c8c373743866f55db6e9763a11b87bb324740a33b"
+
+[[artifacts]]
+version = "4.7.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.7.2/node-v4.7.2-linux-arm64.tar.gz"
+checksum = "sha256:f0a6961fb792c859224b42976eecc202f91ac70edb7fb1186af049d2250970d6"
+
+[[artifacts]]
+version = "4.7.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.7.2/node-v4.7.2-linux-x64.tar.gz"
+checksum = "sha256:2d7be22929fb6580d3936735af711febf57dd879a7d5ca1376e0668608a67250"
+
+[[artifacts]]
+version = "4.7.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.7.1/node-v4.7.1-linux-arm64.tar.gz"
+checksum = "sha256:011d4a50b31941b4dc09e3f9b5b082dc1176f9483a7a758c02de161a36778e7a"
+
+[[artifacts]]
+version = "4.7.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.7.1/node-v4.7.1-linux-x64.tar.gz"
+checksum = "sha256:8076452319f8f30cb860cdcfed78853afa091643658d258306cb1005b4ccb083"
+
+[[artifacts]]
+version = "4.7.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.7.0/node-v4.7.0-linux-arm64.tar.gz"
+checksum = "sha256:5808bcca509170b4c6190c31ac786a5543989469f2ca0198479485b605bd843a"
+
+[[artifacts]]
+version = "4.7.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.7.0/node-v4.7.0-linux-x64.tar.gz"
+checksum = "sha256:31b9414302ff99f8d60ebad6afda30a8f4a09429dab2cdc872f7bc3ce6ead041"
+
+[[artifacts]]
+version = "4.6.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.6.2/node-v4.6.2-linux-arm64.tar.gz"
+checksum = "sha256:831eab2a0fed0c3716e2c6bb9d9f2d64b8f365e5501ec373eb207ce5621ba6d2"
+
+[[artifacts]]
+version = "4.6.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.6.2/node-v4.6.2-linux-x64.tar.gz"
+checksum = "sha256:0a2d6417526509bc4c0d953e1563b0d5c972fe270a45da0ca8ed02d41fb1c223"
+
+[[artifacts]]
+version = "4.6.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.6.1/node-v4.6.1-linux-arm64.tar.gz"
+checksum = "sha256:439a4261c13644dee42d8f5ff6a6fc7974a5c5bb169f6c79cc5852b50298a1c4"
+
+[[artifacts]]
+version = "4.6.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.6.1/node-v4.6.1-linux-x64.tar.gz"
+checksum = "sha256:033243d4ddffd67856c9ccfb512b0d1980e8d1373554bc328472b21bc5de7675"
+
+[[artifacts]]
+version = "4.6.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.6.0/node-v4.6.0-linux-arm64.tar.gz"
+checksum = "sha256:bf03e7384b727bc80c0c59cf38ba5704d83faa7f455f40fa62a67c8331dde7d6"
+
+[[artifacts]]
+version = "4.6.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.6.0/node-v4.6.0-linux-x64.tar.gz"
+checksum = "sha256:acf08148cecf245f28126122ac9128ff9909f00938b18d80fc0b92648d1c98a8"
+
+[[artifacts]]
+version = "4.5.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.5.0/node-v4.5.0-linux-arm64.tar.gz"
+checksum = "sha256:ecdbb3cb55d0a87aeb10334b47310f1823393abe6273f1ce7c97bcb509051e68"
+
+[[artifacts]]
+version = "4.5.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.5.0/node-v4.5.0-linux-x64.tar.gz"
+checksum = "sha256:5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+
+[[artifacts]]
+version = "4.4.7"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.4.7/node-v4.4.7-linux-arm64.tar.gz"
+checksum = "sha256:a1e2faf3859976ac7322b950353044863c2e36ad6e2e09a8fc9f80f72fd01b18"
+
+[[artifacts]]
+version = "4.4.7"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.4.7/node-v4.4.7-linux-x64.tar.gz"
+checksum = "sha256:5ad10465cc9d837c1fda8db0fd1bdc1a4ce823dd6afbc533ac2127e6a9a64133"
+
+[[artifacts]]
+version = "4.4.6"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.4.6/node-v4.4.6-linux-arm64.tar.gz"
+checksum = "sha256:de0c093ed38934f25cc5eaa1ecd84878fe123e0632db3bf4c3ffcd8af107a62d"
+
+[[artifacts]]
+version = "4.4.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.4.6/node-v4.4.6-linux-x64.tar.gz"
+checksum = "sha256:bef5cc1db30b56d3f40b123c6a40529b6f69c403fa969ec2654b62d4cac95e26"
+
+[[artifacts]]
+version = "4.4.5"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.4.5/node-v4.4.5-linux-arm64.tar.gz"
+checksum = "sha256:46c89b2cdb3d7f3e87ef1ed8e4d9ee07dcc603e42f3f86f831a6fd7c34be9404"
+
+[[artifacts]]
+version = "4.4.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.4.5/node-v4.4.5-linux-x64.tar.gz"
+checksum = "sha256:15d57c4a3696df8d5ef1bba452d38e5d27fc3c963760eeb218533c48381e89d5"
+
+[[artifacts]]
+version = "4.4.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.4.4/node-v4.4.4-linux-arm64.tar.gz"
+checksum = "sha256:4d7336411a61e92eb4815dc5b9042cae92ed49d3bc472da153aa13fd4e812b99"
+
+[[artifacts]]
+version = "4.4.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.4.4/node-v4.4.4-linux-x64.tar.gz"
+checksum = "sha256:0881eb010c8a4a0e746a1852fe48416d9c21b5f19a20d418cb02c7197fa55576"
+
+[[artifacts]]
+version = "4.4.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.4.3/node-v4.4.3-linux-arm64.tar.gz"
+checksum = "sha256:261646b9d606ab3cc42f870d4bcaab79a40f18f7b13740762127598ef29d4ffc"
+
+[[artifacts]]
+version = "4.4.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.4.3/node-v4.4.3-linux-x64.tar.gz"
+checksum = "sha256:28ff2b23a837526ecfea66b0db42d43ec84368949998f2cb26dd742e8988ec1f"
+
+[[artifacts]]
+version = "4.4.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.4.2/node-v4.4.2-linux-arm64.tar.gz"
+checksum = "sha256:be881df65ff29ffbec47a14e082800c150d4a9238d1c137ff18cf7c28fafa987"
+
+[[artifacts]]
+version = "4.4.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.4.2/node-v4.4.2-linux-x64.tar.gz"
+checksum = "sha256:b4a44dbe528520397621aad76168bdfd50cdb96fb1f15e99358263f6400c33d2"
+
+[[artifacts]]
+version = "4.4.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.4.1/node-v4.4.1-linux-arm64.tar.gz"
+checksum = "sha256:8ff4cfc1452abaa95f4d40cf13f7ca3c4cf38da23a3ebde9247154dd51fbc42d"
+
+[[artifacts]]
+version = "4.4.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.4.1/node-v4.4.1-linux-x64.tar.gz"
+checksum = "sha256:f0a53527f52dbcab3b98921a6cfe8613e5fe26fb796624988f6d615c30305a95"
+
+[[artifacts]]
+version = "4.4.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.4.0/node-v4.4.0-linux-arm64.tar.gz"
+checksum = "sha256:649590a9c16d262ba95b8e22a2a69105f7e881375b879e34e647748f18d2c830"
+
+[[artifacts]]
+version = "4.4.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.4.0/node-v4.4.0-linux-x64.tar.gz"
+checksum = "sha256:114a865effcff2783022ef0fcd30d1e51624d6c28140db0bdc662bcd0f850d8b"
+
+[[artifacts]]
+version = "4.3.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.3.2/node-v4.3.2-linux-arm64.tar.gz"
+checksum = "sha256:5d86c21d47cad54e3e5d7f36c1323b1e2416efc75e4615dafe35b202b59f26c8"
+
+[[artifacts]]
+version = "4.3.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.3.2/node-v4.3.2-linux-x64.tar.gz"
+checksum = "sha256:f307f173a96dff6652bc70d835af0c732864bb09875cf32a0b6ce7d70cebf77d"
+
+[[artifacts]]
+version = "4.3.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.3.1/node-v4.3.1-linux-arm64.tar.gz"
+checksum = "sha256:cd55ce4426f9dd9be878fb89d715cbaf589210162e4269ce2ccfd6b9674385e9"
+
+[[artifacts]]
+version = "4.3.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.3.1/node-v4.3.1-linux-x64.tar.gz"
+checksum = "sha256:b3af1ed18a9150af42754e9a0385ecc4b4e9b493fcf32bf6ca0d7239d636254b"
+
+[[artifacts]]
+version = "4.3.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.3.0/node-v4.3.0-linux-arm64.tar.gz"
+checksum = "sha256:47a52191e264efdbc36f5ec6510abd71fd5d3337d75120c2ddc6a285873763b7"
+
+[[artifacts]]
+version = "4.3.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.3.0/node-v4.3.0-linux-x64.tar.gz"
+checksum = "sha256:90ce6e23ad9748813742e1cf09e86fa4c0f3d53972d5dbe920a38bcc842e2d09"
+
+[[artifacts]]
+version = "4.2.6"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.2.6/node-v4.2.6-linux-arm64.tar.gz"
+checksum = "sha256:f0aadf2941d91bfac449cdc8c904a926f6d384e45a8f6443a2f0153501753427"
+
+[[artifacts]]
+version = "4.2.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.2.6/node-v4.2.6-linux-x64.tar.gz"
+checksum = "sha256:656d8bff06cc5e108b83176f81de7e1eb16392ae0958ec4a7bca2a3a309333a1"
+
+[[artifacts]]
+version = "4.2.5"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.2.5/node-v4.2.5-linux-arm64.tar.gz"
+checksum = "sha256:b09a144acb67a8de6f873bbf05ccdf2accc1fd005127a5ab385f78a830fd3ddc"
+
+[[artifacts]]
+version = "4.2.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.2.5/node-v4.2.5-linux-x64.tar.gz"
+checksum = "sha256:3ed12d7ee8d911b87aed7f19640ec3d97a038330709ca4e0d137e8882b0f9cc4"
+
+[[artifacts]]
+version = "4.2.4"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.2.4/node-v4.2.4-linux-arm64.tar.gz"
+checksum = "sha256:96b5d86ca677ddfa351289ea78a338f3a66ef57ceb485cdddb4798ae33e52a08"
+
+[[artifacts]]
+version = "4.2.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.2.4/node-v4.2.4-linux-x64.tar.gz"
+checksum = "sha256:dcae0c0faf9841ef38953075e67ca477ef9d2ea7c14ac2221de2429813f83a62"
+
+[[artifacts]]
+version = "4.2.3"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.2.3/node-v4.2.3-linux-arm64.tar.gz"
+checksum = "sha256:9ec1becd52959920a0f06c92f01b3c3e8c09dd35b4b4f591d975f1975a5f1689"
+
+[[artifacts]]
+version = "4.2.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.2.3/node-v4.2.3-linux-x64.tar.gz"
+checksum = "sha256:644d4c0b206ebcb75383fbe42f6025e7253a61992816289359d0f4dcdb6087d7"
+
+[[artifacts]]
+version = "4.2.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.2.2/node-v4.2.2-linux-arm64.tar.gz"
+checksum = "sha256:125b2236da6c0c7fed39b6652b3867646200c3fe7c9284df3f8ac07a84d39010"
+
+[[artifacts]]
+version = "4.2.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.2.2/node-v4.2.2-linux-x64.tar.gz"
+checksum = "sha256:5c39fac55c945be3b8ac381a12bdbe3a64a9bdc5376d27e2ce0c72160eff5942"
+
+[[artifacts]]
+version = "4.2.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.2.1/node-v4.2.1-linux-arm64.tar.gz"
+checksum = "sha256:05df4aeb8a53798f8b10074600518040fc317f2919f9755aeab57b0aaf7227b0"
+
+[[artifacts]]
+version = "4.2.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.2.1/node-v4.2.1-linux-x64.tar.gz"
+checksum = "sha256:e766e387934e17daaad92d0460ed76f756655da62b627a5c9cc07faea4a0b824"
+
+[[artifacts]]
+version = "4.2.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.2.0/node-v4.2.0-linux-arm64.tar.gz"
+checksum = "sha256:ae67d6ddcb72505937982d6a0bcb031b3522f7abc11d9e2d449ea021a5f75faf"
+
+[[artifacts]]
+version = "4.2.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.2.0/node-v4.2.0-linux-x64.tar.gz"
+checksum = "sha256:98b60c86d541f44c5d07111f9ffc9a81848f976cfbe84f71cb9c7d6bfd34e1a4"
+
+[[artifacts]]
+version = "4.1.2"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.1.2/node-v4.1.2-linux-arm64.tar.gz"
+checksum = "sha256:ae74c245b9592d52f8632a249a0bdd2eb664dcf7aaf5089d061f9c5b051f101a"
+
+[[artifacts]]
+version = "4.1.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.1.2/node-v4.1.2-linux-x64.tar.gz"
+checksum = "sha256:c39aefac81a2a4b0ae12df495e7dcdf6a8b75cbfe3a6efb649c8a4daa3aebdb6"
+
+[[artifacts]]
+version = "4.1.1"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.1.1/node-v4.1.1-linux-arm64.tar.gz"
+checksum = "sha256:b2e1915a0c65dd9faee7f05a56792371958980e02d1f7cde447c8260bb805052"
+
+[[artifacts]]
+version = "4.1.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.1.1/node-v4.1.1-linux-x64.tar.gz"
+checksum = "sha256:f5f7e11a503c997486d50d8683741a554bdda1d1181125a05ac5844cb29d1572"
+
+[[artifacts]]
+version = "4.1.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.1.0/node-v4.1.0-linux-arm64.tar.gz"
+checksum = "sha256:d27001f51d75c43cc1f444eab8aef0ced4ac4d162598be7eccf58790127e5368"
+
+[[artifacts]]
+version = "4.1.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.1.0/node-v4.1.0-linux-x64.tar.gz"
+checksum = "sha256:7c6055e08127143d9a8f779aa56f3fe42035fff8843c2652b0b2726204556382"
+
+[[artifacts]]
+version = "4.0.0"
+os = "linux"
+arch = "arm64"
+url = "https://nodejs.org/download/release/v4.0.0/node-v4.0.0-linux-arm64.tar.gz"
+checksum = "sha256:0436f107e1d82c61c3ee4f916781466a49bece74bf4d4fb4bf4d53a57b81df85"
+
+[[artifacts]]
+version = "4.0.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v4.0.0/node-v4.0.0-linux-x64.tar.gz"
+checksum = "sha256:df8ada31840e3dc48c7fe7291c7eba70b2ce5a6b6d959ac01157b04731c8a88f"
+
+[[artifacts]]
+version = "0.12.18"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.18/node-v0.12.18-linux-x64.tar.gz"
+checksum = "sha256:990b3b39b6290000da1c9fdb5352c2e81fca4e6eeaecfce77c46b3cea1a68dba"
+
+[[artifacts]]
+version = "0.12.17"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.17/node-v0.12.17-linux-x64.tar.gz"
+checksum = "sha256:afeec47fc543e24a1e596d05e9bc8e019c3bdf51d45f0ddeac6aeb04f15eaece"
+
+[[artifacts]]
+version = "0.12.16"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.16/node-v0.12.16-linux-x64.tar.gz"
+checksum = "sha256:d9e1cd239844f2a5641e02e48b3c7955e3e73ff3c3d20629c24b561f08ab8219"
+
+[[artifacts]]
+version = "0.12.15"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.15/node-v0.12.15-linux-x64.tar.gz"
+checksum = "sha256:ab2dc52174552e3959f15a438918b32b59e49409e5640f2acb1a3b9c85cf2a95"
+
+[[artifacts]]
+version = "0.12.14"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.14/node-v0.12.14-linux-x64.tar.gz"
+checksum = "sha256:0f1f20f6989d32b4b67835f527ae3bf165c1c4a6a7dc3961d489288817956bae"
+
+[[artifacts]]
+version = "0.12.13"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.13/node-v0.12.13-linux-x64.tar.gz"
+checksum = "sha256:3e8b6ee32fc9a726bfe6f3961bcccf3d2b6d0ddd68326abb4434039f16e10f09"
+
+[[artifacts]]
+version = "0.12.12"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.12/node-v0.12.12-linux-x64.tar.gz"
+checksum = "sha256:a3d51cc26060fe46f9ebe69c750b20fe1f6f27a936db6046a73b8a9715bf3559"
+
+[[artifacts]]
+version = "0.12.11"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.11/node-v0.12.11-linux-x64.tar.gz"
+checksum = "sha256:d98b76b7721a60471801e07e1f90af4fd479e8e42a632d419ede0a7b3c603cc0"
+
+[[artifacts]]
+version = "0.12.10"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.10/node-v0.12.10-linux-x64.tar.gz"
+checksum = "sha256:8fb4d6ed8934f0b0c92c26878511e1d340b068ee966c131ba0fccc1199f4349d"
+
+[[artifacts]]
+version = "0.12.9"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.9/node-v0.12.9-linux-x64.tar.gz"
+checksum = "sha256:3416451924c9c996e1d7224f5e5507df84b90dc730d4760e3f4daac1bd4c44df"
+
+[[artifacts]]
+version = "0.12.8"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.8/node-v0.12.8-linux-x64.tar.gz"
+checksum = "sha256:99f9f8792850867a21caeaf12b1f84da9f64d0cf0ac602920facc0fc4b81e8b4"
+
+[[artifacts]]
+version = "0.12.7"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.7/node-v0.12.7-linux-x64.tar.gz"
+checksum = "sha256:6a2b3077f293d17e2a1e6dba0297f761c9e981c255a2c82f329d4173acf9b9d5"
+
+[[artifacts]]
+version = "0.12.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.6/node-v0.12.6-linux-x64.tar.gz"
+checksum = "sha256:ebbd70ffe0daac6b33df74577c9d25cfb678dbc0016a5ea9eff99d2c5bdb3851"
+
+[[artifacts]]
+version = "0.12.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.5/node-v0.12.5-linux-x64.tar.gz"
+checksum = "sha256:d4d7efb9e1370d9563ace338e01f7be31df48cf8e04ad670f54b6eb8a3c54e03"
+
+[[artifacts]]
+version = "0.12.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.4/node-v0.12.4-linux-x64.tar.gz"
+checksum = "sha256:9095c664c81d7ec90337efd0877e2af72bd055bf8f4f47056d2ac8ea909f561e"
+
+[[artifacts]]
+version = "0.12.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.3/node-v0.12.3-linux-x64.tar.gz"
+checksum = "sha256:22478ba86906666a95010e4eb73763535211719a53da9139b95daeb5b6c170b8"
+
+[[artifacts]]
+version = "0.12.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.2/node-v0.12.2-linux-x64.tar.gz"
+checksum = "sha256:4e1578efc2a2cc67651413a05ccc4c5d43f6b4329c599901c556f24d93cd0508"
+
+[[artifacts]]
+version = "0.12.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.1/node-v0.12.1-linux-x64.tar.gz"
+checksum = "sha256:270d478d0ffb06063f01eab932f672b788f6ecf3c117075ac8b87c0c17e0c9de"
+
+[[artifacts]]
+version = "0.12.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.12.0/node-v0.12.0-linux-x64.tar.gz"
+checksum = "sha256:3bdb7267ca7ee24ac59c54ae146741f70a6ae3a8a8afd42d06204647fe9d4206"
+
+[[artifacts]]
+version = "0.11.16"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.16/node-v0.11.16-linux-x64.tar.gz"
+checksum = "sha256:a1bdc19c779d13b772ac22feead14f592c637ce866d86a59ef225a3273dd7c33"
+
+[[artifacts]]
+version = "0.11.15"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.15/node-v0.11.15-linux-x64.tar.gz"
+checksum = "sha256:940bb9ab99be8be2d9b954fb152e239f2076d28805378e30e781ddcedad382eb"
+
+[[artifacts]]
+version = "0.11.14"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.14/node-v0.11.14-linux-x64.tar.gz"
+checksum = "sha256:3ae6cb227815e7c794215244cecd90a2d3fcf97ba7a30f09accba861bb6057f8"
+
+[[artifacts]]
+version = "0.11.13"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.13/node-v0.11.13-linux-x64.tar.gz"
+checksum = "sha256:4609ed7780cb4aaab6703cdd015f593893e3acc09e432465ec0c9cc178c26655"
+
+[[artifacts]]
+version = "0.11.12"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.12/node-v0.11.12-linux-x64.tar.gz"
+checksum = "sha256:d5369c5608482bcbfcb7a8cd18a43b493a878020c6e5dc241cf55473dafa374a"
+
+[[artifacts]]
+version = "0.11.11"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.11/node-v0.11.11-linux-x64.tar.gz"
+checksum = "sha256:1cf91a851ecb3cb5c4dbd9c14ab59eb53b77ab0cda714b564190746fed67534c"
+
+[[artifacts]]
+version = "0.11.10"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.10/node-v0.11.10-linux-x64.tar.gz"
+checksum = "sha256:5397e1e79c3052b7155deb73525761e3a97d5fcb0868d1e269efb25d7ec0c127"
+
+[[artifacts]]
+version = "0.11.9"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.9/node-v0.11.9-linux-x64.tar.gz"
+checksum = "sha256:89a5013f326e67b73ebef638e765b286831a5d72363ebfdfc75b57b0818c178c"
+
+[[artifacts]]
+version = "0.11.8"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.8/node-v0.11.8-linux-x64.tar.gz"
+checksum = "sha256:5ddc30cb411201cbfde7df9db8a071bd61fac3e3c7d2156b6bef0b10475c934e"
+
+[[artifacts]]
+version = "0.11.7"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.7/node-v0.11.7-linux-x64.tar.gz"
+checksum = "sha256:67253735b86fdba070ef8af6b328e13c9ee4de38f269c60696ff498449646929"
+
+[[artifacts]]
+version = "0.11.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.6/node-v0.11.6-linux-x64.tar.gz"
+checksum = "sha256:4d0b09d88466933439cd5b87c4fbf998732cb6705314edbc9ed3901c2cc24669"
+
+[[artifacts]]
+version = "0.11.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.5/node-v0.11.5-linux-x64.tar.gz"
+checksum = "sha256:c45cfeedbe7149e315f58243ec05dc6575ca2fdd16d4cf0f76853a178eaebf41"
+
+[[artifacts]]
+version = "0.11.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.4/node-v0.11.4-linux-x64.tar.gz"
+checksum = "sha256:9937c02147c01fa7926ffb1cc231bde536a02b6cbed243f88d76de1d445bf97d"
+
+[[artifacts]]
+version = "0.11.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.3/node-v0.11.3-linux-x64.tar.gz"
+checksum = "sha256:50535f04bf36da6efa52ae57d29354f6e0ffd8dc773c08ec655f44314e6f47d3"
+
+[[artifacts]]
+version = "0.11.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.2/node-v0.11.2-linux-x64.tar.gz"
+checksum = "sha256:44989b65a7f784cee48435234b12a253bf8e602651ffcdf0c500f7912798faa2"
+
+[[artifacts]]
+version = "0.11.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.1/node-v0.11.1-linux-x64.tar.gz"
+checksum = "sha256:c6c977e8b828114002f0f9f3cdc9a37370da41ac856ce107190f00ea0065d0d6"
+
+[[artifacts]]
+version = "0.11.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.11.0/node-v0.11.0-linux-x64.tar.gz"
+checksum = "sha256:ab86c554ae27e3938b588083488ae93531a5fba2428bdbcd0fb07a687f514c94"
+
+[[artifacts]]
+version = "0.10.48"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.48/node-v0.10.48-linux-x64.tar.gz"
+checksum = "sha256:82f5fe186349ca69d8889d1079dbb86ae77ce54fce5282b806c359ce360cec7b"
+
+[[artifacts]]
+version = "0.10.47"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.47/node-v0.10.47-linux-x64.tar.gz"
+checksum = "sha256:80757ae8f7bc3161fe44615344c784918ebd93a51ca6f789a75e3d472972eb77"
+
+[[artifacts]]
+version = "0.10.46"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.46/node-v0.10.46-linux-x64.tar.gz"
+checksum = "sha256:58116256f3060703e2e71f2cb5dc265a1d9fab7854a4eee15e78a95a0a87c750"
+
+[[artifacts]]
+version = "0.10.45"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.45/node-v0.10.45-linux-x64.tar.gz"
+checksum = "sha256:54d095d12b6227460f08ec81e50f9db930ec51fa05af1b7722fa85bd2cabb5d7"
+
+[[artifacts]]
+version = "0.10.44"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.44/node-v0.10.44-linux-x64.tar.gz"
+checksum = "sha256:b5f4acc54e5527d793463e05b5435f11dd1f0997168aa71d53a1ff1a06c7b144"
+
+[[artifacts]]
+version = "0.10.43"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.43/node-v0.10.43-linux-x64.tar.gz"
+checksum = "sha256:8a439e17af1971432798ec79a70abf8fa21e03e2aa994bb7150bc088bfa482f2"
+
+[[artifacts]]
+version = "0.10.42"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.42/node-v0.10.42-linux-x64.tar.gz"
+checksum = "sha256:a9b80fb22efc483b6aef282ebb0254b5d9b092ed8091521977af593069a81d53"
+
+[[artifacts]]
+version = "0.10.41"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.41/node-v0.10.41-linux-x64.tar.gz"
+checksum = "sha256:ebda18d4c6545ac42b3404d629504feea0b2b9e7c7fa68de2a5bcc9059a6dc6c"
+
+[[artifacts]]
+version = "0.10.40"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.40/node-v0.10.40-linux-x64.tar.gz"
+checksum = "sha256:0bb15c00fc4668ce3dc1a70a84b80b1aaaaea61ad7efe05dd4eb91165620a17e"
+
+[[artifacts]]
+version = "0.10.39"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.39/node-v0.10.39-linux-x64.tar.gz"
+checksum = "sha256:f7b2f1a7fee90d004fc6eb5629ddde358d96f0ca2fd7ed28f53931127f9875be"
+
+[[artifacts]]
+version = "0.10.38"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.38/node-v0.10.38-linux-x64.tar.gz"
+checksum = "sha256:d0f5771c3adefa4a3c1718206521c603526a3b67d5b1b66abd2e155d0fb77f5e"
+
+[[artifacts]]
+version = "0.10.37"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.37/node-v0.10.37-linux-x64.tar.gz"
+checksum = "sha256:a7d597995b2da1b81c99256bd562dc698e18a12114e67162279dcc23add1f06c"
+
+[[artifacts]]
+version = "0.10.36"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.36/node-v0.10.36-linux-x64.tar.gz"
+checksum = "sha256:2bc13477684a9fe534bdc9d8f4a8caf6257a11953b57c42cad9b919ee259a0d5"
+
+[[artifacts]]
+version = "0.10.35"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.35/node-v0.10.35-linux-x64.tar.gz"
+checksum = "sha256:11f1e0ba34fb77d87db6f2c56898de881fdcf5bcde3e727f00456bfd976d2603"
+
+[[artifacts]]
+version = "0.10.34"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.34/node-v0.10.34-linux-x64.tar.gz"
+checksum = "sha256:d9242c1b04327e8b4069ab1da96794383e562b0610942da501656e53243d04dc"
+
+[[artifacts]]
+version = "0.10.33"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.33/node-v0.10.33-linux-x64.tar.gz"
+checksum = "sha256:159e5485d0fb5c913201baae49f68fd428a7e3b08262e9bf5003c1b399705ca8"
+
+[[artifacts]]
+version = "0.10.32"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.32/node-v0.10.32-linux-x64.tar.gz"
+checksum = "sha256:621777798ed9523a4ad1c4d934f94b7bc765871d769a014a53a4f1f7bcb5d5a7"
+
+[[artifacts]]
+version = "0.10.31"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.31/node-v0.10.31-linux-x64.tar.gz"
+checksum = "sha256:493aa5d4fac0f34df01b07c7d276f1da8d5139df82374c599ab932e740d52147"
+
+[[artifacts]]
+version = "0.10.30"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.30/node-v0.10.30-linux-x64.tar.gz"
+checksum = "sha256:173d2b9ba4cbfb45a2472029f2904f965081498381a34d01b3889a850238de2b"
+
+[[artifacts]]
+version = "0.10.29"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.29/node-v0.10.29-linux-x64.tar.gz"
+checksum = "sha256:ac52da27a4e298a6de610de25b22628bdb97b78cb29d11464ef5cfa2e57847d5"
+
+[[artifacts]]
+version = "0.10.28"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.28/node-v0.10.28-linux-x64.tar.gz"
+checksum = "sha256:5f41f4a90861bddaea92addc5dfba5357de40962031c2281b1683277a0f75932"
+
+[[artifacts]]
+version = "0.10.27"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.27/node-v0.10.27-linux-x64.tar.gz"
+checksum = "sha256:919ef2245045f78725bec9152c711751a1278a8053b86dd181363c0b32465609"
+
+[[artifacts]]
+version = "0.10.26"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.26/node-v0.10.26-linux-x64.tar.gz"
+checksum = "sha256:305bf2983c65edea6dd2c9f3669b956251af03523d31cf0a0471504fd5920aac"
+
+[[artifacts]]
+version = "0.10.25"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.25/node-v0.10.25-linux-x64.tar.gz"
+checksum = "sha256:1dac61c21fa21e47fc6e799757569c6c3914897ca46fc8f4dd2c8f13f0400626"
+
+[[artifacts]]
+version = "0.10.24"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.24/node-v0.10.24-linux-x64.tar.gz"
+checksum = "sha256:6ef93f4a5b53cdd4471786dfc488ba9977cb3944285ed233f70c508b50f0cb5f"
+
+[[artifacts]]
+version = "0.10.23"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.23/node-v0.10.23-linux-x64.tar.gz"
+checksum = "sha256:0ebee6f9b937ed00efc777c468593e6a277dae897a3700090229c2e18d4a4304"
+
+[[artifacts]]
+version = "0.10.22"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.22/node-v0.10.22-linux-x64.tar.gz"
+checksum = "sha256:ca5bebc56830260581849c1099f00d1958b549fc59acfc0d37b1f01690e7ed6d"
+
+[[artifacts]]
+version = "0.10.21"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.21/node-v0.10.21-linux-x64.tar.gz"
+checksum = "sha256:2791efef0a1e9a9231b937e55e5b783146e23291bca59a65092f8340eb7c87c8"
+
+[[artifacts]]
+version = "0.10.20"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.20/node-v0.10.20-linux-x64.tar.gz"
+checksum = "sha256:eaebfc66d031f3b5071b72c84dd74f326a9a3c018e14d5de7d107c4f3a36dc96"
+
+[[artifacts]]
+version = "0.10.19"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.19/node-v0.10.19-linux-x64.tar.gz"
+checksum = "sha256:d9ff0bbc075149a91ac97dba8dabdf4473506527bc3c9461fe2cce92d3da1191"
+
+[[artifacts]]
+version = "0.10.18"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.18/node-v0.10.18-linux-x64.tar.gz"
+checksum = "sha256:480aed8ec0a2acf6c7cc168650045cea559c5b69c9b8538a181af830662c1262"
+
+[[artifacts]]
+version = "0.10.17"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.17/node-v0.10.17-linux-x64.tar.gz"
+checksum = "sha256:a4cf2690394cdb2468482816be22365544475777c2e9cf4058ef3015e33b7993"
+
+[[artifacts]]
+version = "0.10.16"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.16/node-v0.10.16-linux-x64.tar.gz"
+checksum = "sha256:5a2e29d41c6b9eb79e25df6e10fcea84cf44def31c79dec967e8a108c01b02f6"
+
+[[artifacts]]
+version = "0.10.15"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.15/node-v0.10.15-linux-x64.tar.gz"
+checksum = "sha256:0b5191748a91b1c49947fef6b143f3e5e5633c9381a31aaa467e7c80efafb6e9"
+
+[[artifacts]]
+version = "0.10.14"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.14/node-v0.10.14-linux-x64.tar.gz"
+checksum = "sha256:fbed54f3d87febc679823d5309aae52f19f104b8ac6927849b9b852a6fb7d060"
+
+[[artifacts]]
+version = "0.10.13"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.13/node-v0.10.13-linux-x64.tar.gz"
+checksum = "sha256:dcbad86b863faf4a1e10fec9ecd7864cebbbb6783805f1808f563797ce5db2b8"
+
+[[artifacts]]
+version = "0.10.12"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.12/node-v0.10.12-linux-x64.tar.gz"
+checksum = "sha256:d35f3ddb0e8f2de42f9da225a56c19a7aa5c62276d4278242f31087c0397adb8"
+
+[[artifacts]]
+version = "0.10.11"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.11/node-v0.10.11-linux-x64.tar.gz"
+checksum = "sha256:0fa2be9b44d6acd4bd43908bade00053de35e6e27f72a2dc41d072c86263b52a"
+
+[[artifacts]]
+version = "0.10.10"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.10/node-v0.10.10-linux-x64.tar.gz"
+checksum = "sha256:ab42335b0e6e45bac62823d995d8062e9ba0344bc416c76a263a5e45773b2e7d"
+
+[[artifacts]]
+version = "0.10.9"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.9/node-v0.10.9-linux-x64.tar.gz"
+checksum = "sha256:27159f584e108dbe5a9a884a98200a413203d339bf8596a3dbcaff9577fe1b1c"
+
+[[artifacts]]
+version = "0.10.8"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.8/node-v0.10.8-linux-x64.tar.gz"
+checksum = "sha256:47903aa0bc81df9d4503a1fe55f2b2914dfa74ac0dd5be3d554dc4282695f427"
+
+[[artifacts]]
+version = "0.10.7"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.7/node-v0.10.7-linux-x64.tar.gz"
+checksum = "sha256:9fdc924b9732ddf5fe278b7888a6c2c61074b15c71795f10e908b59387d3acd8"
+
+[[artifacts]]
+version = "0.10.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.6/node-v0.10.6-linux-x64.tar.gz"
+checksum = "sha256:cc7ccfce24ae0ebb0c50661ef8d98b5db07fc1cd4a222c5d1ae232260d5834ca"
+
+[[artifacts]]
+version = "0.10.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.5/node-v0.10.5-linux-x64.tar.gz"
+checksum = "sha256:8d9cd65fb6c4ce958649b7da993a9a1f58809a1c7abb408fd85918817d0384c1"
+
+[[artifacts]]
+version = "0.10.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.4/node-v0.10.4-linux-x64.tar.gz"
+checksum = "sha256:6d3eb0cf0438513c2a71a1ff5e9ad140574ffca5a7a100308157aa9005c5d333"
+
+[[artifacts]]
+version = "0.10.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.3/node-v0.10.3-linux-x64.tar.gz"
+checksum = "sha256:62ce0353c80023cd2eb0a60999b10839d732f5ae3eb75c10d7b3924745b32d21"
+
+[[artifacts]]
+version = "0.10.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.2/node-v0.10.2-linux-x64.tar.gz"
+checksum = "sha256:44ff658b1c3ae027b75310e0173b7d069ae70f6adaed23d22f2e087f5048c428"
+
+[[artifacts]]
+version = "0.10.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.1/node-v0.10.1-linux-x64.tar.gz"
+checksum = "sha256:90c555a55ab5d343148511623fdb7c37a6888952db5340734d1c2b8f0f01dd11"
+
+[[artifacts]]
+version = "0.10.0"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.10.0/node-v0.10.0-linux-x64.tar.gz"
+checksum = "sha256:a91c84f993c1674be7548deb81486bf34ade4aa9154f7932d294ed945228a5be"
+
+[[artifacts]]
+version = "0.9.12"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.12/node-v0.9.12-linux-x64.tar.gz"
+checksum = "sha256:bfd58129371ca6abff9adda83dd3d5dee44add6eb4a4c09f074521b97614a7b7"
+
+[[artifacts]]
+version = "0.9.11"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.11/node-v0.9.11-linux-x64.tar.gz"
+checksum = "sha256:511d69123ca08c76692e6c5baf1d7d7dc702993a59bd37ebfd4976b4d833de98"
+
+[[artifacts]]
+version = "0.9.10"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.10/node-v0.9.10-linux-x64.tar.gz"
+checksum = "sha256:7983aed8394a7f159492bd715e0ea3ad0d4d22b2be388b7f9c59b4945d282188"
+
+[[artifacts]]
+version = "0.9.9"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.9/node-v0.9.9-linux-x64.tar.gz"
+checksum = "sha256:76a1b5d17a0bf4de47982c33f9f7e1f1517c4de3defc042cad6f0ef8eac4dc90"
+
+[[artifacts]]
+version = "0.9.8"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.8/node-v0.9.8-linux-x64.tar.gz"
+checksum = "sha256:673e8d79e25d9312725a12c2a10f1c313beffd558e2a49553ac0837a5ab0430b"
+
+[[artifacts]]
+version = "0.9.7"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.7/node-v0.9.7-linux-x64.tar.gz"
+checksum = "sha256:9bd95268508a59127d901164f1375d3c8908df858cfc781a312fa95410e59679"
+
+[[artifacts]]
+version = "0.9.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.6/node-v0.9.6-linux-x64.tar.gz"
+checksum = "sha256:739e20d6bc3fefe50b07dd01fa524389b846b6b6caa31a1b2e1ca0246d8f7c56"
+
+[[artifacts]]
+version = "0.9.5"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.5/node-v0.9.5-linux-x64.tar.gz"
+checksum = "sha256:e6a28d6946bd15132b6af44e00e91c15b7fabfb66713189449b71b2ccf2a3123"
+
+[[artifacts]]
+version = "0.9.4"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.4/node-v0.9.4-linux-x64.tar.gz"
+checksum = "sha256:10daa5991f2e82874ac5a2ad3c223dea4e7f2f67587825135396906edbfb16d1"
+
+[[artifacts]]
+version = "0.9.3"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.3/node-v0.9.3-linux-x64.tar.gz"
+checksum = "sha256:fa92deff7cffd10130520245c1bc724a22c61d89e50d0e232af5c51eeb80dcfe"
+
+[[artifacts]]
+version = "0.9.2"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.2/node-v0.9.2-linux-x64.tar.gz"
+checksum = "sha256:db2b1740f652ffdfeecb073d1ca91863783675f42c31c2fe6f7643da11268331"
+
+[[artifacts]]
+version = "0.9.1"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.9.1/node-v0.9.1-linux-x64.tar.gz"
+checksum = "sha256:094afa13511cac6638f69b100ca4990392ea5430f2277b7acd93a1f2378e3b86"
+
+[[artifacts]]
+version = "0.8.28"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.28/node-v0.8.28-linux-x64.tar.gz"
+checksum = "sha256:9ea0be4f08ade1645d2acb3fc4e294eb4d1ca595a405168caec2d7a0d41ca84e"
+
+[[artifacts]]
+version = "0.8.27"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.27/node-v0.8.27-linux-x64.tar.gz"
+checksum = "sha256:d65fafd755ed630abc6df04548dc3075282c06661cfd44f1af42c5e15a8c6826"
+
+[[artifacts]]
+version = "0.8.26"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.26/node-v0.8.26-linux-x64.tar.gz"
+checksum = "sha256:57e70b7571393cc32019f0ff6d086183198b8e7824c3690ebed504d37f52c298"
+
+[[artifacts]]
+version = "0.8.25"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.25/node-v0.8.25-linux-x64.tar.gz"
+checksum = "sha256:7eedbece123b5acacfa5ca9d1e7a1ab6bd9b32bed5b3c92f6853cca57be82d07"
+
+[[artifacts]]
+version = "0.8.24"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.24/node-v0.8.24-linux-x64.tar.gz"
+checksum = "sha256:1296b795fb1d8406d7548372caef82454c460111b3ed4ef6d4b67dca6cfa4a76"
+
+[[artifacts]]
+version = "0.8.23"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.23/node-v0.8.23-linux-x64.tar.gz"
+checksum = "sha256:b88284ec2a5944154962bfe3221238a003aa0a6b5306f777ad1554c22e89698b"
+
+[[artifacts]]
+version = "0.8.22"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.22/node-v0.8.22-linux-x64.tar.gz"
+checksum = "sha256:6228478b96ed4765bdf9576abfb19088ba8ef333cd86a9e18c31e26014cbbad5"
+
+[[artifacts]]
+version = "0.8.21"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.21/node-v0.8.21-linux-x64.tar.gz"
+checksum = "sha256:eaedcf7e3e443cf2fa35f834ed62b334885dc20fcbc7a32ea34e8e85f81b2533"
+
+[[artifacts]]
+version = "0.8.20"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.20/node-v0.8.20-linux-x64.tar.gz"
+checksum = "sha256:e78965ffe7b7b56c15fbde44b8a9da7438a3527567b895b71336015917c7923e"
+
+[[artifacts]]
+version = "0.8.19"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.19/node-v0.8.19-linux-x64.tar.gz"
+checksum = "sha256:32ab76970568ea17a7c20bb49d31b82b2534138fe30256086544734e4fd728c7"
+
+[[artifacts]]
+version = "0.8.18"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.18/node-v0.8.18-linux-x64.tar.gz"
+checksum = "sha256:20c3e06f5f0d31b4e95bbba35eaff1f953a2b471021cc49e53b546c2e2efd97b"
+
+[[artifacts]]
+version = "0.8.17"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.17/node-v0.8.17-linux-x64.tar.gz"
+checksum = "sha256:e55ee735ca063026901c1f876ac1b04d345150e06f54977e693b5ce5d082fd01"
+
+[[artifacts]]
+version = "0.8.16"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.16/node-v0.8.16-linux-x64.tar.gz"
+checksum = "sha256:528ca5b68c04bf13dd9eaf784328dcfe6128449b32a409c5ef798200e7f15350"
+
+[[artifacts]]
+version = "0.8.15"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.15/node-v0.8.15-linux-x64.tar.gz"
+checksum = "sha256:97026c2a421737ac54b0faa95ea0d261b9940f7524bf2bcf5ce0aadf05f98377"
+
+[[artifacts]]
+version = "0.8.14"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.14/node-v0.8.14-linux-x64.tar.gz"
+checksum = "sha256:032aeede8ef2f147c10327aa310430554a67c30c6fe3b041426e7afb39932320"
+
+[[artifacts]]
+version = "0.8.13"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.13/node-v0.8.13-linux-x64.tar.gz"
+checksum = "sha256:963b0187643a2c60a597ffcdb71343765e4a0acb8cb53ff14f8c3a3bd4226b58"
+
+[[artifacts]]
+version = "0.8.12"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.12/node-v0.8.12-linux-x64.tar.gz"
+checksum = "sha256:7a5437d5c088f1b787444b2ac049add8fd11f21f0486819491ac1b3965d6f288"
+
+[[artifacts]]
+version = "0.8.11"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.11/node-v0.8.11-linux-x64.tar.gz"
+checksum = "sha256:8586d1e89977567c5c3d75a974409a2453a5fc9f26f8ea634016dee255595347"
+
+[[artifacts]]
+version = "0.8.10"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.10/node-v0.8.10-linux-x64.tar.gz"
+checksum = "sha256:536b88491d8d5db046897a4024209b076be1c25dbf92474b85f8b854812c2c21"
+
+[[artifacts]]
+version = "0.8.9"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.9/node-v0.8.9-linux-x64.tar.gz"
+checksum = "sha256:ee785197324d0a0335de12a2be124b2eaf49865fc791d600651edff3d3831aea"
+
+[[artifacts]]
+version = "0.8.8"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.8/node-v0.8.8-linux-x64.tar.gz"
+checksum = "sha256:bc0038a4ec650578b8d9a55aa4f86be22b43c0115a1efe0378d6a177a8ee3bca"
+
+[[artifacts]]
+version = "0.8.7"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.7/node-v0.8.7-linux-x64.tar.gz"
+checksum = "sha256:a9fa9e6ea54bb8cc940264dab60c867f8231aef00b4d1b07be63f3150e91067e"
+
+[[artifacts]]
+version = "0.8.6"
+os = "linux"
+arch = "amd64"
+url = "https://nodejs.org/download/release/v0.8.6/node-v0.8.6-linux-x64.tar.gz"
+checksum = "sha256:d2c04ae64f9070b6ab5b7da7ccfc6d22f019e165ce6cce06d3ab422dfbeded1f"

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -36,7 +36,7 @@ pub(crate) enum DistLayerError {
     Download(libherokubuildpack::download::DownloadError),
     #[error("Couldn't decompress Node.js distribution: {0}")]
     Untar(std::io::Error),
-    #[error("Couldn't extra tarball prefix from artifact URL: {0}")]
+    #[error("Couldn't extract tarball prefix from artifact URL: {0}")]
     TarballPrefix(String),
     #[error("Couldn't move Node.js distribution artifacts to the correct location: {0}")]
     Installation(std::io::Error),

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -59,7 +59,10 @@ impl Layer for DistLayer {
     ) -> Result<LayerResult<Self::Metadata>, NodeJsEngineBuildpackError> {
         let node_tgz = NamedTempFile::new().map_err(DistLayerError::TempFile)?;
 
-        log_info(format!("Downloading Node.js {}", self.artifact));
+        log_info(format!(
+            "Downloading Node.js {} from {}",
+            self.artifact, self.artifact.url
+        ));
         download_file(&self.artifact.url, node_tgz.path()).map_err(DistLayerError::Download)?;
 
         log_info(format!("Extracting Node.js {}", self.artifact));

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -73,7 +73,7 @@ impl Layer for DistLayer {
         ));
         download_file(&self.artifact.url, node_tgz.path()).map_err(DistLayerError::Download)?;
 
-        log_info("Verifying Node.js checksum");
+        log_info("Verifying checksum");
         let digest = sha256(node_tgz.path()).map_err(DistLayerError::ReadTempFile)?;
         if self.artifact.checksum.value != digest {
             Err(DistLayerError::ChecksumVerification)?;

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -59,13 +59,13 @@ impl Layer for DistLayer {
     ) -> Result<LayerResult<Self::Metadata>, NodeJsEngineBuildpackError> {
         let node_tgz = NamedTempFile::new().map_err(DistLayerError::TempFile)?;
 
-        log_info(format!("Downloading Node.js {}", self.artifact.version));
+        log_info(format!("Downloading Node.js {}", self.artifact));
         download_file(&self.artifact.url, node_tgz.path()).map_err(DistLayerError::Download)?;
 
-        log_info(format!("Extracting Node.js {}", self.artifact.version));
+        log_info(format!("Extracting Node.js {}", self.artifact));
         decompress_tarball(&mut node_tgz.into_file(), layer_path).map_err(DistLayerError::Untar)?;
 
-        log_info(format!("Installing Node.js {}", self.artifact.version));
+        log_info(format!("Installing Node.js {}", self.artifact));
         let dist_name = format!("node-v{}-{}", self.artifact.version, "linux-x64");
         let dist_path = Path::new(layer_path).join(dist_name);
         move_directory_contents(dist_path, layer_path).map_err(DistLayerError::Installation)?;
@@ -79,7 +79,7 @@ impl Layer for DistLayer {
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
         if layer_data.content_metadata.metadata == DistLayerMetadata::current(self) {
-            log_info(format!("Reusing Node.js {}", self.artifact.version));
+            log_info(format!("Reusing Node.js {}", self.artifact));
             Ok(ExistingLayerStrategy::Keep)
         } else {
             Ok(ExistingLayerStrategy::Recreate)

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -1,5 +1,6 @@
 use crate::{NodeJsEngineBuildpack, NodeJsEngineBuildpackError};
-use heroku_nodejs_utils::inv::Release;
+use heroku_inventory_utils::inv::Artifact;
+use heroku_nodejs_utils::vrs::Version;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
@@ -9,13 +10,14 @@ use libherokubuildpack::fs::move_directory_contents;
 use libherokubuildpack::log::log_info;
 use libherokubuildpack::tar::decompress_tarball;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use std::path::Path;
 use tempfile::NamedTempFile;
 use thiserror::Error;
 
 /// A layer that downloads the Node.js distribution artifacts
 pub(crate) struct DistLayer {
-    pub(crate) release: Release,
+    pub(crate) release: Artifact<Version, Sha256>,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -121,14 +121,10 @@ fn sha256(path: impl AsRef<Path>) -> Result<Vec<u8>, std::io::Error> {
 }
 
 fn extract_tarball_prefix(url: &str) -> Option<&str> {
-    let last_slash = url.rfind('/')?;
-    let tar_gz_index = url.rfind(".tar.gz")?;
-
-    if tar_gz_index > last_slash {
-        Some(&url[last_slash + 1..tar_gz_index])
-    } else {
-        None
-    }
+    url.rfind('/').and_then(|last_slash| {
+        url.rfind(".tar.gz")
+            .map(|tar_gz_index| &url[last_slash + 1..tar_gz_index])
+    })
 }
 
 impl DistLayerMetadata {

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -1,3 +1,5 @@
+use std::env::consts;
+
 use crate::layers::{
     DistLayer, DistLayerError, NodeRuntimeMetricsError, NodeRuntimeMetricsLayer, WebEnvLayer,
 };
@@ -86,10 +88,13 @@ impl Buildpack for NodeJsEngineBuildpack {
             Requirement::parse(LTS_VERSION).expect("The default Node.js version should be valid")
         };
 
-        let target_artifact = resolve(&inv.artifacts, Os::Linux, Arch::Amd64, &version_range)
-            .ok_or(NodeJsEngineBuildpackError::UnknownVersionError(
-                version_range.to_string(),
-            ))?;
+        let target_artifact = match (consts::OS.parse::<Os>(), consts::ARCH.parse::<Arch>()) {
+            (Ok(os), Ok(arch)) => resolve(&inv.artifacts, os, arch, &version_range),
+            (_, _) => None,
+        }
+        .ok_or(NodeJsEngineBuildpackError::UnknownVersionError(
+            version_range.to_string(),
+        ))?;
 
         log_info(format!(
             "Resolved Node.js version: {}",

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -86,21 +86,21 @@ impl Buildpack for NodeJsEngineBuildpack {
             Requirement::parse(LTS_VERSION).expect("The default Node.js version should be valid")
         };
 
-        let target_release = resolve(&inv.artifacts, Os::Linux, Arch::Amd64, &version_range)
+        let target_artifact = resolve(&inv.artifacts, Os::Linux, Arch::Amd64, &version_range)
             .ok_or(NodeJsEngineBuildpackError::UnknownVersionError(
                 version_range.to_string(),
             ))?;
 
         log_info(format!(
             "Resolved Node.js version: {}",
-            target_release.version
+            target_artifact.version
         ));
 
         log_header("Installing Node.js distribution");
         context.handle_layer(
             layer_name!("dist"),
             DistLayer {
-                release: target_release.clone(),
+                artifact: target_artifact.clone(),
             },
         )?;
 
@@ -108,7 +108,7 @@ impl Buildpack for NodeJsEngineBuildpack {
 
         if Requirement::parse(MINIMUM_NODE_VERSION_FOR_METRICS)
             .expect("should be a valid version range")
-            .satisfies(&target_release.version)
+            .satisfies(&target_artifact.version)
         {
             context.handle_layer(layer_name!("node_runtime_metrics"), NodeRuntimeMetricsLayer)?;
         }

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -27,6 +27,10 @@ fn simple_indexjs() {
 fn simple_serverjs() {
     nodejs_integration_test("./fixtures/node-with-serverjs", |ctx| {
         assert_contains!(ctx.pack_stdout, "Detected Node.js version range: 16.0.0");
+        assert_contains!(
+            ctx.pack_stdout,
+            "Downloading Node.js 16.0.0 (linux-amd64) from https://nodejs.org/download/release/v16.0.0/node-v16.0.0-linux-x64.tar.gz"
+        );
         assert_contains!(ctx.pack_stdout, "Installing Node.js 16.0.0 (linux-amd64)");
         assert_web_response(&ctx, "node-with-serverjs");
     });

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -27,7 +27,7 @@ fn simple_indexjs() {
 fn simple_serverjs() {
     nodejs_integration_test("./fixtures/node-with-serverjs", |ctx| {
         assert_contains!(ctx.pack_stdout, "Detected Node.js version range: 16.0.0");
-        assert_contains!(ctx.pack_stdout, "Installing Node.js 16.0.0");
+        assert_contains!(ctx.pack_stdout, "Installing Node.js 16.0.0 (linux-amd64)");
         assert_web_response(&ctx, "node-with-serverjs");
     });
 }

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
-heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "28d59e1935a6474f854d030a18e2a52ea5cd258d" }
+heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "2a86fae18332b9bd495eb29422c13ac3fcb2d0dc" }
 indoc = "2"
 node-semver = "2"
 opentelemetry = "0.22"

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
+heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "28d59e1935a6474f854d030a18e2a52ea5cd258d" }
 indoc = "2"
 node-semver = "2"
 opentelemetry = "0.22"

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -20,6 +20,7 @@ regex = "1"
 serde = { version = "1", features = ['derive'] }
 serde_json = "1"
 serde-xml-rs = "0.6"
+sha2 = "0.10.8"
 thiserror = "1"
 toml = "0.8"
 ureq = { version = "2", features = ["json"] }

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -137,15 +137,13 @@ fn parse_shasums(input: &str) -> HashMap<String, String> {
         .lines()
         .filter_map(|line| {
             let mut parts = line.split_whitespace();
-            match (parts.next(), parts.next()) {
-                (Some(checksum), Some(filename)) if parts.next().is_none() => {
-                    Some((
-                        // Some of the checksum filenames contain a leading `./` (e.g.
-                        // https://nodejs.org/download/release/v0.11.6/SHASUMS256.txt)
-                        filename.trim_start_matches("./").to_string(),
-                        checksum.to_string(),
-                    ))
-                }
+            match (parts.next(), parts.next(), parts.next()) {
+                (Some(checksum), Some(filename), None) => Some((
+                    // Some of the checksum filenames contain a leading `./` (e.g.
+                    // https://nodejs.org/download/release/v0.11.6/SHASUMS256.txt)
+                    filename.trim_start_matches("./").to_string(),
+                    checksum.to_string(),
+                )),
                 _ => None,
             }
         })

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -77,12 +77,15 @@ fn list_upstream_artifacts() -> Result<Vec<Artifact<Version, Sha256>>, anyhow::E
     let earliest_version =
         Version::parse("0.8.6").context("Failed to parse earliest Node.js version")?;
 
-    list_releases()?
-        .into_iter()
-        .filter(|release| release.version >= earliest_version)
-        .map(|release| get_release_artifacts(&release))
-        .collect::<Result<Vec<_>>>()
-        .map(|nested| nested.into_iter().flatten().collect())
+    let mut artifacts = vec![];
+    for release in list_releases()? {
+        if release.version >= earliest_version {
+            for artifact in get_release_artifacts(&release)? {
+                artifacts.push(artifact);
+            }
+        }
+    }
+    Ok(artifacts)
 }
 
 fn get_release_artifacts(release: &NodeJSRelease) -> Result<Vec<Artifact<Version, Sha256>>> {

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -18,7 +18,7 @@ use std::{
 fn main() {
     let inventory_path = env::args().nth(1).unwrap_or_else(|| {
         eprintln!("Usage: update_inventory <path/to/inventory.toml>");
-        process::exit(2);
+        process::exit(1);
     });
 
     let inventory_artifacts: HashSet<Artifact<Version, Sha256>> =
@@ -33,7 +33,7 @@ fn main() {
 
     let upstream_artifacts = list_upstream_artifacts().unwrap_or_else(|e| {
         eprintln!("Failed to fetch upstream node.js versions: {e}");
-        process::exit(4);
+        process::exit(1);
     });
 
     let inventory = Inventory {
@@ -42,12 +42,12 @@ fn main() {
 
     let toml = toml::to_string(&inventory).unwrap_or_else(|e| {
         eprintln!("Error serializing inventory as toml: {e}");
-        process::exit(6);
+        process::exit(1);
     });
 
     fs::write(inventory_path, toml).unwrap_or_else(|e| {
         eprintln!("Error writing inventory file: {e}");
-        process::exit(7);
+        process::exit(1);
     });
 
     let remote_artifacts: HashSet<Artifact<Version, Sha256>> =

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -31,13 +31,13 @@ fn main() {
             .into_iter()
             .collect();
 
-    let remote_artifacts = list_upstream_artifacts().unwrap_or_else(|e| {
+    let upstream_artifacts = list_upstream_artifacts().unwrap_or_else(|e| {
         eprintln!("Failed to fetch upstream go versions: {e}");
         process::exit(4);
     });
 
     let inventory = Inventory {
-        artifacts: remote_artifacts,
+        artifacts: upstream_artifacts,
     };
 
     let toml = toml::to_string(&inventory).unwrap_or_else(|e| {

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -1,0 +1,169 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
+use anyhow::{Context, Result};
+use heroku_inventory_utils::{
+    checksum::Checksum,
+    inv::{read_inventory_file, Arch, Artifact, Inventory, Os},
+};
+use node_semver::Version;
+use serde::Deserialize;
+use sha2::Sha256;
+use std::{
+    collections::{HashMap, HashSet},
+    env, fs, process,
+};
+
+/// Updates the local node.js inventory.toml with versions published on nodejs.org.
+fn main() {
+    let inventory_path = env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("Usage: update_inventory <path/to/inventory.toml>");
+        process::exit(2);
+    });
+
+    let inventory_artifacts: HashSet<Artifact<Version, Sha256>> =
+        read_inventory_file(&inventory_path)
+            .unwrap_or_else(|e| {
+                eprintln!("Error reading inventory at '{inventory_path}': {e}");
+                std::process::exit(1);
+            })
+            .artifacts
+            .into_iter()
+            .collect();
+
+    // List available upstream artifacts.
+    let remote_artifacts = list_upstream_artifacts().unwrap_or_else(|e| {
+        eprintln!("Failed to fetch upstream go versions: {e}");
+        process::exit(4);
+    });
+
+    let inventory = Inventory {
+        artifacts: remote_artifacts,
+    };
+
+    let toml = toml::to_string(&inventory).unwrap_or_else(|e| {
+        eprintln!("Error serializing inventory as toml: {e}");
+        process::exit(6);
+    });
+
+    fs::write(inventory_path, toml).unwrap_or_else(|e| {
+        eprintln!("Error writing inventory to file: {e}");
+        process::exit(7);
+    });
+
+    let remote_artifacts: HashSet<Artifact<Version, Sha256>> =
+        inventory.artifacts.into_iter().collect();
+
+    [
+        ("Added", &remote_artifacts - &inventory_artifacts),
+        ("Removed", &inventory_artifacts - &remote_artifacts),
+    ]
+    .iter()
+    .filter(|(_, artifact_diff)| !artifact_diff.is_empty())
+    .for_each(|(action, artifacts)| {
+        let mut list: Vec<&Artifact<Version, Sha256>> = artifacts.iter().collect();
+        list.sort_by_key(|a| &a.version);
+        println!(
+            "{} {}.",
+            action,
+            list.iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    });
+}
+
+pub(crate) fn list_upstream_artifacts() -> Result<Vec<Artifact<Version, Sha256>>, anyhow::Error> {
+    let target_version = Version::parse("0.8.6").context("Failed to parse version")?;
+
+    list_releases()?
+        .into_iter()
+        .filter(|release| release.version >= target_version)
+        .map(|release| get_release_artifacts(&release))
+        .collect::<Result<Vec<_>>>()
+        .map(|nested| nested.into_iter().flatten().collect())
+}
+
+fn get_release_artifacts(release: &NodeJSRelease) -> Result<Vec<Artifact<Version, Sha256>>> {
+    let supported_platforms = HashMap::from([
+        ("linux-arm64", (Os::Linux, Arch::Arm64)),
+        ("linux-x64", (Os::Linux, Arch::Amd64)),
+    ]);
+
+    let shasums = fetch_checksums(&release.version)?;
+    release
+        .files
+        .iter()
+        .filter(|file| supported_platforms.contains_key(&file.as_str()))
+        .map(|file| {
+            let (os, arch) = supported_platforms
+                .get(file.as_str())
+                .ok_or_else(|| anyhow::anyhow!("Unsupported platform: {}", file))?;
+
+            let filename = format!("node-v{}-{}.tar.gz", release.version, file);
+            let checksum_hex = shasums
+                .get(&filename)
+                .ok_or_else(|| anyhow::anyhow!("Checksum not found for {}", filename))?;
+
+            Ok(Artifact::<Version, Sha256> {
+                url: format!(
+                    "https://nodejs.org/download/release/v{}/{filename}",
+                    release.version
+                ),
+                version: release.version.clone(),
+                checksum: Checksum::try_from(checksum_hex.to_owned())?,
+                arch: *arch,
+                os: *os,
+            })
+        })
+        .collect()
+}
+
+fn fetch_checksums(version: &Version) -> Result<HashMap<String, String>> {
+    ureq::get(&format!(
+        "https://nodejs.org/download/release/v{version}/SHASUMS256.txt"
+    ))
+    .call()?
+    .into_string()
+    .map_err(anyhow::Error::from)
+    .map(|x| parse_shasums(&x))
+}
+
+// Parses a SHASUMS256.txt file into a map of filename to checksum.
+// Lines are expected to be of the form `<checksum> <filename>`.
+fn parse_shasums(input: &str) -> HashMap<String, String> {
+    input
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.split_whitespace();
+            match (parts.next(), parts.next()) {
+                (Some(checksum), Some(filename)) if parts.next().is_none() => {
+                    Some((
+                        // Some of the checksum filenames contain a leading `./` (e.g.
+                        // https://nodejs.org/download/release/v0.11.6/SHASUMS256.txt)
+                        filename.trim_start_matches("./").to_string(),
+                        checksum.to_string(),
+                    ))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+const NODE_UPSTREAM_LIST_URL: &str = "https://nodejs.org/download/release/index.json";
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct NodeJSRelease {
+    pub(crate) version: Version,
+    pub(crate) files: Vec<String>,
+}
+
+pub(crate) fn list_releases() -> Result<Vec<NodeJSRelease>> {
+    ureq::get(NODE_UPSTREAM_LIST_URL)
+        .call()
+        .context("Failed to fetch nodejs.org release list")?
+        .into_json::<Vec<NodeJSRelease>>()
+        .context("Failed to parse nodejs.org release list from JSON")
+}

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -26,7 +26,15 @@ fn main() -> Result<()> {
             .into_iter()
             .collect();
 
-    let upstream_artifacts = list_upstream_artifacts()?;
+    let mut upstream_artifacts = vec![];
+    for release in list_releases()? {
+        if release.version >= Version::parse("0.8.6")? {
+            for artifact in get_release_artifacts(&release)? {
+                upstream_artifacts.push(artifact);
+            }
+        }
+    }
+
     let inventory = Inventory {
         artifacts: upstream_artifacts,
     };
@@ -57,18 +65,6 @@ fn main() -> Result<()> {
     });
 
     Ok(())
-}
-
-fn list_upstream_artifacts() -> Result<Vec<Artifact<Version, Sha256>>, anyhow::Error> {
-    let mut artifacts = vec![];
-    for release in list_releases()? {
-        if release.version >= Version::parse("0.8.6")? {
-            for artifact in get_release_artifacts(&release)? {
-                artifacts.push(artifact);
-            }
-        }
-    }
-    Ok(artifacts)
 }
 
 fn get_release_artifacts(release: &NodeJSRelease) -> Result<Vec<Artifact<Version, Sha256>>> {

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -32,7 +32,7 @@ fn main() {
             .collect();
 
     let upstream_artifacts = list_upstream_artifacts().unwrap_or_else(|e| {
-        eprintln!("Failed to fetch upstream go versions: {e}");
+        eprintln!("Failed to fetch upstream node.js versions: {e}");
         process::exit(4);
     });
 

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -74,12 +74,9 @@ fn main() {
 }
 
 fn list_upstream_artifacts() -> Result<Vec<Artifact<Version, Sha256>>, anyhow::Error> {
-    let earliest_version =
-        Version::parse("0.8.6").context("Failed to parse earliest Node.js version")?;
-
     let mut artifacts = vec![];
     for release in list_releases()? {
-        if release.version >= earliest_version {
+        if release.version >= Version::parse("0.8.6")? {
             for artifact in get_release_artifacts(&release)? {
                 artifacts.push(artifact);
             }

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -31,7 +31,6 @@ fn main() {
             .into_iter()
             .collect();
 
-    // List available upstream artifacts.
     let remote_artifacts = list_upstream_artifacts().unwrap_or_else(|e| {
         eprintln!("Failed to fetch upstream go versions: {e}");
         process::exit(4);

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -25,7 +25,7 @@ fn main() {
         read_inventory_file(&inventory_path)
             .unwrap_or_else(|e| {
                 eprintln!("Error reading inventory at '{inventory_path}': {e}");
-                std::process::exit(1);
+                process::exit(1);
             })
             .artifacts
             .into_iter()

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -46,7 +46,7 @@ fn main() {
     });
 
     fs::write(inventory_path, toml).unwrap_or_else(|e| {
-        eprintln!("Error writing inventory to file: {e}");
+        eprintln!("Error writing inventory file: {e}");
         process::exit(7);
     });
 

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -74,7 +74,7 @@ fn main() {
     });
 }
 
-pub(crate) fn list_upstream_artifacts() -> Result<Vec<Artifact<Version, Sha256>>, anyhow::Error> {
+fn list_upstream_artifacts() -> Result<Vec<Artifact<Version, Sha256>>, anyhow::Error> {
     let target_version = Version::parse("0.8.6").context("Failed to parse version")?;
 
     list_releases()?
@@ -155,12 +155,12 @@ fn parse_shasums(input: &str) -> HashMap<String, String> {
 const NODE_UPSTREAM_LIST_URL: &str = "https://nodejs.org/download/release/index.json";
 
 #[derive(Deserialize, Debug)]
-pub(crate) struct NodeJSRelease {
+struct NodeJSRelease {
     pub(crate) version: Version,
     pub(crate) files: Vec<String>,
 }
 
-pub(crate) fn list_releases() -> Result<Vec<NodeJSRelease>> {
+fn list_releases() -> Result<Vec<NodeJSRelease>> {
     ureq::get(NODE_UPSTREAM_LIST_URL)
         .call()
         .context("Failed to fetch nodejs.org release list")?

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -74,11 +74,12 @@ fn main() {
 }
 
 fn list_upstream_artifacts() -> Result<Vec<Artifact<Version, Sha256>>, anyhow::Error> {
-    let target_version = Version::parse("0.8.6").context("Failed to parse version")?;
+    let earliest_version =
+        Version::parse("0.8.6").context("Failed to parse earliest Node.js version")?;
 
     list_releases()?
         .into_iter()
-        .filter(|release| release.version >= target_version)
+        .filter(|release| release.version >= earliest_version)
         .map(|release| get_release_artifacts(&release))
         .collect::<Result<Vec<_>>>()
         .map(|nested| nested.into_iter().flatten().collect())

--- a/common/nodejs-utils/src/lib.rs
+++ b/common/nodejs-utils/src/lib.rs
@@ -1,3 +1,5 @@
+use sha2 as _;
+
 pub mod application;
 pub mod distribution;
 pub mod inv;

--- a/common/nodejs-utils/src/vrs.rs
+++ b/common/nodejs-utils/src/vrs.rs
@@ -1,5 +1,6 @@
 use crate::{distribution::Distribution, s3};
 use anyhow::anyhow;
+use heroku_inventory_utils::inv::VersionRequirement;
 use node_semver::{Range, Version as NSVersion};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -74,6 +75,12 @@ impl fmt::Display for Version {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(try_from = "String")]
 pub struct Requirement(Range);
+
+impl VersionRequirement<Version> for Requirement {
+    fn satisfies(&self, version: &Version) -> bool {
+        self.satisfies(version)
+    }
+}
 
 impl Requirement {
     /// Parses `package.json` version string into a Requirement. Handles


### PR DESCRIPTION
This PR introduces support for the artifact inventory code shared with the Go buildpack, and updates the GitHub actions for node.js to write a corresponding `inventory.toml` file in the new format (which includes the `sha256` checksum that is used to verify the download, as well as the upstream URL rather than our own S3 mirrored artifact store).

A few notes:

* The shared inventory code is being [pulled directly from the Go buildpack](https://github.com/heroku/buildpacks-nodejs/pull/814/files#diff-1c40ca553da3605cd6bc186c75dc58896ae0e0114a1bb8479939b219747d3117R10). This will be moved to `libherokubuildpack` at some point.
* The inventory file includes arm64 and amd64 linux artifacts and are resolved based on [the current host OS and arch](https://github.com/heroku/buildpacks-nodejs/pull/814/files#diff-8aedf08d8ee6e6284476c90e1f7457c8e0be666ac0cf4822b5f4785f10737214R91-R93).
* `darwin` artifacts and the `staging` channel releases are no longer included in the inventory.
* As the classic nodejs buildpack uses the current implementation for inventory updates, this PR does not update or remove any of the shared code.
* When/if the classic node.js buildpack if migrated to use the new inventory utilities we can remove the node specific code from this repository.

We may also want to consider migrating NPM and Yarn over to the new format at some point (so we can avoid mirroring, and simplify our codebase), but that's probably out of scope for the time being.