### PR TITLE
Switch to the new GitHub Actions runner groups

### DIFF
--- a/.github/workflows/_mirror-distribution.yml
+++ b/.github/workflows/_mirror-distribution.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   get-unmirrored-versions:
     name: Get Unmirrored Versions
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       versions: ${{ steps.get-unmirrored-versions.outputs.versions }}
     steps:
@@ -42,7 +42,7 @@ jobs:
   mirror-distribution:
     name: Mirror v${{ matrix.version }} ${{ matrix.platform && format('({0})', matrix.platform) || '' }}
     needs: [get-unmirrored-versions]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: needs.get-unmirrored-versions.outputs.versions != '[]'
     strategy:
       fail-fast: false

--- a/.github/workflows/_update-inventory.yml
+++ b/.github/workflows/_update-inventory.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   update-inventory:
     name: Update Inventory
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - uses: actions/create-github-app-token@v1
         id: generate-token

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
 
   shell-lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: koalaman/shellcheck-alpine:v0.9.0
     steps:
@@ -24,7 +24,7 @@ jobs:
         run: shfmt -f . | grep -v ^test/ | grep -v '_shpec.sh$' | xargs shfmt -d
 
   rust-lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
         run: cargo fmt -- --check
 
   rust-unit-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
 
   find-libcnb-buildpacks:
     name: Find libcnb buildpacks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       libcnb-buildpacks: ${{ steps.find-buildpack-dirs.outputs.buildpacks }}
     steps:
@@ -79,7 +79,7 @@ jobs:
 
   rust-integration-test:
     name: ${{ matrix.name }} (${{ matrix.builder_tag }}, ${{ matrix.arch }})
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-small' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
     env:
       INTEGRATION_TEST_CNB_BUILDER: heroku/builder:${{ matrix.builder_tag }}
     needs: find-libcnb-buildpacks
@@ -114,7 +114,7 @@ jobs:
         run: cargo test --locked -- --ignored --test-threads 16
 
   shpec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: heroku/heroku:${{ matrix.stack-version }}-build
     strategy:
@@ -143,7 +143,7 @@ jobs:
         # (assumes the versions between have backwards-compatible APIs)
         version: [14.10.0, latest]
     name: Test Metrics (${{ matrix.version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-nodejs-inventory:
     name: Update Node.js Inventory
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - uses: actions/create-github-app-token@v1
         id: generate-token


### PR DESCRIPTION
To update to Ubuntu 24.04, and to prevent the rate limit issues mentioned here:
https://github.com/heroku/buildpacks-go/pull/283

See also:
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZR57becb9df8d94f80b132168fd
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

Closes #888.
GUS-W-16238120.