### PR TITLE
Remove check and warning for `node_modules` directory

### DIFF
--- a/buildpacks/nodejs-npm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-install/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Check and warning for `node_modules` directory is unnecessary since
+  `npm ci` will remove it before installing dependencies. ([#998]https://github.com/heroku/buildpacks-nodejs/pull/998))
+
 ## [3.4.2] - 2025-01-08
 
 - No changes.

--- a/buildpacks/nodejs-npm-install/src/main.rs
+++ b/buildpacks/nodejs-npm-install/src/main.rs
@@ -98,13 +98,6 @@ impl Buildpack for NpmInstallBuildpack {
 
         configure_npm_runtime_env(&context)?;
 
-        let logger =
-            if let Some(prebuilt_modules_warning) = application::warn_prebuilt_modules(app_dir) {
-                logger.warning(prebuilt_modules_warning)
-            } else {
-                logger
-            };
-
         logger.done();
         build_result
     }

--- a/common/nodejs-utils/src/application.rs
+++ b/common/nodejs-utils/src/application.rs
@@ -1,6 +1,6 @@
 use crate::package_manager::PackageManager;
 use bullet_stream::style;
-use indoc::{formatdoc, writedoc};
+use indoc::writedoc;
 use std::fmt::{Display, Formatter};
 use std::path::Path;
 
@@ -25,23 +25,6 @@ pub fn check_for_singular_lockfile(app_dir: &Path) -> Result<(), Error> {
         0 => Err(Error::MissingLockfile),
         1 => Ok(()),
         _ => Err(Error::MultipleLockfiles(detected_lockfiles)),
-    }
-}
-
-/// Checks if the `node_modules` folder is present in the given directory which indicates that
-/// the application contains files that it shouldn't in its git repository. If this is the case,
-/// a warning message will be returned.
-#[must_use]
-pub fn warn_prebuilt_modules(app_dir: &Path) -> Option<String> {
-    if app_dir.join("node_modules").exists() {
-        Some(formatdoc! {"
-            Warning: {node_modules} checked into source control
-
-            Add these files and directories to {gitignore}. See the Dev Center for more info:
-            https://devcenter.heroku.com/articles/node-best-practices#only-git-the-important-bits
-        ", node_modules = style::value("node_modules"), gitignore = style::value(".gitignore") })
-    } else {
-        None
     }
 }
 
@@ -132,6 +115,7 @@ impl Display for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::formatdoc;
 
     #[test]
     fn test_error_output_for_multiple_lockfiles() {

--- a/common/nodejs-utils/src/package_json.rs
+++ b/common/nodejs-utils/src/package_json.rs
@@ -107,7 +107,7 @@ impl PackageJson {
     pub fn has_start_script(&self) -> bool {
         self.scripts
             .as_ref()
-            .map_or(false, |scripts| scripts.start.is_some())
+            .is_some_and(|scripts| scripts.start.is_some())
     }
 }
 


### PR DESCRIPTION
This warning was carried over from the classic Heroku Node.js buildpack which did support both `npm install` and `npm ci`. If a `node_modules` directory existed and there was no lockfile present, this could cause issues with the dependencies installed.

This buildpack only supports `npm ci` so this check and warning is not required. If the `node_modules` directory is already present, `npm ci` will automatically remove it.