### PR TITLE
Fix warning for checked in `node_modules` dir

### DIFF
--- a/buildpacks/nodejs-npm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-install/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Warning for checked in `node_modules` di
+- Performs check for detecting `node_modules` directory at build start and outputs warning at build end. ([#997](https://github.com/heroku/buildpacks-nodejs/pull/997))
 
 ## [3.4.2] - 2025-01-08
 

--- a/buildpacks/nodejs-npm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-install/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Warning for checked in `node_modules` di
+
 ## [3.4.2] - 2025-01-08
 
 - No changes.

--- a/buildpacks/nodejs-npm-install/src/main.rs
+++ b/buildpacks/nodejs-npm-install/src/main.rs
@@ -78,6 +78,8 @@ impl Buildpack for NpmInstallBuildpack {
         let node_build_scripts_metadata = read_node_build_scripts_metadata(&context.buildpack_plan)
             .map_err(NpmInstallBuildpackError::NodeBuildScriptsMetadata)?;
 
+        let prebuild_modules_warning = application::warn_prebuilt_modules(app_dir);
+
         application::check_for_singular_lockfile(app_dir)
             .map_err(NpmInstallBuildpackError::Application)?;
 
@@ -98,12 +100,11 @@ impl Buildpack for NpmInstallBuildpack {
 
         configure_npm_runtime_env(&context)?;
 
-        let logger =
-            if let Some(prebuilt_modules_warning) = application::warn_prebuilt_modules(app_dir) {
-                logger.warning(prebuilt_modules_warning)
-            } else {
-                logger
-            };
+        let logger = if let Some(warning_message) = prebuild_modules_warning {
+            logger.warning(warning_message)
+        } else {
+            logger
+        };
 
         logger.done();
         build_result

--- a/buildpacks/nodejs-npm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-npm-install/tests/integration_test.rs
@@ -288,6 +288,29 @@ fn test_default_web_process_registration_is_skipped_if_procfile_exists() {
     );
 }
 
+#[test]
+#[ignore]
+fn npm_modules_checked_in_warning() {
+    nodejs_integration_test("./fixtures/npm-project", |ctx| {
+        assert_not_contains!(
+            ctx.pack_stdout,
+            "Warning: `node_modules` checked into source control"
+        );
+
+        let mut config = ctx.config.clone();
+        config.app_dir_preprocessor(|app_dir| {
+            std::fs::create_dir(app_dir.join("node_modules")).unwrap();
+        });
+
+        ctx.rebuild(config, |ctx| {
+            assert_contains!(
+                ctx.pack_stdout,
+                "Warning: `node_modules` checked into source control"
+            );
+        });
+    });
+}
+
 fn add_lockfile_entry(app_dir: &Path, package_name: &str, lockfile_entry: serde_json::Value) {
     update_json_file(&app_dir.join("package-lock.json"), |json| {
         let dependencies = json["dependencies"].as_object_mut().unwrap();

--- a/common/nodejs-utils/src/package_json.rs
+++ b/common/nodejs-utils/src/package_json.rs
@@ -107,7 +107,7 @@ impl PackageJson {
     pub fn has_start_script(&self) -> bool {
         self.scripts
             .as_ref()
-            .map_or(false, |scripts| scripts.start.is_some())
+            .is_some_and(|scripts| scripts.start.is_some())
     }
 }
 


### PR DESCRIPTION
One of the features of the `commons` logger that was removed in https://github.com/heroku/buildpacks-nodejs/pull/993 was the ability to collect log messages that would be emitted at a later point. This feature is not available in `bullet_stream` so when I moved the logging message that notifies the user they've checked in their `node_modules` directory to the end of the build phase, I mistakenly moved the timing of that check to run at the end of the build phase as well.

This check needs to run at the beginning of the build phase and the warning needs to be emitted at the end. This PR contains changes to do this + adds an integration test to verify this case.