### PR TITLE
Update default Node.js version to 22.x

### DIFF
--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update default Node.js version to 22.x
+
 ## [3.2.18] - 2024-10-31
 
 ### Added

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Update default Node.js version to 22.x
+- Updated default Node.js version to 22.x
 
 ## [3.2.18] - 2024-10-31
 

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Updated default Node.js version to 22.x
+### Changed
+
+- Updated default Node.js version to 22.x.
+  ([#950](https://github.com/heroku/buildpacks-nodejs/pull/950))
 
 ## [3.2.18] - 2024-10-31
 

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -33,7 +33,7 @@ mod install_node;
 
 const INVENTORY: &str = include_str!("../inventory.toml");
 
-const LTS_VERSION: &str = "20.x";
+const LTS_VERSION: &str = "22.x";
 
 const MINIMUM_NODE_VERSION_FOR_METRICS: &str = ">=14.10";
 

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -16,7 +16,7 @@ const METRICS_SEND_TIMEOUT: Duration = Duration::from_secs(15);
 #[ignore]
 fn simple_indexjs() {
     nodejs_integration_test("./fixtures/node-with-indexjs", |ctx| {
-        assert_contains!(ctx.pack_stdout, "Node.js version not specified, using 20.x");
+        assert_contains!(ctx.pack_stdout, "Node.js version not specified, using 22.x");
         assert_contains!(ctx.pack_stdout, "Installing Node.js");
         assert_web_response(&ctx, "node-with-indexjs");
     });


### PR DESCRIPTION
Node.js 22.x is now the Active LTS release line as of 10-29-2024 ([source](https://github.com/nodejs/Release)). In accordance with our support policy, it should be the default version.