### PR TITLE
Add `[[metadata.targets]]` to `heroku/nodejs` for arm64 support

### DIFF
--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.1.0] - 2024-05-09
-
 ### Added
 
 - Support for `arm64` and multi-arch images. ([#815](https://github.com/heroku/buildpacks-nodejs/pull/815))
+
+## [3.1.0] - 2024-05-09
 
 ### Changed
 

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -80,5 +80,13 @@ version = "3.1.0"
 id = "heroku/nodejs-engine"
 version = "3.1.0"
 
+[[metadata.targets]]
+os = "linux"
+arch = "amd64"
+
+[[metadata.targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-nodejs" }


### PR DESCRIPTION
We haven't added `[[metadata.targets]]` to `heroku/nodejs` yet, so it will be published as single architecture. Adding that here and updating the changelog to match reality.