### PR TITLE
Update to `libcnb` v0.22 and annotate deprecated APIs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       libcnb:
         patterns:
           - "libcnb"
+          - "libcnb-test"
           - "libcnb-*"
           - "libherokubuildpack"
       rust-dependencies:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
         patterns:
           - "libcnb"
           - "libcnb-test"
-          - "libcnb-*"
           - "libherokubuildpack"
       rust-dependencies:
         update-types:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,8 +213,8 @@ dependencies = [
  "glob",
  "indoc",
  "lazy_static",
- "libcnb",
- "libherokubuildpack",
+ "libcnb 0.21.0",
+ "libherokubuildpack 0.21.0",
  "regex",
  "serde",
  "sha2",
@@ -568,9 +568,9 @@ version = "0.0.0"
 dependencies = [
  "heroku-nodejs-utils",
  "indoc",
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.22.0",
  "opentelemetry 0.23.0",
  "serde",
  "test_support",
@@ -584,9 +584,9 @@ version = "0.0.0"
 dependencies = [
  "heroku-inventory-utils",
  "heroku-nodejs-utils",
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.22.0",
  "serde",
  "serde_json",
  "sha2",
@@ -604,9 +604,9 @@ dependencies = [
  "base64",
  "heroku-nodejs-utils",
  "hex",
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.22.0",
  "rand",
  "serde",
  "serde_json",
@@ -623,9 +623,9 @@ version = "0.0.0"
 dependencies = [
  "heroku-nodejs-utils",
  "indoc",
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.22.0",
  "serde",
  "test_support",
  "toml",
@@ -663,9 +663,9 @@ name = "heroku-nodejs-yarn-buildpack"
 version = "0.0.0"
 dependencies = [
  "heroku-nodejs-utils",
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.22.0",
  "serde",
  "tempfile",
  "test_support",
@@ -682,9 +682,9 @@ dependencies = [
  "fun_run 0.2.0",
  "heroku-nodejs-utils",
  "indoc",
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
- "libherokubuildpack",
+ "libherokubuildpack 0.22.0",
  "serde",
  "serde_json",
  "test_support",
@@ -699,7 +699,7 @@ dependencies = [
  "fun_run 0.2.0",
  "heroku-nodejs-utils",
  "indoc",
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
  "serde",
  "serde_json",
@@ -712,7 +712,7 @@ version = "0.0.0"
 dependencies = [
  "commons",
  "indoc",
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
  "test_support",
 ]
@@ -846,9 +846,23 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc89bfeaef5f43cdee664798e3c0aa36e052a412ab1391f0750aee4df1f407"
 dependencies = [
- "libcnb-common",
- "libcnb-data",
- "libcnb-proc-macros",
+ "libcnb-common 0.21.0",
+ "libcnb-data 0.21.0",
+ "libcnb-proc-macros 0.21.0",
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "libcnb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8627f5e9c7116a1deddb30a1c9ae79bdf2b5677c6948f21d662d6185a867951c"
+dependencies = [
+ "libcnb-common 0.22.0",
+ "libcnb-data 0.22.0",
+ "libcnb-proc-macros 0.22.0",
  "opentelemetry 0.21.0",
  "opentelemetry-stdout 0.2.0",
  "opentelemetry_sdk 0.21.2",
@@ -869,13 +883,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "libcnb-common"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4862a2ef99cfcaabcb1e84e6c3babe2c281bd1328295a49ee1a2b14aed2fea9"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "libcnb-data"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfcd102bfb1bf98ee4c18da0b29be6f23a19681937924bf758e9ea8499668b18"
 dependencies = [
  "fancy-regex",
- "libcnb-proc-macros",
+ "libcnb-proc-macros 0.21.0",
+ "serde",
+ "thiserror",
+ "toml",
+ "uriparse",
+]
+
+[[package]]
+name = "libcnb-data"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6c2902672cc78276832bc57ca7013d7ed037067d203f34edce3d77981e8762"
+dependencies = [
+ "fancy-regex",
+ "libcnb-proc-macros 0.22.0",
  "serde",
  "thiserror",
  "toml",
@@ -884,15 +923,15 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8d9b42112212a875c07fb3acf19504cf330edaa63cddd1823e9d03a5e2b934"
+checksum = "ed93a039d62d0840d55112b5873a00faa17201c6e36342e4e1e8cbab151267ab"
 dependencies = [
  "cargo_metadata",
  "ignore",
  "indoc",
- "libcnb-common",
- "libcnb-data",
+ "libcnb-common 0.22.0",
+ "libcnb-data 0.22.0",
  "petgraph",
  "thiserror",
  "uriparse",
@@ -912,16 +951,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "libcnb-test"
-version = "0.21.0"
+name = "libcnb-proc-macros"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9471152703833b74d565c7f7c910b4d5e084f955c327eba2bdb6658e86bd6dd6"
+checksum = "e5d7c591359e5b24c0cea9bfc4bbd929cbf2c7c1a20b677258aa8fe104cbb1db"
+dependencies = [
+ "cargo_metadata",
+ "fancy-regex",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libcnb-test"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95d9be983eb6527dbe6830c63e10f97a06705f9d1f45c91964e98aa86d48f9f2"
 dependencies = [
  "fastrand",
  "fs_extra",
- "libcnb-common",
- "libcnb-data",
+ "libcnb-common 0.22.0",
+ "libcnb-data 0.22.0",
  "libcnb-package",
+ "regex",
  "tempfile",
  "thiserror",
 ]
@@ -933,8 +985,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146f61983fd384cb5ab5373acdd8f53fcb4b27ecb200435a6bfb6a70b421bc9d"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "libherokubuildpack"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab52a85eac161353c49a53c2af9531ebca4262902ffb861f9ddfc135aedda93"
+dependencies = [
  "flate2",
- "libcnb",
+ "libcnb 0.22.0",
  "pathdiff",
  "tar",
  "termcolor",
@@ -1182,9 +1242,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1216,9 +1276,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1469,9 +1529,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1480,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
 dependencies = [
  "filetime",
  "libc",
@@ -1513,7 +1573,7 @@ dependencies = [
 name = "test_support"
 version = "0.0.0"
 dependencies = [
- "libcnb",
+ "libcnb 0.22.0",
  "libcnb-test",
  "serde_json",
  "ureq",

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -9,13 +9,13 @@ workspace = true
 [dependencies]
 heroku-nodejs-utils.workspace = true
 indoc = "2"
-libcnb = { version = "=0.21.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["log"] }
+libcnb = { version = "=0.22.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.22.0", default-features = false, features = ["log"] }
 opentelemetry = "0.23"
 serde = "1"
 thiserror = "1"
 
 [dev-dependencies]
-libcnb-test = "=0.21.0"
+libcnb-test = "=0.22.0"
 test_support.workspace = true
 ureq = "2"

--- a/buildpacks/nodejs-corepack/src/layers/manager.rs
+++ b/buildpacks/nodejs-corepack/src/layers/manager.rs
@@ -2,6 +2,7 @@ use heroku_nodejs_utils::package_json::PackageManager;
 use heroku_nodejs_utils::vrs::Version;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::Buildpack;
@@ -29,6 +30,7 @@ pub(crate) struct ManagerLayerMetadata {
 const LAYER_VERSION: &str = "1";
 const CACHE_DIR: &str = "cache";
 
+#[allow(deprecated)]
 impl Layer for ManagerLayer {
     type Buildpack = CorepackBuildpack;
     type Metadata = ManagerLayerMetadata;

--- a/buildpacks/nodejs-corepack/src/layers/shim.rs
+++ b/buildpacks/nodejs-corepack/src/layers/shim.rs
@@ -1,6 +1,7 @@
 use heroku_nodejs_utils::vrs::Version;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use libherokubuildpack::log::log_info;
@@ -26,6 +27,7 @@ pub(crate) struct ShimLayerMetadata {
 const LAYER_VERSION: &str = "1";
 const BIN_DIR: &str = "bin";
 
+#[allow(deprecated)]
 impl Layer for ShimLayer {
     type Buildpack = CorepackBuildpack;
     type Metadata = ShimLayerMetadata;

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -61,6 +61,7 @@ impl Buildpack for CorepackBuildpack {
         })
     }
 
+    #[allow(deprecated)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let tracer = init_tracer(context.buildpack_descriptor.buildpack.id.to_string());
         tracer.in_span("nodejs-corepack-build", |cx| {

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -9,8 +9,8 @@ workspace = true
 [dependencies]
 heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "2a86fae18332b9bd495eb29422c13ac3fcb2d0dc" }
 heroku-nodejs-utils.workspace = true
-libcnb = { version = "=0.21.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["download", "fs", "log", "tar"] }
+libcnb = { version = "=0.22.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.22.0", default-features = false, features = ["download", "fs", "log", "tar"] }
 serde = "1"
 sha2 = "0.10.8"
 tempfile = "3"
@@ -18,7 +18,7 @@ thiserror = "1"
 toml = "0.8"
 
 [dev-dependencies]
-libcnb-test = "=0.21.0"
+libcnb-test = "=0.22.0"
 serde_json = "1"
 test_support.workspace = true
 ureq = "2"

--- a/buildpacks/nodejs-engine/src/layers/dist.rs
+++ b/buildpacks/nodejs-engine/src/layers/dist.rs
@@ -3,6 +3,7 @@ use heroku_inventory_utils::inv::Artifact;
 use heroku_nodejs_utils::vrs::Version;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use libherokubuildpack::download::download_file;
@@ -49,6 +50,7 @@ pub(crate) enum DistLayerError {
 
 const LAYER_VERSION: &str = "1";
 
+#[allow(deprecated)]
 impl Layer for DistLayer {
     type Buildpack = NodeJsEngineBuildpack;
     type Metadata = DistLayerMetadata;
@@ -61,6 +63,7 @@ impl Layer for DistLayer {
         }
     }
 
+    #[allow(deprecated)]
     fn create(
         &mut self,
         _context: &BuildContext<Self::Buildpack>,
@@ -93,6 +96,7 @@ impl Layer for DistLayer {
         LayerResultBuilder::new(DistLayerMetadata::current(self)).build()
     }
 
+    #[allow(deprecated)]
     fn existing_layer_strategy(
         &mut self,
         _context: &BuildContext<Self::Buildpack>,

--- a/buildpacks/nodejs-engine/src/layers/node_runtime_metrics.rs
+++ b/buildpacks/nodejs-engine/src/layers/node_runtime_metrics.rs
@@ -2,6 +2,7 @@ use crate::{NodeJsEngineBuildpack, NodeJsEngineBuildpackError};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
+#[allow(deprecated)]
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use std::fs;
@@ -10,6 +11,7 @@ use thiserror::Error;
 
 pub(crate) struct NodeRuntimeMetricsLayer;
 
+#[allow(deprecated)]
 impl Layer for NodeRuntimeMetricsLayer {
     type Buildpack = NodeJsEngineBuildpack;
     type Metadata = GenericMetadata;
@@ -22,6 +24,7 @@ impl Layer for NodeRuntimeMetricsLayer {
         }
     }
 
+    #[allow(deprecated)]
     fn create(
         &mut self,
         _context: &BuildContext<Self::Buildpack>,

--- a/buildpacks/nodejs-engine/src/layers/web_env.rs
+++ b/buildpacks/nodejs-engine/src/layers/web_env.rs
@@ -5,11 +5,13 @@ use libcnb::additional_buildpack_binary_path;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
+#[allow(deprecated)]
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 
 /// A layer that sets `WEB_MEMORY` and `WEB_CONCURRENCY` via exec.d
 pub(crate) struct WebEnvLayer;
 
+#[allow(deprecated)]
 impl Layer for WebEnvLayer {
     type Buildpack = NodeJsEngineBuildpack;
     type Metadata = GenericMetadata;
@@ -22,6 +24,7 @@ impl Layer for WebEnvLayer {
         }
     }
 
+    #[allow(deprecated)]
     fn create(
         &mut self,
         _context: &BuildContext<Self::Buildpack>,

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -102,6 +102,7 @@ impl Buildpack for NodeJsEngineBuildpack {
         ));
 
         log_header("Installing Node.js distribution");
+        #[allow(deprecated)]
         context.handle_layer(
             layer_name!("dist"),
             DistLayer {
@@ -109,12 +110,14 @@ impl Buildpack for NodeJsEngineBuildpack {
             },
         )?;
 
+        #[allow(deprecated)]
         context.handle_layer(layer_name!("web_env"), WebEnvLayer)?;
 
         if Requirement::parse(MINIMUM_NODE_VERSION_FOR_METRICS)
             .expect("should be a valid version range")
             .satisfies(&target_artifact.version)
         {
+            #[allow(deprecated)]
             context.handle_layer(layer_name!("node_runtime_metrics"), NodeRuntimeMetricsLayer)?;
         }
 

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -8,8 +8,8 @@ workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb = "=0.21.0"
-libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["error", "log", "toml"] }
+libcnb = "=0.22.0"
+libherokubuildpack = { version = "=0.22.0", default-features = false, features = ["error", "log", "toml"] }
 serde = "1"
 thiserror = "1"
 toml = "0.8"
@@ -17,7 +17,7 @@ toml = "0.8"
 [dev-dependencies]
 base64 = "0.22"
 hex = "0.4"
-libcnb-test = "=0.21.0"
+libcnb-test = "=0.22.0"
 rand = "0.8"
 serde_json = "1"
 tempfile = "3"

--- a/buildpacks/nodejs-function-invoker/src/layers/runtime.rs
+++ b/buildpacks/nodejs-function-invoker/src/layers/runtime.rs
@@ -1,6 +1,7 @@
 use crate::{NodeJsInvokerBuildpack, NodeJsInvokerBuildpackError};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use libherokubuildpack::log::log_info;
@@ -34,6 +35,7 @@ pub(crate) enum RuntimeLayerError {
 
 const LAYER_VERSION: &str = "1";
 
+#[allow(deprecated)]
 impl Layer for RuntimeLayer {
     type Buildpack = NodeJsInvokerBuildpack;
     type Metadata = RuntimeLayerMetadata;

--- a/buildpacks/nodejs-function-invoker/src/layers/script.rs
+++ b/buildpacks/nodejs-function-invoker/src/layers/script.rs
@@ -3,6 +3,7 @@ use crate::NodeJsInvokerBuildpackError;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
+#[allow(deprecated)]
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -14,6 +15,7 @@ pub(crate) const NODEJS_RUNTIME_SCRIPT: &str = "nodejs-runtime.sh";
 /// on to sf-fx-runtime-nodejs as arguments.
 pub(crate) struct ScriptLayer;
 
+#[allow(deprecated)]
 impl Layer for ScriptLayer {
     type Buildpack = NodeJsInvokerBuildpack;
     type Metadata = GenericMetadata;

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -67,6 +67,7 @@ impl Buildpack for NodeJsInvokerBuildpack {
             .unwrap_or_else(|| DetectResultBuilder::fail().build())
     }
 
+    #[allow(deprecated)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         log_header("Heroku Node.js Function Invoker Buildpack");
 

--- a/buildpacks/nodejs-npm-engine/Cargo.toml
+++ b/buildpacks/nodejs-npm-engine/Cargo.toml
@@ -11,12 +11,12 @@ commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 fun_run = "0.2"
 heroku-nodejs-utils.workspace = true
 indoc = "2"
-libcnb = { version = "=0.21.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["download", "tar"] }
+libcnb = { version = "=0.22.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.22.0", default-features = false, features = ["download", "tar"] }
 serde = "1"
 toml = "0.8"
 
 [dev-dependencies]
-libcnb-test = "=0.21.0"
+libcnb-test = "=0.22.0"
 serde_json = "1"
 test_support.workspace = true

--- a/buildpacks/nodejs-npm-engine/src/layers/npm_engine.rs
+++ b/buildpacks/nodejs-npm-engine/src/layers/npm_engine.rs
@@ -7,6 +7,7 @@ use heroku_nodejs_utils::inv::Release;
 use heroku_nodejs_utils::vrs::Version;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use libherokubuildpack::download::{download_file, DownloadError};
@@ -26,6 +27,7 @@ pub(crate) struct NpmEngineLayer<'a> {
 
 const LAYER_VERSION: &str = "1";
 
+#[allow(deprecated)]
 impl<'a> Layer for NpmEngineLayer<'a> {
     type Buildpack = NpmEngineBuildpack;
     type Metadata = NpmEngineLayerMetadata;

--- a/buildpacks/nodejs-npm-engine/src/main.rs
+++ b/buildpacks/nodejs-npm-engine/src/main.rs
@@ -120,6 +120,7 @@ fn resolve_requested_npm_version(
     Ok(npm_release)
 }
 
+#[allow(deprecated)]
 fn install_npm_release(
     npm_release: Release,
     context: &BuildContext<NpmEngineBuildpack>,

--- a/buildpacks/nodejs-npm-install/Cargo.toml
+++ b/buildpacks/nodejs-npm-install/Cargo.toml
@@ -11,10 +11,10 @@ commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 fun_run = "0.2"
 heroku-nodejs-utils.workspace = true
 indoc = "2"
-libcnb = { version = "=0.21.0", features = ["trace"] }
+libcnb = { version = "=0.22.0", features = ["trace"] }
 serde = "1"
 
 [dev-dependencies]
-libcnb-test = "=0.21.0"
+libcnb-test = "=0.22.0"
 serde_json = "1"
 test_support.workspace = true

--- a/buildpacks/nodejs-npm-install/src/layers/npm_cache.rs
+++ b/buildpacks/nodejs-npm-install/src/layers/npm_cache.rs
@@ -2,6 +2,7 @@ use crate::NpmInstallBuildpack;
 use commons::output::section_log::{log_step, SectionLogger};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use serde::{Deserialize, Serialize};
@@ -12,6 +13,7 @@ pub(crate) struct NpmCacheLayer<'a> {
     pub(crate) _section_logger: &'a dyn SectionLogger,
 }
 
+#[allow(deprecated)]
 impl<'a> Layer for NpmCacheLayer<'a> {
     type Buildpack = NpmInstallBuildpack;
     type Metadata = NpmCacheLayerMetadata;

--- a/buildpacks/nodejs-npm-install/src/layers/npm_runtime_config.rs
+++ b/buildpacks/nodejs-npm-install/src/layers/npm_runtime_config.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
+#[allow(deprecated)]
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::Buildpack;
@@ -12,6 +13,7 @@ use crate::NpmInstallBuildpack;
 
 pub(crate) struct NpmRuntimeConfigLayer;
 
+#[allow(deprecated)]
 impl Layer for NpmRuntimeConfigLayer {
     type Buildpack = NpmInstallBuildpack;
     type Metadata = GenericMetadata;

--- a/buildpacks/nodejs-npm-install/src/main.rs
+++ b/buildpacks/nodejs-npm-install/src/main.rs
@@ -66,6 +66,7 @@ impl Buildpack for NpmInstallBuildpack {
         }
     }
 
+    #[allow(deprecated)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let logger = BuildLog::new(stdout()).buildpack_name(BUILDPACK_NAME);
         let warn_later = WarnGuard::new(stdout());
@@ -134,6 +135,7 @@ fn log_npm_version(
         })
 }
 
+#[allow(deprecated)]
 fn configure_npm_cache_layer(
     context: &BuildContext<NpmInstallBuildpack>,
     env: &Env,

--- a/buildpacks/nodejs-pnpm-engine/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-engine/Cargo.toml
@@ -9,8 +9,8 @@ workspace = true
 [dependencies]
 commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
 indoc = "2"
-libcnb = { version = "=0.21.0", features = ["trace"] }
+libcnb = { version = "=0.22.0", features = ["trace"] }
 
 [dev-dependencies]
-libcnb-test = "=0.21.0"
+libcnb-test = "=0.22.0"
 test_support.workspace = true

--- a/buildpacks/nodejs-pnpm-install/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-install/Cargo.toml
@@ -9,12 +9,12 @@ workspace = true
 [dependencies]
 heroku-nodejs-utils.workspace = true
 indoc = "2"
-libcnb = { version = "=0.21.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["log"] }
+libcnb = { version = "=0.22.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.22.0", default-features = false, features = ["log"] }
 serde = "1"
 toml = "0.8"
 
 [dev-dependencies]
-libcnb-test = "=0.21.0"
+libcnb-test = "=0.22.0"
 test_support.workspace = true
 ureq = "2"

--- a/buildpacks/nodejs-pnpm-install/src/layers/addressable_store.rs
+++ b/buildpacks/nodejs-pnpm-install/src/layers/addressable_store.rs
@@ -1,6 +1,7 @@
 use crate::{PnpmInstallBuildpack, PnpmInstallBuildpackError};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use libherokubuildpack::log::log_info;
@@ -20,6 +21,7 @@ pub(crate) struct AddressableStoreLayerMetadata {
 
 const LAYER_VERSION: &str = "1";
 
+#[allow(deprecated)]
 impl Layer for AddressableStoreLayer {
     type Buildpack = PnpmInstallBuildpack;
     type Metadata = AddressableStoreLayerMetadata;

--- a/buildpacks/nodejs-pnpm-install/src/layers/virtual_store.rs
+++ b/buildpacks/nodejs-pnpm-install/src/layers/virtual_store.rs
@@ -2,6 +2,7 @@ use crate::{PnpmInstallBuildpack, PnpmInstallBuildpackError};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
+#[allow(deprecated)]
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libherokubuildpack::log::log_info;
 use std::fs::create_dir;
@@ -14,6 +15,7 @@ use std::path::Path;
 /// in `AddressableStoreLayer`.
 pub(crate) struct VirtualStoreLayer;
 
+#[allow(deprecated)]
 impl Layer for VirtualStoreLayer {
     type Buildpack = PnpmInstallBuildpack;
     type Metadata = GenericMetadata;

--- a/buildpacks/nodejs-pnpm-install/src/main.rs
+++ b/buildpacks/nodejs-pnpm-install/src/main.rs
@@ -49,6 +49,7 @@ impl Buildpack for PnpmInstallBuildpack {
             .unwrap_or_else(|| DetectResultBuilder::fail().build())
     }
 
+    #[allow(deprecated)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let env = Env::from_current();
         let pkg_json = PackageJson::read(context.app_dir.join("package.json"))

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -8,14 +8,14 @@ workspace = true
 
 [dependencies]
 heroku-nodejs-utils.workspace = true
-libcnb = { version = "=0.21.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["download", "fs", "log", "tar"] }
+libcnb = { version = "=0.22.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.22.0", default-features = false, features = ["download", "fs", "log", "tar"] }
 serde = "1"
 tempfile = "3"
 thiserror = "1"
 toml = "0.8"
 
 [dev-dependencies]
-libcnb-test = "=0.21.0"
+libcnb-test = "=0.22.0"
 test_support.workspace = true
 ureq = "2"

--- a/buildpacks/nodejs-yarn/src/layers/cli.rs
+++ b/buildpacks/nodejs-yarn/src/layers/cli.rs
@@ -2,6 +2,7 @@ use crate::{YarnBuildpack, YarnBuildpackError};
 use heroku_nodejs_utils::inv::Release;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use libherokubuildpack::download::{download_file, DownloadError};
@@ -45,6 +46,7 @@ pub(crate) enum CliLayerError {
 
 const LAYER_VERSION: &str = "1";
 
+#[allow(deprecated)]
 impl Layer for CliLayer {
     type Buildpack = YarnBuildpack;
     type Metadata = CliLayerMetadata;

--- a/buildpacks/nodejs-yarn/src/layers/deps.rs
+++ b/buildpacks/nodejs-yarn/src/layers/deps.rs
@@ -2,6 +2,7 @@ use crate::yarn::Yarn;
 use crate::{YarnBuildpack, YarnBuildpackError};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use libherokubuildpack::log::log_info;
@@ -36,6 +37,7 @@ const LAYER_VERSION: &str = "1";
 const MAX_CACHE_USAGE_COUNT: f32 = 150.0;
 const CACHE_DIR: &str = "cache";
 
+#[allow(deprecated)]
 impl Layer for DepsLayer {
     type Buildpack = YarnBuildpack;
     type Metadata = DepsLayerMetadata;
@@ -48,6 +50,7 @@ impl Layer for DepsLayer {
         }
     }
 
+    #[allow(deprecated)]
     fn create(
         &mut self,
         _context: &BuildContext<Self::Buildpack>,
@@ -57,6 +60,7 @@ impl Layer for DepsLayer {
         LayerResultBuilder::new(DepsLayerMetadata::new(self)).build()
     }
 
+    #[allow(deprecated)]
     fn update(
         &mut self,
         _context: &BuildContext<Self::Buildpack>,
@@ -69,6 +73,7 @@ impl Layer for DepsLayer {
         .build()
     }
 
+    #[allow(deprecated)]
     fn existing_layer_strategy(
         &mut self,
         _context: &BuildContext<Self::Buildpack>,

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -58,6 +58,7 @@ impl Buildpack for YarnBuildpack {
             .unwrap_or_else(|| DetectResultBuilder::fail().build())
     }
 
+    #[allow(deprecated)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let mut env = Env::from_current();
         let pkg_json = PackageJson::read(context.app_dir.join("package.json"))

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-libcnb = "=0.21.0"
-libcnb-test = "=0.21.0"
+libcnb = "=0.22.0"
+libcnb-test = "=0.22.0"
 serde_json = "1"
 ureq = "2"


### PR DESCRIPTION
Update buildpacks to `libcnb@0.22` and add `#[allow(deprecated)]` annotations to the old layer traits. Removing these deprecations will be addressed in several follow-up PRs.

Closes #871 

## Follow-up PRs
- [ ] #878 
- [ ] #879
- [ ] #880
- [ ] #881
- [ ] #882
- [ ] #883
- [ ] #884