### PR TITLE
Add linux/arm64 targets

### DIFF
--- a/buildpacks/nodejs-corepack/CHANGELOG.md
+++ b/buildpacks/nodejs-corepack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 - No changes.

--- a/buildpacks/nodejs-corepack/buildpack.toml
+++ b/buildpacks/nodejs-corepack/buildpack.toml
@@ -18,5 +18,9 @@ id = "*"
 os = "linux"
 arch = "amd64"
 
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-corepack" }

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 - Added Node.js version 22.1.0.

--- a/buildpacks/nodejs-engine/buildpack.toml
+++ b/buildpacks/nodejs-engine/buildpack.toml
@@ -18,5 +18,9 @@ id = "*"
 os = "linux"
 arch = "amd64"
 
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-engine" }

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 - No changes.

--- a/buildpacks/nodejs-function-invoker/buildpack.toml
+++ b/buildpacks/nodejs-function-invoker/buildpack.toml
@@ -17,6 +17,10 @@ id = "heroku-22"
 os = "linux"
 arch = "amd64"
 
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.runtime]
 package_name = "@heroku/sf-fx-runtime-nodejs"
 package_version = "0.14.4"

--- a/buildpacks/nodejs-npm-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 - Added npm version 10.7.0.

--- a/buildpacks/nodejs-npm-engine/buildpack.toml
+++ b/buildpacks/nodejs-npm-engine/buildpack.toml
@@ -18,5 +18,9 @@ id = "*"
 os = "linux"
 arch = "amd64"
 
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-npm-engine" }

--- a/buildpacks/nodejs-npm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-install/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 - No changes.

--- a/buildpacks/nodejs-npm-install/buildpack.toml
+++ b/buildpacks/nodejs-npm-install/buildpack.toml
@@ -14,5 +14,13 @@ type = "MIT"
 [[stacks]]
 id = "*"
 
+[[targets]]
+os = "linux"
+arch = "amd64"
+
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-npm-install" }

--- a/buildpacks/nodejs-pnpm-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 - No changes.

--- a/buildpacks/nodejs-pnpm-engine/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-engine/buildpack.toml
@@ -18,5 +18,9 @@ id = "*"
 os = "linux"
 arch = "amd64"
 
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-pnpm-engine" }

--- a/buildpacks/nodejs-pnpm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-install/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 - No changes.

--- a/buildpacks/nodejs-pnpm-install/buildpack.toml
+++ b/buildpacks/nodejs-pnpm-install/buildpack.toml
@@ -18,5 +18,9 @@ id = "*"
 os = "linux"
 arch = "amd64"
 
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-pnpm-install" }

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 - Added Yarn version 4.2.1.

--- a/buildpacks/nodejs-yarn/buildpack.toml
+++ b/buildpacks/nodejs-yarn/buildpack.toml
@@ -18,5 +18,9 @@ id = "*"
 os = "linux"
 arch = "amd64"
 
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs-yarn" }

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
 ## [3.0.6] - 2024-05-03
 
 ### Changed


### PR DESCRIPTION
This PR simply adds the linux/arm64 targets required to package and use the various buildpacks in this repository.

It depends on https://github.com/heroku/buildpacks-nodejs/pull/814, which introduces arm64 support through updated inventory logic and version resolution that factors in the host OS and arch.