### PR TITLE
Update nodejs-engine buildpack output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,7 @@ dependencies = [
 name = "heroku-nodejs-engine-buildpack"
 version = "0.0.0"
 dependencies = [
+ "bullet_stream",
  "heroku-nodejs-utils",
  "libcnb",
  "libcnb-test",

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -7,9 +7,10 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
+bullet_stream = "0.4"
 heroku-nodejs-utils.workspace = true
 libcnb = { version = "=0.26.0", features = ["trace"] }
-libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["download", "fs", "inventory", "log", "tar"] }
+libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["download", "fs", "inventory", "tar"] }
 serde = "1"
 sha2 = "0.10.8"
 tempfile = "3"

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -1,7 +1,6 @@
-use std::env::consts;
-
 use crate::configure_web_env::configure_web_env;
 use crate::install_node::{install_node, DistLayerError};
+use bullet_stream::{style, Print};
 use heroku_nodejs_utils::package_json::{PackageJson, PackageJsonError};
 use heroku_nodejs_utils::vrs::{Requirement, Version};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
@@ -16,10 +15,11 @@ use libcnb::{buildpack_main, Buildpack};
 use libcnb_test as _;
 use libherokubuildpack::inventory::artifact::{Arch, Os};
 use libherokubuildpack::inventory::Inventory;
-use libherokubuildpack::log::{log_error, log_header, log_info};
 #[cfg(test)]
 use serde_json as _;
 use sha2::Sha256;
+use std::env::consts;
+use std::io::stdout;
 #[cfg(test)]
 use test_support as _;
 use thiserror::Error;
@@ -67,8 +67,14 @@ impl Buildpack for NodeJsEngineBuildpack {
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-        log_header("Heroku Node.js Engine Buildpack");
-        log_header("Checking Node.js version");
+        let mut log = Print::new(stdout()).h1(context
+            .buildpack_descriptor
+            .buildpack
+            .name
+            .as_ref()
+            .expect("The buildpack.toml should have a 'name' field set"));
+
+        let mut bullet = log.bullet("Checking Node.js version");
 
         let inv: Inventory<Version, Sha256, Option<()>> =
             toml::from_str(INVENTORY).map_err(NodeJsEngineBuildpackError::InventoryParseError)?;
@@ -78,11 +84,15 @@ impl Buildpack for NodeJsEngineBuildpack {
             .map(|package_json| package_json.engines.and_then(|e| e.node))?;
 
         let version_range = if let Some(value) = requested_version_range {
-            log_info(format!("Detected Node.js version range: {value}"));
+            bullet = bullet.sub_bullet(format!(
+                "Detected Node.js version range: {}",
+                style::value(value.to_string())
+            ));
             value
         } else {
-            log_info(format!(
-                "Node.js version not specified, using {LTS_VERSION}"
+            bullet = bullet.sub_bullet(format!(
+                "Node.js version not specified, using {}",
+                style::value(LTS_VERSION)
             ));
             Requirement::parse(LTS_VERSION).expect("The default Node.js version should be valid")
         };
@@ -95,13 +105,14 @@ impl Buildpack for NodeJsEngineBuildpack {
             version_range.to_string(),
         ))?;
 
-        log_info(format!(
-            "Resolved Node.js version: {}",
-            target_artifact.version
-        ));
+        log = bullet
+            .sub_bullet(format!(
+                "Resolved Node.js version: {}",
+                style::value(target_artifact.version.to_string())
+            ))
+            .done();
 
-        log_header("Installing Node.js distribution");
-        install_node(&context, target_artifact)?;
+        log = install_node(&context, target_artifact, log)?;
 
         configure_web_env(&context)?;
 
@@ -122,6 +133,8 @@ impl Buildpack for NodeJsEngineBuildpack {
                     .build()
             });
 
+        log.done();
+
         let resulter = BuildResultBuilder::new();
         match launchjs {
             Some(l) => resulter.launch(l).build(),
@@ -130,26 +143,24 @@ impl Buildpack for NodeJsEngineBuildpack {
     }
 
     fn on_error(&self, error: libcnb::Error<Self::Error>) {
+        let log = Print::new(stdout()).without_header();
         match error {
-            libcnb::Error::BuildpackError(bp_err) => {
-                let err_string = bp_err.to_string();
-                match bp_err {
-                    NodeJsEngineBuildpackError::DistLayerError(_) => {
-                        log_error("Node.js engine distribution error", err_string);
-                    }
-                    NodeJsEngineBuildpackError::InventoryParseError(_) => {
-                        log_error("Node.js engine inventory parse error", err_string);
-                    }
-                    NodeJsEngineBuildpackError::PackageJsonError(_) => {
-                        log_error("Node.js engine package.json error", err_string);
-                    }
-                    NodeJsEngineBuildpackError::UnknownVersionError(_) => {
-                        log_error("Node.js engine version error", err_string);
-                    }
+            libcnb::Error::BuildpackError(bp_err) => match bp_err {
+                NodeJsEngineBuildpackError::DistLayerError(_) => {
+                    log.error(format!("Node.js engine distribution error:\n{bp_err}"));
                 }
-            }
+                NodeJsEngineBuildpackError::InventoryParseError(_) => {
+                    log.error(format!("Node.js engine inventory parse error:\n{bp_err}"));
+                }
+                NodeJsEngineBuildpackError::PackageJsonError(_) => {
+                    log.error(format!("Node.js engine package.json error:\n{bp_err}"));
+                }
+                NodeJsEngineBuildpackError::UnknownVersionError(_) => {
+                    log.error(format!("Node.js engine version error:\n{bp_err}"));
+                }
+            },
             err => {
-                log_error("Internal Buildpack Error", err.to_string());
+                log.error(format!("Internal Buildpack Error:\n{err}"));
             }
         };
     }

--- a/buildpacks/nodejs-engine/tests/integration_test.rs
+++ b/buildpacks/nodejs-engine/tests/integration_test.rs
@@ -11,7 +11,10 @@ use test_support::{
 #[ignore]
 fn simple_indexjs() {
     nodejs_integration_test("./fixtures/node-with-indexjs", |ctx| {
-        assert_contains!(ctx.pack_stdout, "Node.js version not specified, using 22.x");
+        assert_contains!(
+            ctx.pack_stdout,
+            "Node.js version not specified, using `22.x`"
+        );
         assert_contains!(ctx.pack_stdout, "Installing Node.js");
         assert_web_response(&ctx, "node-with-indexjs");
     });
@@ -21,19 +24,19 @@ fn simple_indexjs() {
 #[ignore]
 fn simple_serverjs() {
     nodejs_integration_test("./fixtures/node-with-serverjs", |ctx| {
-        assert_contains!(ctx.pack_stdout, "Detected Node.js version range: 16.0.0");
+        assert_contains!(ctx.pack_stdout, "Detected Node.js version range: `16.0.0`");
         if cfg!(target_arch = "aarch64") {
             assert_contains!(
                 ctx.pack_stdout,
-                "Downloading Node.js 16.0.0 (linux-arm64) from https://nodejs.org/download/release/v16.0.0/node-v16.0.0-linux-arm64.tar.gz"
+                "Downloading Node.js `16.0.0 (linux-arm64)` from https://nodejs.org/download/release/v16.0.0/node-v16.0.0-linux-arm64.tar.gz"
             );
-            assert_contains!(ctx.pack_stdout, "Installing Node.js 16.0.0 (linux-arm64)");
+            assert_contains!(ctx.pack_stdout, "Installing Node.js `16.0.0 (linux-arm64)`");
         } else {
             assert_contains!(
                 ctx.pack_stdout,
-                "Downloading Node.js 16.0.0 (linux-amd64) from https://nodejs.org/download/release/v16.0.0/node-v16.0.0-linux-x64.tar.gz"
+                "Downloading Node.js `16.0.0 (linux-amd64)` from https://nodejs.org/download/release/v16.0.0/node-v16.0.0-linux-x64.tar.gz"
             );
-            assert_contains!(ctx.pack_stdout, "Installing Node.js 16.0.0 (linux-amd64)");
+            assert_contains!(ctx.pack_stdout, "Installing Node.js `16.0.0 (linux-amd64)`");
         }
         assert_web_response(&ctx, "node-with-serverjs");
     });
@@ -50,13 +53,13 @@ fn reinstalls_node_if_version_changes() {
             });
         },
         |ctx| {
-            assert_contains!(ctx.pack_stdout, "Installing Node.js 14");
+            assert_contains!(ctx.pack_stdout, "Installing Node.js `14");
             let mut config = ctx.config.clone();
             config.app_dir_preprocessor(|app_dir| {
                 set_node_engine(&app_dir, "^16.0");
             });
             ctx.rebuild(config, |ctx| {
-                assert_contains!(ctx.pack_stdout, "Installing Node.js 16");
+                assert_contains!(ctx.pack_stdout, "Installing Node.js `16");
             });
         },
     );


### PR DESCRIPTION
This PR replaces the previous logging mechanisms with `bullet_stream`.