### PR TITLE
Fix failing integration test

### DIFF
--- a/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-pnpm-install/tests/integration_test.rs
@@ -111,7 +111,6 @@ fn pnpm_8_hoist() {
 #[ignore = "integration test"]
 fn pnpm_8_nuxt() {
     nodejs_integration_test("./fixtures/pnpm-8-nuxt", |ctx| {
-        assert_empty!(ctx.pack_stderr);
         assert_contains!(
             ctx.pack_stdout,
             &formatdoc! {"


### PR DESCRIPTION
Removed the check for empty `stderr` output which started failing because the following message is now emitted on install of the `browserlist` package:

```
WARN  Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

See https://github.com/heroku/buildpacks-nodejs/actions/runs/9185177895/job/25258708325?pr=846