### PR TITLE
Extend timeouts for test reliability

### DIFF
--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -8,7 +8,7 @@ use test_support::{
     set_node_engine, wait_for, PORT,
 };
 
-const APPLICATION_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+const APPLICATION_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 const METRICS_SEND_INTERVAL: Duration = Duration::from_secs(10);
 const METRICS_SEND_TIMEOUT: Duration = Duration::from_secs(15);
 

--- a/buildpacks/nodejs-function-invoker/tests/integration_test.rs
+++ b/buildpacks/nodejs-function-invoker/tests/integration_test.rs
@@ -166,7 +166,7 @@ fn invoke_function(socket_addr: &SocketAddr, payload: &serde_json::Value) -> ser
             .set("ce-sffncontext", &ssfn_context)
             .send_json(payload.clone())
     })
-        .unwrap();
+    .unwrap();
 
     response.into_json().expect("expected response to be json")
 }
@@ -177,7 +177,7 @@ fn assert_health_check_responds(socket_addr: &SocketAddr) {
             .set("x-health-check", "true")
             .call()
     })
-        .unwrap();
+    .unwrap();
     let response_body = response.into_string().unwrap();
     assert_contains!(response_body, "OK");
 }

--- a/buildpacks/nodejs-function-invoker/tests/integration_test.rs
+++ b/buildpacks/nodejs-function-invoker/tests/integration_test.rs
@@ -7,9 +7,13 @@ use base64::Engine;
 use libcnb_test::{assert_contains, assert_not_contains, TestContext};
 use rand::RngCore;
 use std::net::SocketAddr;
+use std::time::Duration;
 use test_support::{
-    function_integration_test, retry, start_container, DEFAULT_RETRIES, DEFAULT_RETRY_DELAY,
+    function_integration_test, retry, start_container, wait_for, DEFAULT_RETRIES,
+    DEFAULT_RETRY_DELAY,
 };
+
+const FUNCTION_LOGGING_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[test]
 #[ignore]
@@ -21,8 +25,13 @@ fn simple_javascript_function() {
             let payload = serde_json::json!({});
             let result = invoke_function(socket_addr, &payload);
             assert_eq!(result, serde_json::Value::String("hello world".to_string()));
-            let container_logs = container.logs_now();
-            assert_contains!(container_logs.stdout, "logging info is a fun 1");
+            wait_for(
+                || {
+                    let container_logs = container.logs_now();
+                    assert_contains!(container_logs.stdout, "logging info is a fun 1");
+                },
+                FUNCTION_LOGGING_TIMEOUT,
+            );
         });
     });
 }
@@ -107,8 +116,13 @@ fn function_with_no_lockfile() {
             let payload = serde_json::json!({});
             let result = invoke_function(socket_addr, &payload);
             assert_eq!(result, serde_json::Value::String("hello world".to_string()));
-            let container_logs = container.logs_now();
-            assert_contains!(container_logs.stdout, "logging info is a fun 1");
+            wait_for(
+                || {
+                    let container_logs = container.logs_now();
+                    assert_contains!(container_logs.stdout, "logging info is a fun 1");
+                },
+                FUNCTION_LOGGING_TIMEOUT,
+            );
         });
     });
 }
@@ -152,7 +166,7 @@ fn invoke_function(socket_addr: &SocketAddr, payload: &serde_json::Value) -> ser
             .set("ce-sffncontext", &ssfn_context)
             .send_json(payload.clone())
     })
-    .unwrap();
+        .unwrap();
 
     response.into_json().expect("expected response to be json")
 }
@@ -163,7 +177,7 @@ fn assert_health_check_responds(socket_addr: &SocketAddr) {
             .set("x-health-check", "true")
             .call()
     })
-    .unwrap();
+        .unwrap();
     let response_body = response.into_string().unwrap();
     assert_contains!(response_body, "OK");
 }


### PR DESCRIPTION
The tests in this PR fail occasionally in CI test runs and then pass on re-run. I'm extending the timeouts in the hopes this will result in more stability.