### PR TITLE
Add coverage reporting via cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,33 @@ jobs:
       - name: Run unit tests
         run: cargo test --locked
 
+  # Currently a separate job since the #coverage(off) attribute requires nightly Rust. As soon as we can use llvm-cov
+  # without Rust nightly, we should merge this job with the regular unit tests.
+  unit-test-coverage:
+    name: Generate test coverage report
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install nightly Rust toolchain
+        run: rustup install nightly
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@575f713d0233afba556737a7b85080563be14186 # v2.49.43
+        with:
+          tool: cargo-llvm-cov
+      - name: Run unit tests and generate coverage report
+        run: cargo +nightly llvm-cov --locked --html
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: "llvm-cov-html-${{github.event.repository.name}}-${{github.sha}}"
+          path: "target/llvm-cov/html"
+          if-no-files-found: "error"
+
   find-libcnb-buildpacks:
     name: Find libcnb buildpacks
     runs-on: ubuntu-24.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,8 @@ test_support = { path = "./test_support" }
 
 [profile.release]
 strip = true
+
+# Allows the usage of cfg(coverage_nightly).
+# cargo-llvm-cov enables that config when instrumenting our code, so we can enable
+# the experimental coverage_attribute feature.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/buildpacks/nodejs-corepack/src/main.rs
+++ b/buildpacks/nodejs-corepack/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use bullet_stream::{style, Print};
 use heroku_nodejs_utils::package_json::{PackageJson, PackageJsonError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};

--- a/buildpacks/nodejs-engine/src/main.rs
+++ b/buildpacks/nodejs-engine/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use crate::configure_web_env::configure_web_env;
 use crate::install_node::{install_node, DistLayerError};
 use bullet_stream::{style, Print};

--- a/buildpacks/nodejs-function-invoker/src/main.rs
+++ b/buildpacks/nodejs-function-invoker/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use crate::attach_startup_script::{
     attach_startup_script, ScriptLayerError, NODEJS_RUNTIME_SCRIPT,
 };

--- a/buildpacks/nodejs-npm-engine/src/main.rs
+++ b/buildpacks/nodejs-npm-engine/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 mod errors;
 mod install_npm;
 mod node;

--- a/buildpacks/nodejs-npm-install/src/main.rs
+++ b/buildpacks/nodejs-npm-install/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 mod configure_npm_cache_directory;
 mod configure_npm_runtime_env;
 mod errors;

--- a/buildpacks/nodejs-pnpm-engine/src/main.rs
+++ b/buildpacks/nodejs-pnpm-engine/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 mod errors;
 
 use crate::errors::PnpmEngineBuildpackError;

--- a/buildpacks/nodejs-pnpm-install/src/main.rs
+++ b/buildpacks/nodejs-pnpm-install/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use bullet_stream::{style, Print};
 use heroku_nodejs_utils::package_json::{PackageJson, PackageJsonError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};

--- a/buildpacks/nodejs-yarn/src/main.rs
+++ b/buildpacks/nodejs-yarn/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use crate::yarn::Yarn;
 use bullet_stream::{style, Print};
 use heroku_nodejs_utils::inv::Inventory;


### PR DESCRIPTION
This sets up a GitHub Action job that uploads an HTML report of unit test code coverage to the run summary.