### PR TITLE
Migrate to libherokubuildpack inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,9 +441,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -601,19 +601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
-name = "heroku-inventory-utils"
-version = "0.0.0"
-source = "git+https://github.com/heroku/buildpacks-go/?rev=2a86fae18332b9bd495eb29422c13ac3fcb2d0dc#2a86fae18332b9bd495eb29422c13ac3fcb2d0dc"
-dependencies = [
- "hex",
- "semver",
- "serde",
- "sha2",
- "thiserror",
- "toml",
-]
-
-[[package]]
 name = "heroku-nodejs-corepack-buildpack"
 version = "0.0.0"
 dependencies = [
@@ -633,11 +620,10 @@ dependencies = [
 name = "heroku-nodejs-engine-buildpack"
 version = "0.0.0"
 dependencies = [
- "heroku-inventory-utils",
  "heroku-nodejs-utils",
  "libcnb",
  "libcnb-test",
- "libherokubuildpack 0.23.0",
+ "libherokubuildpack 0.24.0",
  "serde",
  "serde_json",
  "sha2",
@@ -690,10 +676,10 @@ dependencies = [
  "anyhow",
  "chrono",
  "commons",
- "heroku-inventory-utils",
  "indoc",
  "keep_a_changelog_file",
  "libcnb-data",
+ "libherokubuildpack 0.24.0",
  "node-semver",
  "opentelemetry 0.24.0",
  "opentelemetry-stdout 0.5.0",
@@ -1012,6 +998,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "libherokubuildpack"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec33ef08ce0508ced826f7bdfcd0538bdfc2270632915e447d1ea72bce5645d"
+dependencies = [
+ "flate2",
+ "hex",
+ "pathdiff",
+ "serde",
+ "sha2",
+ "tar",
+ "termcolor",
+ "thiserror",
+ "toml",
+ "ureq",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "pathdiff"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
 
 [[package]]
 name = "percent-encoding"
@@ -1472,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -1493,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1580,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
 dependencies = [
  "filetime",
  "libc",
@@ -1624,18 +1628,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -7,10 +7,9 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "2a86fae18332b9bd495eb29422c13ac3fcb2d0dc" }
 heroku-nodejs-utils.workspace = true
 libcnb = { version = "=0.23.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.23.0", default-features = false, features = ["download", "fs", "log", "tar"] }
+libherokubuildpack = { version = "=0.24.0", default-features = false, features = ["download", "fs", "inventory", "log", "tar"] }
 serde = "1"
 sha2 = "0.10.8"
 tempfile = "3"

--- a/buildpacks/nodejs-engine/src/install_node.rs
+++ b/buildpacks/nodejs-engine/src/install_node.rs
@@ -2,7 +2,6 @@ use std::fs;
 use std::io::Read;
 use std::path::Path;
 
-use heroku_inventory_utils::inv::Artifact;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
@@ -10,6 +9,7 @@ use libcnb::layer::{
 };
 use libherokubuildpack::download::download_file;
 use libherokubuildpack::fs::move_directory_contents;
+use libherokubuildpack::inventory::artifact::Artifact;
 use libherokubuildpack::log::log_info;
 use libherokubuildpack::tar::decompress_tarball;
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ use crate::{NodeJsEngineBuildpack, NodeJsEngineBuildpackError};
 
 pub(crate) fn install_node(
     context: &BuildContext<NodeJsEngineBuildpack>,
-    distribution_artifact: &Artifact<Version, Sha256>,
+    distribution_artifact: &Artifact<Version, Sha256, Option<()>>,
 ) -> Result<(), libcnb::Error<NodeJsEngineBuildpackError>> {
     let new_metadata = DistLayerMetadata {
         artifact: distribution_artifact.clone(),
@@ -115,7 +115,7 @@ const LAYER_VERSION: &str = "1";
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct DistLayerMetadata {
-    artifact: Artifact<Version, Sha256>,
+    artifact: Artifact<Version, Sha256, Option<()>>,
     layer_version: String,
 }
 
@@ -147,8 +147,10 @@ impl From<DistLayerError> for libcnb::Error<NodeJsEngineBuildpackError> {
 mod tests {
     use std::str::FromStr;
 
-    use heroku_inventory_utils::checksum::Checksum;
-    use heroku_inventory_utils::inv::{Arch, Os};
+    use libherokubuildpack::inventory::{
+        artifact::{Arch, Os},
+        checksum::Checksum,
+    };
 
     use super::*;
 
@@ -160,10 +162,10 @@ mod tests {
             arch: Arch::Arm64,
             url: "https://nodejs.org/download/release/v22.1.0/node-v22.1.0-linux-arm64.tar.gz"
                 .to_string(),
-            checksum: Checksum::<Sha256>::try_from(
-                "9c111af1f951e8869615bca3601ce7ab6969374933bdba6397469843b808f222".to_string(),
-            )
-            .unwrap(),
+            checksum: "sha256:9c111af1f951e8869615bca3601ce7ab6969374933bdba6397469843b808f222"
+                .parse::<Checksum<Sha256>>()
+                .unwrap(),
+            metadata: None,
         };
         let node_version_22_1_0_linux_amd = Artifact {
             version: Version::from_str("22.1.0").unwrap(),
@@ -171,10 +173,10 @@ mod tests {
             arch: Arch::Amd64,
             url: "https://nodejs.org/download/release/v22.1.0/node-v22.1.0-linux-x64.tar.gz"
                 .to_string(),
-            checksum: Checksum::<Sha256>::try_from(
-                "d8ae35a9e2bb0c0c0611ee9bacf564ea51cc8291ace1447f95ee6aeaf4f1d61d".to_string(),
-            )
-            .unwrap(),
+            checksum: "sha256:d8ae35a9e2bb0c0c0611ee9bacf564ea51cc8291ace1447f95ee6aeaf4f1d61d"
+                .parse::<Checksum<Sha256>>()
+                .unwrap(),
+            metadata: None,
         };
 
         // this is a check to ensure that the same node.js artifact doesn't invalidate the cache
@@ -211,10 +213,10 @@ mod tests {
                 arch: Arch::Amd64,
                 url: "https://nodejs.org/download/release/v22.1.0/node-v22.1.0-linux-x64.tar.gz"
                     .to_string(),
-                checksum: Checksum::<Sha256>::try_from(
-                    "d8ae35a9e2bb0c0c0611ee9bacf564ea51cc8291ace1447f95ee6aeaf4f1d61d".to_string(),
-                )
-                .unwrap(),
+                checksum: "sha256:d8ae35a9e2bb0c0c0611ee9bacf564ea51cc8291ace1447f95ee6aeaf4f1d61d"
+                    .parse::<Checksum<Sha256>>()
+                    .unwrap(),
+                metadata: None,
             },
             layer_version: LAYER_VERSION.to_string(),
         };

--- a/buildpacks/nodejs-engine/src/install_node.rs
+++ b/buildpacks/nodejs-engine/src/install_node.rs
@@ -46,9 +46,13 @@ pub(crate) fn install_node(
         },
     )?;
 
+    let version_tag = format!(
+        "{} ({}-{})",
+        distribution_artifact.version, distribution_artifact.os, distribution_artifact.arch
+    );
     match distribution_layer.state {
         LayerState::Restored { .. } => {
-            log_info(format!("Reusing Node.js {distribution_artifact}"));
+            log_info(format!("Reusing Node.js {version_tag}"));
         }
         LayerState::Empty { .. } => {
             distribution_layer.write_metadata(new_metadata)?;
@@ -57,7 +61,7 @@ pub(crate) fn install_node(
 
             log_info(format!(
                 "Downloading Node.js {} from {}",
-                distribution_artifact, distribution_artifact.url
+                version_tag, distribution_artifact.url
             ));
             download_file(&distribution_artifact.url, node_tgz.path())
                 .map_err(DistLayerError::Download)?;
@@ -68,11 +72,11 @@ pub(crate) fn install_node(
                 Err(DistLayerError::ChecksumVerification)?;
             }
 
-            log_info(format!("Extracting Node.js {distribution_artifact}"));
+            log_info(format!("Extracting Node.js {version_tag}"));
             decompress_tarball(&mut node_tgz.into_file(), distribution_layer.path())
                 .map_err(DistLayerError::Untar)?;
 
-            log_info(format!("Installing Node.js {distribution_artifact}"));
+            log_info(format!("Installing Node.js {version_tag}"));
 
             let dist_name = extract_tarball_prefix(&distribution_artifact.url)
                 .ok_or_else(|| DistLayerError::TarballPrefix(distribution_artifact.url.clone()))?;

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -10,10 +10,10 @@ workspace = true
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
-heroku-inventory-utils = { git = "https://github.com/heroku/buildpacks-go/", rev = "2a86fae18332b9bd495eb29422c13ac3fcb2d0dc" }
 indoc = "2"
 keep_a_changelog_file = "0.1.0"
 libcnb-data = "=0.23.0"
+libherokubuildpack = { version = "=0.24.0", default-features = false, features = ["inventory", "inventory-sha2"] }
 node-semver = "2"
 opentelemetry = "0.24"
 opentelemetry_sdk = { version = "0.24", features = ["trace"] }

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -43,23 +43,24 @@ fn write_inventory(
     inventory_path: impl Into<PathBuf>,
     upstream_artifacts: &[Artifact<Version, Sha256, Option<()>>],
 ) -> Result<()> {
-    toml::to_string(&Inventory {
-        artifacts: {
-            let mut artifacts = Vec::from_iter(upstream_artifacts.to_owned());
-            artifacts.sort_by(|a, b| {
-                if a.version == b.version {
-                    b.arch.to_string().cmp(&a.arch.to_string())
-                } else {
-                    b.version.cmp(&a.version)
-                }
-            });
-            artifacts
-        },
-    })
-    .context("Error serializing inventory as toml")
-    .and_then(|contents| {
-        fs::write(inventory_path.into(), contents).context("Error writing inventory file")
-    })
+    fs::write(
+        inventory_path.into(),
+        Inventory {
+            artifacts: {
+                let mut artifacts = upstream_artifacts.to_vec();
+                artifacts.sort_by(|a, b| {
+                    if a.version == b.version {
+                        b.arch.to_string().cmp(&a.arch.to_string())
+                    } else {
+                        b.version.cmp(&a.version)
+                    }
+                });
+                artifacts
+            },
+        }
+        .to_string(),
+    )
+    .context("Error writing inventory file")
 }
 
 fn write_changelog(

--- a/common/nodejs-utils/src/vrs.rs
+++ b/common/nodejs-utils/src/vrs.rs
@@ -1,6 +1,6 @@
 use crate::{distribution::Distribution, s3};
 use anyhow::anyhow;
-use heroku_inventory_utils::inv::VersionRequirement;
+use libherokubuildpack::inventory::version::VersionRequirement;
 use node_semver::{Range, Version as NSVersion};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;


### PR DESCRIPTION
This PR removes the `heroku-inventory-utils` dependency in favor of the [recently migrated](https://github.com/heroku/libcnb.rs/pull/861) `inventory` code in `libherokubuildpack`.