### PR TITLE
Reduce scopes granted to `GITHUB_TOKEN` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/_mirror-distribution.yml
+++ b/.github/workflows/_mirror-distribution.yml
@@ -17,6 +17,9 @@ on:
       AWS_SECRET_ACCESS_KEY:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   get-unmirrored-versions:
     name: Get Unmirrored Versions

--- a/.github/workflows/_update-inventory.yml
+++ b/.github/workflows/_update-inventory.yml
@@ -22,6 +22,9 @@ on:
       LINGUIST_GH_PRIVATE_KEY:
         required: true
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 jobs:
   update-inventory:
     name: Update Inventory

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '00 4 * * 1-5'
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 jobs:
   update-nodejs-inventory:
     name: Update Node.js Inventory

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '00 1 * * 1-5'
 
+permissions:
+  contents: read
+
 jobs:
   mirror-node:
     name: Mirror Node.js

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,6 +13,9 @@ on:
           - minor
           - patch
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 jobs:
   prepare-release:
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         type: boolean
         default: false
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
As part of security-hardening our GHA workflows, this reduces the permissions granted to the automatically set `GITHUB_TOKEN` env var in GitHub Actions workflows to no more than what is required by that workflow.

See:
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

GUS-W-18053749.