### PR TITLE
Use actions/create-github-app-token instead of heroku/use-app-token

### DIFF
--- a/.github/workflows/_update-inventory.yml
+++ b/.github/workflows/_update-inventory.yml
@@ -27,16 +27,16 @@ jobs:
     name: Update Inventory
     runs-on: pub-hk-ubuntu-22.04-small
     steps:
-      - uses: heroku/use-app-token-action@main
+      - uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
 
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Update Rust toolchain
         run: rustup update
@@ -64,7 +64,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: Update Inventory - ${{ inputs.name }}
           branch: update-${{ inputs.distribution }}-inventory
           commit-message: "Update Inventory for ${{ inputs.buildpack_id }}\n\n${{ steps.set-diff-msg.outputs.msg }}"
@@ -75,5 +75,5 @@ jobs:
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -10,11 +10,11 @@ jobs:
     name: Update Node.js Inventory
     runs-on: pub-hk-ubuntu-22.04-small
     steps:
-      - uses: heroku/use-app-token-action@main
+      - uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
 
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: "Update Node.js Inventory"
           commit-message: "Update Inventory for heroku/nodejs\n\n${{ steps.rebuild-inventory.outputs.msg }}"
           committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
@@ -50,7 +50,7 @@ jobs:
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"
 
   update-yarn-inventory:


### PR DESCRIPTION
The use-app-token action is deprecated: https://github.com/heroku/use-app-token-action/pull/17

<img width="1080" alt="334930895-d73c5548-5bd5-4a0b-9102-cad77f556f06" src="https://github.com/heroku/buildpacks-nodejs/assets/27900/7313a042-0f36-41ae-8295-4d353ac12f3a">

GUS-W-16159724