### PR TITLE
Use `heroku/builder:24` in README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To build a Node.js application codebase into a production image:
 
 ```bash
 $ cd ~/workdir/sample-nodejs-app
-$ pack build sample-app --builder heroku/builder:22
+$ pack build sample-app --builder heroku/builder:24
 ```
 
 Then run the image:

--- a/buildpacks/nodejs-corepack/README.md
+++ b/buildpacks/nodejs-corepack/README.md
@@ -59,7 +59,7 @@ For most users, it's simplest to build an app using [`pack`](https://buildpacks.
 and Heroku's [builder](https://github.com/heroku/cnb-builder-images), which includes this buildpack.
 
 ```
-pack build example-app-image --builder heroku/builder:22 --path /my/example-app
+pack build example-app-image --builder heroku/builder:24 --path /my/example-app
 ```
 
 For users desiring more control, this buildpack can be used as part of a

--- a/buildpacks/nodejs-pnpm-install/README.md
+++ b/buildpacks/nodejs-pnpm-install/README.md
@@ -93,11 +93,11 @@ command from Cloud Native Buildpacks using
 pack build example-app-image --buildpack heroku/nodejs-engine --buildpack heroku/nodejs-corepack --buildpack heroku/nodejs-pnpm-install --path /some/example-app
 ```
 
-Alternatively, use the `heroku/builder:22` builder, which includes the above
+Alternatively, use the `heroku/builder:24` builder, which includes the above
 buildpacks:
 
 ```
-pack build example-app-image --builder heroku/builder:22 --path /some/example-app
+pack build example-app-image --builder heroku/builder:24 --path /some/example-app
 ```
 
 ## Build Plan


### PR DESCRIPTION
For multi-arch support + now that Heroku-24 is the default stack instead of Heroku-22.