### PR TITLE
Add CI step to docker pull the run image ahead of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
 
 permissions:
@@ -102,6 +102,8 @@ jobs:
         uses: buildpacks/github-actions/setup-pack@v5.7.2
       - name: Pull builder image
         run: docker pull ${{ env.INTEGRATION_TEST_CNB_BUILDER }}
+      - name: Pull run image
+        run: docker pull $(pack builder inspect ${{ env.INTEGRATION_TEST_CNB_BUILDER }} -o json | jq -r '.remote_info.run_images[0].name')
       - name: Run integration tests
         working-directory: ${{ matrix.dir }}
         run: cargo test --locked -- --ignored --test-threads 16
@@ -134,7 +136,7 @@ jobs:
       matrix:
         # check the minimum node version supported by the metrics script and the latest node version
         # (assumes the versions between have backwards-compatible APIs)
-        version: [ 14.10.0, latest ]
+        version: [14.10.0, latest]
     name: Test Metrics (${{ matrix.version }})
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,13 @@ jobs:
         uses: buildpacks/github-actions/setup-pack@v5.7.2
       - name: Pull builder image
         run: docker pull ${{ env.INTEGRATION_TEST_CNB_BUILDER }}
-      - name: Check for tests that start the container
-        id: needs-run-image
-        run: echo "result=$(grep --quiet --recursive "start_container" ${{ matrix.dir }}/tests && echo "true" || echo "false")" >> $GITHUB_OUTPUT
       - name: Pull run image
-        if: steps.needs-run-image.outputs.result == 'true'
-        run: docker pull $(pack builder inspect ${{ env.INTEGRATION_TEST_CNB_BUILDER }} -o json | jq -r '.remote_info.run_images[0].name')
+        run: |
+          RUN_IMAGE=$(
+            docker inspect --format='{{index .Config.Labels "io.buildpacks.builder.metadata"}}' '${{ env.INTEGRATION_TEST_CNB_BUILDER }}' \
+            | jq --exit-status --raw-output '.stack.runImage.image'
+          )
+          docker pull "${RUN_IMAGE}"
       - name: Run integration tests
         working-directory: ${{ matrix.dir }}
         run: cargo test --locked -- --ignored --test-threads 16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,11 @@ jobs:
         uses: buildpacks/github-actions/setup-pack@v5.7.2
       - name: Pull builder image
         run: docker pull ${{ env.INTEGRATION_TEST_CNB_BUILDER }}
+      - name: Check for tests that start the container
+        id: needs-run-image
+        run: echo "result=$(grep --quiet --recursive "start_container" ${{ matrix.dir }}/tests && echo "true" || echo "false")" >> $GITHUB_OUTPUT
       - name: Pull run image
+        if: steps.needs-run-image.outputs.result == 'true'
         run: docker pull $(pack builder inspect ${{ env.INTEGRATION_TEST_CNB_BUILDER }} -o json | jq -r '.remote_info.run_images[0].name')
       - name: Run integration tests
         working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
During the integration tests, if the application is started this will cause `pack` to download the run image if it hasn't already been pulled. Depending on how the tests are executed this could cause multiple attempts to download the run image. 

To be more respectful towards Docker pull limits, this PR attempts to pull the run image using metadata from the builder. This happens before the tests execute and only for tests that attempt to start the container so that pulls should be minimized.