### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,15 @@
-# The Languages team should be the default requested reviewer on all PRs
+# Default to requesting pull request reviews from the Heroku Languages team.
 * @heroku/languages
 
-# Except for automation that:
-# - updates binary inventories
-# - updates project dependencies
-# - prepares releases
-# Only Node.js language owners should be the requested reviewers here
-CHANGELOG.md @joshwlewis @colincasey
-inventory.toml @joshwlewis @colincasey
-Cargo.toml @joshwlewis @colincasey
-Cargo.lock @joshwlewis @colincasey
-buildpack.toml @joshwlewis @colincasey
+# However, request review from the language owner instead for files that are updated
+# by Dependabot or inventory/release automation, to reduce team review request noise.
+CHANGELOG.md @colincasey
+inventory.toml @colincasey
+Cargo.toml @colincasey
+Cargo.lock @colincasey
+buildpack.toml @colincasey
+npm-shrinkwrap.json @colincasey
+package.json @colincasey
+package-lock.json @colincasey
+pnpm-lock.yaml @colincasey
+yarn.lock @colincasey


### PR DESCRIPTION
Adds more files that are updated by Dependabot, to avoid team review being requested for PRs like:
https://github.com/heroku/heroku-buildpack-nodejs/pull/1277

Also updates the owners given Colin now being the Node.js language owner.