### PR TITLE
Use `bullet_stream` global functions instead of state-based ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 name = "heroku-pnpm-engine-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream 0.7.0",
+ "bullet_stream 0.8.0",
  "heroku-nodejs-utils",
  "indoc",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 name = "heroku-nodejs-pnpm-install-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream 0.7.0",
+ "bullet_stream 0.8.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ name = "heroku-nodejs-function-invoker-buildpack"
 version = "0.0.0"
 dependencies = [
  "base64",
- "bullet_stream 0.7.0",
+ "bullet_stream 0.8.0",
  "heroku-nodejs-utils",
  "hex",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 name = "heroku-nodejs-engine-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream 0.7.0",
+ "bullet_stream 0.8.0",
  "heroku-nodejs-utils",
  "indoc",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 name = "heroku-nodejs-yarn-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream 0.7.0",
+ "bullet_stream 0.8.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 name = "heroku-npm-install-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream 0.7.0",
+ "bullet_stream 0.8.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 name = "heroku-npm-engine-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream 0.7.0",
+ "bullet_stream 0.8.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bullet_stream"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc54f3252b0ff30201f78a466a017afef4da0ec6c669efcabef8d4cec7c0d58"
+dependencies = [
+ "fun_run",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,7 +664,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 name = "heroku-nodejs-corepack-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream",
+ "bullet_stream 0.8.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",
@@ -672,7 +681,7 @@ dependencies = [
 name = "heroku-nodejs-engine-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream",
+ "bullet_stream 0.7.0",
  "heroku-nodejs-utils",
  "indoc",
  "insta",
@@ -694,7 +703,7 @@ name = "heroku-nodejs-function-invoker-buildpack"
 version = "0.0.0"
 dependencies = [
  "base64",
- "bullet_stream",
+ "bullet_stream 0.7.0",
  "heroku-nodejs-utils",
  "hex",
  "indoc",
@@ -715,7 +724,7 @@ dependencies = [
 name = "heroku-nodejs-pnpm-install-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream",
+ "bullet_stream 0.7.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",
@@ -734,7 +743,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bon",
- "bullet_stream",
+ "bullet_stream 0.7.0",
  "chrono",
  "indoc",
  "keep_a_changelog_file",
@@ -757,7 +766,7 @@ dependencies = [
 name = "heroku-nodejs-yarn-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream",
+ "bullet_stream 0.7.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",
@@ -777,7 +786,7 @@ dependencies = [
 name = "heroku-npm-engine-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream",
+ "bullet_stream 0.7.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",
@@ -796,7 +805,7 @@ dependencies = [
 name = "heroku-npm-install-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream",
+ "bullet_stream 0.7.0",
  "fun_run",
  "heroku-nodejs-utils",
  "indoc",
@@ -813,7 +822,7 @@ dependencies = [
 name = "heroku-pnpm-engine-buildpack"
 version = "0.0.0"
 dependencies = [
- "bullet_stream",
+ "bullet_stream 0.7.0",
  "heroku-nodejs-utils",
  "indoc",
  "insta",

--- a/buildpacks/nodejs-corepack/CHANGELOG.md
+++ b/buildpacks/nodejs-corepack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack output changes. ([#1093](https://github.com/heroku/buildpacks-nodejs/pull/1093))
+
 ## [3.6.1] - 2025-04-24
 
 - No changes.

--- a/buildpacks/nodejs-corepack/Cargo.toml
+++ b/buildpacks/nodejs-corepack/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-bullet_stream = "0.7"
+bullet_stream = "0.8"
 fun_run = "0.5"
 heroku-nodejs-utils.workspace = true
 indoc = "2"

--- a/buildpacks/nodejs-corepack/src/cmd.rs
+++ b/buildpacks/nodejs-corepack/src/cmd.rs
@@ -1,9 +1,8 @@
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::global::print;
+use bullet_stream::style;
 use fun_run::CommandWithName;
 use heroku_nodejs_utils::vrs::{Version, VersionError};
 use libcnb::Env;
-use std::io::Stderr;
 use std::{path::Path, process::Command};
 
 #[derive(Debug)]
@@ -31,8 +30,7 @@ pub(crate) fn corepack_enable(
     package_manager: &str,
     shim_path: &Path,
     env: &Env,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, fun_run::CmdError> {
+) -> Result<(), fun_run::CmdError> {
     let shim_path_string = shim_path.to_string_lossy();
     let mut command = Command::new("corepack");
     command.args([
@@ -43,24 +41,12 @@ pub(crate) fn corepack_enable(
     ]);
     command.envs(env);
 
-    log = log.sub_bullet(format!("Executing {}", style::command(command.name())));
+    print::sub_bullet(format!("Executing {}", style::command(command.name())));
 
-    command.named_output()?;
-
-    Ok(log)
+    command.named_output().map(|_| ())
 }
 
 /// Execute `corepack prepare` to install the correct package manager
-pub(crate) fn corepack_prepare(
-    env: &Env,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, fun_run::CmdError> {
-    let mut command = Command::new("corepack");
-    command.arg("prepare");
-    command.envs(env);
-    log.stream_with(
-        format!("Running {}", style::command(command.name())),
-        |stdout, stderr| command.stream_output(stdout, stderr),
-    )?;
-    Ok(log)
+pub(crate) fn corepack_prepare(env: &Env) -> Result<(), fun_run::CmdError> {
+    print::sub_stream_cmd(Command::new("corepack").arg("prepare").envs(env)).map(|_| ())
 }

--- a/buildpacks/nodejs-corepack/src/prepare_corepack.rs
+++ b/buildpacks/nodejs-corepack/src/prepare_corepack.rs
@@ -48,15 +48,15 @@ pub(crate) fn prepare_corepack(
 
     match manager_layer.state {
         LayerState::Restored { .. } => {
-            print::bullet("Restoring Corepack package manager");
+            print::sub_bullet("Restoring Corepack package manager");
         }
         LayerState::Empty { cause } => {
             match cause {
                 EmptyLayerCause::NewlyCreated => {
-                    print::bullet("Creating Corepack package manager");
+                    print::sub_bullet("Creating Corepack package manager");
                 }
                 _ => {
-                    print::bullet("Recreating Corepack package manager (version changed)");
+                    print::sub_bullet("Recreating Corepack package manager (version changed)");
                 }
             }
             manager_layer.write_metadata(new_metadata)?;

--- a/buildpacks/nodejs-corepack/tests/snapshots/corepack_npm_10.snap
+++ b/buildpacks/nodejs-corepack/tests/snapshots/corepack_npm_10.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `npm@10.2.0` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `10.2.0`

--- a/buildpacks/nodejs-corepack/tests/snapshots/corepack_npm_8.snap
+++ b/buildpacks/nodejs-corepack/tests/snapshots/corepack_npm_8.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `npm@8.19.4` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `8.19.4`

--- a/buildpacks/nodejs-corepack/tests/snapshots/corepack_pnpm_7.snap
+++ b/buildpacks/nodejs-corepack/tests/snapshots/corepack_pnpm_7.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `pnpm@7.32.3` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Creating new pnpm content-addressable store

--- a/buildpacks/nodejs-corepack/tests/snapshots/corepack_pnpm_8.snap
+++ b/buildpacks/nodejs-corepack/tests/snapshots/corepack_pnpm_8.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `pnpm@8.4.0` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Creating new pnpm content-addressable store

--- a/buildpacks/nodejs-corepack/tests/snapshots/corepack_yarn_2.snap
+++ b/buildpacks/nodejs-corepack/tests/snapshots/corepack_yarn_2.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@2.4.1` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 2.4.1 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-corepack/tests/snapshots/corepack_yarn_3.snap
+++ b/buildpacks/nodejs-corepack/tests/snapshots/corepack_yarn_3.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@3.2.0` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 3.2.0 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack output changes. ([#1093](https://github.com/heroku/buildpacks-nodejs/pull/1093))
+
 ## [3.6.1] - 2025-04-24
 
 ### Added

--- a/buildpacks/nodejs-engine/Cargo.toml
+++ b/buildpacks/nodejs-engine/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-bullet_stream = "0.7"
+bullet_stream = "0.8"
 heroku-nodejs-utils.workspace = true
 indoc = "2"
 libcnb = { version = "=0.28.1", features = ["trace"] }

--- a/buildpacks/nodejs-engine/src/install_node.rs
+++ b/buildpacks/nodejs-engine/src/install_node.rs
@@ -1,5 +1,5 @@
-use bullet_stream::state::Bullet;
-use bullet_stream::{style, Print};
+use bullet_stream::global::print;
+use bullet_stream::style;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use sha2::digest::Output;
 use sha2::{Digest, Sha256};
 use std::fs;
-use std::io::{Read, Stderr};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
@@ -24,9 +24,8 @@ use crate::{NodeJsEngineBuildpack, NodeJsEngineBuildpackError};
 pub(crate) fn install_node(
     context: &BuildContext<NodeJsEngineBuildpack>,
     distribution_artifact: &Artifact<Version, Sha256, Option<()>>,
-    log: Print<Bullet<Stderr>>,
-) -> Result<Print<Bullet<Stderr>>, libcnb::Error<NodeJsEngineBuildpackError>> {
-    let mut bullet = log.bullet("Installing Node.js distribution");
+) -> Result<(), libcnb::Error<NodeJsEngineBuildpackError>> {
+    print::bullet("Installing Node.js distribution");
 
     let new_metadata = DistLayerMetadata {
         artifact: distribution_artifact.clone(),
@@ -55,14 +54,14 @@ pub(crate) fn install_node(
     );
     match distribution_layer.state {
         LayerState::Restored { .. } => {
-            bullet = bullet.sub_bullet(format!("Reusing Node.js {version_tag}"));
+            print::sub_bullet(format!("Reusing Node.js {version_tag}"));
         }
         LayerState::Empty { .. } => {
             distribution_layer.write_metadata(new_metadata)?;
 
             let node_tgz = NamedTempFile::new().map_err(DistLayerError::TempFile)?;
 
-            let timer = bullet.start_timer(format!(
+            let timer = print::sub_start_timer(format!(
                 "Downloading Node.js {} from {}",
                 style::value(&version_tag),
                 style::url(&distribution_artifact.url)
@@ -74,9 +73,9 @@ pub(crate) fn install_node(
                     source: e,
                 }
             })?;
-            bullet = timer.done();
+            let _ = timer.done();
 
-            bullet = bullet.sub_bullet("Verifying checksum");
+            print::sub_bullet("Verifying checksum");
             let digest = sha256(node_tgz.path()).map_err(|e| DistLayerError::ReadTempFile {
                 path: node_tgz.path().to_path_buf(),
                 source: e,
@@ -92,8 +91,7 @@ pub(crate) fn install_node(
                 })?;
             }
 
-            bullet =
-                bullet.sub_bullet(format!("Extracting Node.js {}", style::value(&version_tag)));
+            print::sub_bullet(format!("Extracting Node.js {}", style::value(&version_tag)));
             let node_tgz_path = node_tgz.path().to_path_buf();
             decompress_tarball(&mut node_tgz.into_file(), distribution_layer.path()).map_err(
                 |e| DistLayerError::Untar {
@@ -103,8 +101,10 @@ pub(crate) fn install_node(
                 },
             )?;
 
-            let timer =
-                bullet.start_timer(format!("Installing Node.js {}", style::value(&version_tag)));
+            let timer = print::sub_start_timer(format!(
+                "Installing Node.js {}",
+                style::value(&version_tag)
+            ));
             let dist_name = extract_tarball_prefix(&distribution_artifact.url)
                 .ok_or_else(|| DistLayerError::TarballPrefix(distribution_artifact.url.clone()))?;
             let dist_path = distribution_layer.path().join(dist_name);
@@ -115,11 +115,11 @@ pub(crate) fn install_node(
                     source: e,
                 }
             })?;
-            bullet = timer.done();
+            let _ = timer.done();
         }
     }
 
-    Ok(bullet.done())
+    Ok(())
 }
 
 fn sha256(path: impl AsRef<Path>) -> Result<Output<Sha256>, std::io::Error> {

--- a/buildpacks/nodejs-engine/tests/snapshots/reinstalls_node_if_version_changes.snap
+++ b/buildpacks/nodejs-engine/tests/snapshots/reinstalls_node_if_version_changes.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -15,7 +15,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=16.0.0 <17.0.0-0`

--- a/buildpacks/nodejs-engine/tests/snapshots/simple_indexjs.snap
+++ b/buildpacks/nodejs-engine/tests/snapshots/simple_indexjs.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`

--- a/buildpacks/nodejs-engine/tests/snapshots/simple_serverjs.snap
+++ b/buildpacks/nodejs-engine/tests/snapshots/simple_serverjs.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `16.0.0`

--- a/buildpacks/nodejs-function-invoker/CHANGELOG.md
+++ b/buildpacks/nodejs-function-invoker/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack output changes. ([#1093](https://github.com/heroku/buildpacks-nodejs/pull/1093))
+
 ## [3.6.1] - 2025-04-24
 
 - No changes.

--- a/buildpacks/nodejs-function-invoker/Cargo.toml
+++ b/buildpacks/nodejs-function-invoker/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-bullet_stream = "0.7"
+bullet_stream = "0.8"
 heroku-nodejs-utils.workspace = true
 indoc = "2"
 libcnb = "=0.28.1"

--- a/buildpacks/nodejs-function-invoker/src/install_nodejs_function_runtime.rs
+++ b/buildpacks/nodejs-function-invoker/src/install_nodejs_function_runtime.rs
@@ -1,12 +1,11 @@
-use bullet_stream::state::Bullet;
-use bullet_stream::Print;
+use bullet_stream::global::print;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
     CachedLayerDefinition, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use serde::{Deserialize, Serialize};
-use std::io::{stderr, stdout, Stderr, Write};
+use std::io::{stderr, stdout, Write};
 use std::process::Command;
 use thiserror::Error;
 
@@ -15,8 +14,7 @@ use crate::{NodeJsInvokerBuildpack, NodeJsInvokerBuildpackError};
 pub(crate) fn install_nodejs_function_runtime(
     context: &BuildContext<NodeJsInvokerBuildpack>,
     package: &str,
-    mut log: Print<Bullet<Stderr>>,
-) -> Result<Print<Bullet<Stderr>>, libcnb::Error<NodeJsInvokerBuildpackError>> {
+) -> Result<(), libcnb::Error<NodeJsInvokerBuildpackError>> {
     let new_metadata = RuntimeLayerMetadata {
         package: package.to_string(),
         layer_version: LAYER_VERSION.to_string(),
@@ -42,20 +40,16 @@ pub(crate) fn install_nodejs_function_runtime(
 
     match runtime_layer.state {
         LayerState::Restored { .. } => {
-            log = log
-                .bullet(format!(
-                    "Reusing Node.js Function Invoker Runtime {package}",
-                ))
-                .done();
+            print::bullet(format!(
+                "Reusing Node.js Function Invoker Runtime {package}",
+            ));
         }
         LayerState::Empty { .. } => {
             runtime_layer.write_metadata(new_metadata)?;
 
-            log = log
-                .bullet(format!(
-                    "Installing Node.js Function Invoker Runtime {package}",
-                ))
-                .done();
+            print::bullet(format!(
+                "Installing Node.js Function Invoker Runtime {package}",
+            ));
 
             Command::new("npm")
                 .args([
@@ -78,7 +72,7 @@ pub(crate) fn install_nodejs_function_runtime(
         }
     }
 
-    Ok(log)
+    Ok(())
 }
 
 const LAYER_VERSION: &str = "1";

--- a/buildpacks/nodejs-npm-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack output changes. ([#1093](https://github.com/heroku/buildpacks-nodejs/pull/1093))
+
 ## [3.6.1] - 2025-04-24
 
 ### Changed

--- a/buildpacks/nodejs-npm-engine/Cargo.toml
+++ b/buildpacks/nodejs-npm-engine/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-bullet_stream = "0.7"
+bullet_stream = "0.8"
 fun_run = "0.5"
 heroku-nodejs-utils.workspace = true
 indoc = "2"

--- a/buildpacks/nodejs-npm-engine/src/install_npm.rs
+++ b/buildpacks/nodejs-npm-engine/src/install_npm.rs
@@ -1,7 +1,7 @@
 use crate::NpmEngineBuildpack;
 use crate::NpmEngineBuildpackError;
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::global::print;
+use bullet_stream::style;
 use fun_run::{CommandWithName, NamedOutput};
 use heroku_nodejs_utils::inv::Release;
 use heroku_nodejs_utils::vrs::Version;
@@ -14,7 +14,6 @@ use libherokubuildpack::download::{download_file, DownloadError};
 use libherokubuildpack::tar::decompress_tarball;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::io::Stderr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -22,8 +21,7 @@ pub(crate) fn install_npm(
     context: &BuildContext<NpmEngineBuildpack>,
     npm_release: &Release,
     node_version: &Version,
-    mut logger: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, libcnb::Error<NpmEngineBuildpackError>> {
+) -> Result<(), libcnb::Error<NpmEngineBuildpackError>> {
     let new_metadata = NpmEngineLayerMetadata {
         node_version: node_version.to_string(),
         npm_version: npm_release.version.to_string(),
@@ -53,13 +51,13 @@ pub(crate) fn install_npm(
 
     match npm_engine_layer.state {
         LayerState::Restored { .. } => {
-            logger = logger.sub_bullet("Using cached npm");
+            print::sub_bullet("Using cached npm");
         }
         LayerState::Empty { ref cause } => {
             npm_engine_layer.write_metadata(new_metadata)?;
 
             if let EmptyLayerCause::RestoredLayerAction { cause } = cause {
-                logger = logger.sub_bullet(format!(
+                print::sub_bullet(format!(
                     "Invalidating cached npm ({} changed)",
                     cause.join(", ")
                 ));
@@ -70,27 +68,25 @@ pub(crate) fn install_npm(
 
             // this install process is generalized from the npm install script at:
             // https://www.npmjs.com/install.sh
-            logger = download_and_unpack_release(
+            download_and_unpack_release(
                 &npm_release.url,
                 &downloaded_package_path,
                 &npm_engine_layer.path(),
-                logger,
             )?;
-            logger = remove_existing_npm_installation(&npm_cli_script, logger)?;
-            logger = install_npm_package(&npm_cli_script, &downloaded_package_path, logger)?;
+            remove_existing_npm_installation(&npm_cli_script)?;
+            install_npm_package(&npm_cli_script, &downloaded_package_path)?;
         }
     }
 
-    Ok(logger)
+    Ok(())
 }
 
 fn download_and_unpack_release(
     download_from: &String,
     download_to: &Path,
     unpack_into: &Path,
-    logger: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, NpmInstallError> {
-    let timer = logger.start_timer(format!("Downloading {}", style::value(download_from)));
+) -> Result<(), NpmInstallError> {
+    let timer = print::sub_start_timer(format!("Downloading {}", style::value(download_from)));
     download_file(download_from, download_to)
         .map_err(NpmInstallError::Download)
         .and_then(|()| {
@@ -101,14 +97,12 @@ fn download_and_unpack_release(
             decompress_tarball(&mut npm_tgz_file, unpack_into)
                 .map_err(|e| NpmInstallError::DecompressTarball(download_to.to_path_buf(), e))
         })?;
-    Ok(timer.done())
+    let _ = timer.done();
+    Ok(())
 }
 
-fn remove_existing_npm_installation(
-    npm_cli_script: &Path,
-    mut logger: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, NpmInstallError> {
-    logger = logger.sub_bullet("Removing npm bundled with Node.js");
+fn remove_existing_npm_installation(npm_cli_script: &Path) -> Result<(), NpmInstallError> {
+    print::sub_bullet("Removing npm bundled with Node.js");
     Command::new("node")
         .args([
             &npm_cli_script.to_string_lossy(),
@@ -119,15 +113,11 @@ fn remove_existing_npm_installation(
         ])
         .named_output()
         .map_err(NpmInstallError::RemoveExistingNpmInstall)
-        .map(|_| logger)
+        .map(|_| ())
 }
 
-fn install_npm_package(
-    npm_cli_script: &Path,
-    package: &Path,
-    mut logger: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, NpmInstallError> {
-    logger = logger.sub_bullet("Installing requested npm");
+fn install_npm_package(npm_cli_script: &Path, package: &Path) -> Result<(), NpmInstallError> {
+    print::sub_bullet("Installing requested npm");
     Command::new("node")
         .args([
             &npm_cli_script.to_string_lossy(),
@@ -138,7 +128,7 @@ fn install_npm_package(
         .named_output()
         .and_then(NamedOutput::nonzero_captured)
         .map_err(NpmInstallError::InstallNpm)
-        .map(|_| logger)
+        .map(|_| ())
 }
 
 fn changed_metadata_fields(

--- a/buildpacks/nodejs-npm-engine/tests/snapshots/npm_engine_install.snap
+++ b/buildpacks/nodejs-npm-engine/tests/snapshots/npm_engine_install.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `16.20.2`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `16.20.2 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Engine
+## Heroku Node.js npm Engine
 
 - Installing npm
   - Found `engines.npm` version `9.6.6` declared in `package.json`
@@ -24,7 +24,7 @@ source: test_support/src/lib.rs
   - Successfully installed `npm@9.6.6`
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `9.6.6`

--- a/buildpacks/nodejs-npm-engine/tests/snapshots/test_node_version_change_invalidates_npm_engine_cache.snap
+++ b/buildpacks/nodejs-npm-engine/tests/snapshots/test_node_version_change_invalidates_npm_engine_cache.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `16.20.2`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `16.20.2 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Engine
+## Heroku Node.js npm Engine
 
 - Installing npm
   - Found `engines.npm` version `9.6.6` declared in `package.json`
@@ -24,7 +24,7 @@ source: test_support/src/lib.rs
   - Successfully installed `npm@9.6.6`
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `9.6.6`
@@ -53,7 +53,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `16.20.1`
@@ -65,7 +65,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `16.20.1 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Engine
+## Heroku Node.js npm Engine
 
 - Installing npm
   - Found `engines.npm` version `9.6.6` declared in `package.json`
@@ -77,7 +77,7 @@ source: test_support/src/lib.rs
   - Successfully installed `npm@9.6.6`
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `9.6.6`

--- a/buildpacks/nodejs-npm-engine/tests/snapshots/test_npm_engine_caching.snap
+++ b/buildpacks/nodejs-npm-engine/tests/snapshots/test_npm_engine_caching.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `16.20.2`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `16.20.2 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Engine
+## Heroku Node.js npm Engine
 
 - Installing npm
   - Found `engines.npm` version `9.6.6` declared in `package.json`
@@ -24,7 +24,7 @@ source: test_support/src/lib.rs
   - Successfully installed `npm@9.6.6`
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `9.6.6`
@@ -53,7 +53,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `16.20.2`
@@ -62,7 +62,7 @@ source: test_support/src/lib.rs
   - Reusing Node.js 16.20.2 (<arch>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Engine
+## Heroku Node.js npm Engine
 
 - Installing npm
   - Found `engines.npm` version `9.6.6` declared in `package.json`
@@ -71,7 +71,7 @@ source: test_support/src/lib.rs
   - Successfully installed `npm@9.6.6`
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `9.6.6`

--- a/buildpacks/nodejs-npm-engine/tests/snapshots/test_npm_version_change_invalidates_npm_engine_cache.snap
+++ b/buildpacks/nodejs-npm-engine/tests/snapshots/test_npm_version_change_invalidates_npm_engine_cache.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `16.20.2`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `16.20.2 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Engine
+## Heroku Node.js npm Engine
 
 - Installing npm
   - Found `engines.npm` version `9.6.6` declared in `package.json`
@@ -24,7 +24,7 @@ source: test_support/src/lib.rs
   - Successfully installed `npm@9.6.6`
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `9.6.6`
@@ -53,7 +53,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `16.20.2`
@@ -62,7 +62,7 @@ source: test_support/src/lib.rs
   - Reusing Node.js 16.20.2 (<arch>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Engine
+## Heroku Node.js npm Engine
 
 - Installing npm
   - Found `engines.npm` version `9.6.5` declared in `package.json`
@@ -74,7 +74,7 @@ source: test_support/src/lib.rs
   - Successfully installed `npm@9.6.5`
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `9.6.5`

--- a/buildpacks/nodejs-npm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-install/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack output changes. ([#1093](https://github.com/heroku/buildpacks-nodejs/pull/1093))
+
 ## [3.6.1] - 2025-04-24
 
 ### Changed

--- a/buildpacks/nodejs-npm-install/Cargo.toml
+++ b/buildpacks/nodejs-npm-install/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-bullet_stream = "0.7"
+bullet_stream = "0.8"
 fun_run = "0.5"
 heroku-nodejs-utils.workspace = true
 indoc = "2"

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_dependencies_and_missing_lockfile_errors.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_dependencies_and_missing_lockfile_errors.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=20.0.0 <21.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `20.19.1 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 
 

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=20.0.0 <21.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `20.19.1 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `10.8.2`
@@ -41,7 +41,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=20.0.0 <21.0.0-0`
@@ -50,7 +50,7 @@ source: test_support/src/lib.rs
   - Reusing Node.js 20.19.1 (<arch>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `10.8.2`

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts_prefers_heroku_build_over_build.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts_prefers_heroku_build_over_build.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_caching.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_caching.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`
@@ -32,7 +32,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -41,7 +41,7 @@ source: test_support/src/lib.rs
   - Reusing Node.js 14.21.3 (<arch>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_new_package.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_new_package.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`
@@ -32,7 +32,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -41,7 +41,7 @@ source: test_support/src/lib.rs
   - Reusing Node.js 14.21.3 (<arch>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_with_lockfile.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_with_lockfile.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_start_script_creates_a_web_process_launcher.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_start_script_creates_a_web_process_launcher.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js npm Install
+## Heroku Node.js npm Install
 
 - Installing node modules
   - Using npm version `6.14.18`

--- a/buildpacks/nodejs-pnpm-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack output changes. ([#1093](https://github.com/heroku/buildpacks-nodejs/pull/1093))
+
 ## [3.6.1] - 2025-04-24
 
 ### Changed

--- a/buildpacks/nodejs-pnpm-engine/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-engine/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-bullet_stream = "0.7"
+bullet_stream = "0.8"
 heroku-nodejs-utils.workspace = true
 indoc = "2"
 libcnb = { version = "=0.28.1", features = ["trace"] }

--- a/buildpacks/nodejs-pnpm-engine/src/main.rs
+++ b/buildpacks/nodejs-pnpm-engine/src/main.rs
@@ -5,7 +5,7 @@
 
 mod errors;
 
-use bullet_stream::Print;
+use bullet_stream::global::print;
 use libcnb::build::{BuildContext, BuildResult};
 use libcnb::data::build_plan::BuildPlanBuilder;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
@@ -13,7 +13,6 @@ use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
 #[cfg(test)]
 use libcnb_test as _;
-use std::io::stderr;
 #[cfg(test)]
 use test_support as _;
 
@@ -40,12 +39,14 @@ impl Buildpack for PnpmEngineBuildpack {
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-        let _logger = Print::new(stderr()).h1(context
-            .buildpack_descriptor
-            .buildpack
-            .name
-            .as_ref()
-            .expect("The buildpack.toml should have a 'name' field set"));
+        print::buildpack(
+            context
+                .buildpack_descriptor
+                .buildpack
+                .name
+                .as_ref()
+                .expect("The buildpack.toml should have a 'name' field set"),
+        );
 
         // This buildpack does not install pnpm yet, suggest using
         // `heroku/nodejs-corepack` instead.

--- a/buildpacks/nodejs-pnpm-engine/tests/snapshots/pnpm_unknown_version.snap
+++ b/buildpacks/nodejs-pnpm-engine/tests/snapshots/pnpm_unknown_version.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Engine
+## Heroku Node.js pnpm Engine
 
 
 

--- a/buildpacks/nodejs-pnpm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-pnpm-install/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack output changes. ([#1093](https://github.com/heroku/buildpacks-nodejs/pull/1093))
+
 ## [3.6.1] - 2025-04-24
 
 ### Changed

--- a/buildpacks/nodejs-pnpm-install/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-install/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-bullet_stream = "0.7"
+bullet_stream = "0.8"
 fun_run = "0.5"
 heroku-nodejs-utils.workspace = true
 indoc = "2"

--- a/buildpacks/nodejs-pnpm-install/src/cmd.rs
+++ b/buildpacks/nodejs-pnpm-install/src/cmd.rs
@@ -1,5 +1,4 @@
 use bullet_stream::global::print;
-use bullet_stream::style;
 use fun_run::{CmdError, CommandWithName};
 use libcnb::Env;
 use std::{path::Path, process::Command};
@@ -16,17 +15,7 @@ pub(crate) fn pnpm_install(pnpm_env: &Env) -> Result<(), CmdError> {
 
 /// Execute `pnpm run` commands like `build`.
 pub(crate) fn pnpm_run(pnpm_env: &Env, script: &str) -> Result<(), CmdError> {
-    print::sub_stream_cmd(
-        Command::new("pnpm")
-            .arg("run")
-            .arg(script)
-            .envs(pnpm_env)
-            .named(format!(
-                "Running {script} script",
-                script = style::value(script)
-            )),
-    )
-    .map(|_| ())
+    print::sub_stream_cmd(Command::new("pnpm").arg("run").arg(script).envs(pnpm_env)).map(|_| ())
 }
 
 /// Execute `pnpm config set store-dir` to set pnpm's addressable store location.

--- a/buildpacks/nodejs-pnpm-install/src/cmd.rs
+++ b/buildpacks/nodejs-pnpm-install/src/cmd.rs
@@ -1,40 +1,32 @@
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::global::print;
+use bullet_stream::style;
 use fun_run::{CmdError, CommandWithName};
 use libcnb::Env;
-use std::io::Stderr;
 use std::{path::Path, process::Command};
 
 /// Execute `pnpm install` to install dependencies for a pnpm project.
-pub(crate) fn pnpm_install(
-    pnpm_env: &Env,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, CmdError> {
-    log.stream_cmd(
+pub(crate) fn pnpm_install(pnpm_env: &Env) -> Result<(), CmdError> {
+    print::sub_stream_cmd(
         Command::new("pnpm")
             .args(["install", "--frozen-lockfile"])
             .envs(pnpm_env),
-    )?;
-    Ok(log)
+    )
+    .map(|_| ())
 }
 
 /// Execute `pnpm run` commands like `build`.
-pub(crate) fn pnpm_run(
-    pnpm_env: &Env,
-    script: &str,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, CmdError> {
-    log.stream_with(
-        format!("Running {script} script", script = style::value(script)),
-        |stdout, stderr| {
-            Command::new("pnpm")
-                .arg("run")
-                .arg(script)
-                .envs(pnpm_env)
-                .stream_output(stdout, stderr)
-        },
-    )?;
-    Ok(log)
+pub(crate) fn pnpm_run(pnpm_env: &Env, script: &str) -> Result<(), CmdError> {
+    print::sub_stream_cmd(
+        Command::new("pnpm")
+            .arg("run")
+            .arg(script)
+            .envs(pnpm_env)
+            .named(format!(
+                "Running {script} script",
+                script = style::value(script)
+            )),
+    )
+    .map(|_| ())
 }
 
 /// Execute `pnpm config set store-dir` to set pnpm's addressable store location.
@@ -62,10 +54,6 @@ pub(crate) fn pnpm_set_virtual_dir(pnpm_env: &Env, location: &Path) -> Result<()
 
 /// Execute `pnpm store prune` to remove unused dependencies from the
 /// content-addressable store.
-pub(crate) fn pnpm_store_prune(
-    pnpm_env: &Env,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, CmdError> {
-    log.stream_cmd(Command::new("pnpm").args(["store", "prune"]).envs(pnpm_env))?;
-    Ok(log)
+pub(crate) fn pnpm_store_prune(pnpm_env: &Env) -> Result<(), CmdError> {
+    print::sub_stream_cmd(Command::new("pnpm").args(["store", "prune"]).envs(pnpm_env)).map(|_| ())
 }

--- a/buildpacks/nodejs-pnpm-install/src/main.rs
+++ b/buildpacks/nodejs-pnpm-install/src/main.rs
@@ -5,7 +5,8 @@
 
 use crate::configure_pnpm_store_directory::configure_pnpm_store_directory;
 use crate::configure_pnpm_virtual_store_directory::configure_pnpm_virtual_store_directory;
-use bullet_stream::{style, Print};
+use bullet_stream::global::print;
+use bullet_stream::style;
 use heroku_nodejs_utils::buildplan::{
     read_node_build_scripts_metadata, NodeBuildScriptsMetadataError,
     NODE_BUILD_SCRIPTS_BUILD_PLAN_NAME,
@@ -21,7 +22,6 @@ use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack, Env};
 #[cfg(test)]
 use libcnb_test as _;
-use std::io::stderr;
 use std::path::PathBuf;
 #[cfg(test)]
 use test_support as _;
@@ -62,12 +62,14 @@ impl Buildpack for PnpmInstallBuildpack {
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-        let mut log = Print::new(stderr()).h1(context
-            .buildpack_descriptor
-            .buildpack
-            .name
-            .as_ref()
-            .expect("The buildpack should have a name"));
+        let buildpack_start = print::buildpack(
+            context
+                .buildpack_descriptor
+                .buildpack
+                .name
+                .as_ref()
+                .expect("The buildpack should have a name"),
+        );
 
         let env = Env::from_current();
         let pkg_json = PackageJson::read(context.app_dir.join("package.json"))
@@ -75,51 +77,42 @@ impl Buildpack for PnpmInstallBuildpack {
         let node_build_scripts_metadata = read_node_build_scripts_metadata(&context.buildpack_plan)
             .map_err(PnpmInstallBuildpackError::NodeBuildScriptsMetadata)?;
 
-        let mut bullet = log.bullet("Setting up pnpm dependency store");
-        bullet = configure_pnpm_store_directory(&context, &env, bullet)?;
-        bullet = configure_pnpm_virtual_store_directory(&context, &env, bullet)?;
-        log = bullet.done();
+        print::bullet("Setting up pnpm dependency store");
+        configure_pnpm_store_directory(&context, &env)?;
+        configure_pnpm_virtual_store_directory(&context, &env)?;
 
-        let mut bullet = log.bullet("Installing dependencies");
-        bullet = cmd::pnpm_install(&env, bullet).map_err(PnpmInstallBuildpackError::PnpmInstall)?;
-        log = bullet.done();
+        print::bullet("Installing dependencies");
+        cmd::pnpm_install(&env).map_err(PnpmInstallBuildpackError::PnpmInstall)?;
 
         let mut metadata = context.store.unwrap_or_default().metadata;
         let cache_use_count = store::read_cache_use_count(&metadata);
         if store::should_prune_cache(cache_use_count) {
-            let mut bullet =
-                log.bullet("Pruning unused dependencies from pnpm content-addressable store");
-            bullet = cmd::pnpm_store_prune(&env, bullet)
-                .map_err(PnpmInstallBuildpackError::PnpmStorePrune)?;
-            log = bullet.done();
+            print::bullet("Pruning unused dependencies from pnpm content-addressable store");
+            cmd::pnpm_store_prune(&env).map_err(PnpmInstallBuildpackError::PnpmStorePrune)?;
         }
         store::set_cache_use_count(&mut metadata, cache_use_count + 1);
 
-        let mut bullet = log.bullet("Running scripts");
+        print::bullet("Running scripts");
         let scripts = pkg_json.build_scripts();
         if scripts.is_empty() {
-            bullet = bullet.sub_bullet("No build scripts found");
+            print::sub_bullet("No build scripts found");
         } else {
             for script in scripts {
                 if let Some(false) = node_build_scripts_metadata.enabled {
-                    bullet = bullet.sub_bullet(format!(
+                    print::sub_bullet(format!(
                         "! Not running {script} as it was disabled by a participating buildpack",
                         script = style::value(&script)
                     ));
                 } else {
-                    bullet = cmd::pnpm_run(&env, &script, bullet)
-                        .map_err(PnpmInstallBuildpackError::BuildScript)?;
+                    cmd::pnpm_run(&env, &script).map_err(PnpmInstallBuildpackError::BuildScript)?;
                 }
             }
         }
-        log = bullet.done();
 
         let mut result_builder = BuildResultBuilder::new().store(Store { metadata });
 
         if context.app_dir.join("Procfile").exists() {
-            log = log
-                .bullet("Skipping default web process (Procfile detected)")
-                .done();
+            print::bullet("Skipping default web process (Procfile detected)");
         } else if pkg_json.has_start_script() {
             result_builder = result_builder.launch(
                 LaunchBuilder::new()
@@ -132,7 +125,7 @@ impl Buildpack for PnpmInstallBuildpack {
             );
         }
 
-        log.done();
+        print::all_done(&Some(buildpack_start));
         result_builder.build()
     }
 

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_7_pnp.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_7_pnp.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=18.0.0 <19.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `18.20.8 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `pnpm@7.32.3` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Creating new pnpm content-addressable store

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_8_hoist.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_8_hoist.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `pnpm@8.4.0` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Creating new pnpm content-addressable store

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_8_nuxt.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_8_nuxt.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `pnpm@8.11.0` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Creating new pnpm content-addressable store
@@ -74,7 +74,7 @@ source: test_support/src/lib.rs
 
   - Done (<time_elapsed>)
 - Running scripts
-  - Running `build` script
+  - Running `pnpm run build`
 
 
       > pnpm-8-nuxt@ build /workspace

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Creating new pnpm content-addressable store

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=20.0.0 <21.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `20.19.1 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.31.0`
 - Found `packageManager` set to `pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Creating new pnpm content-addressable store
@@ -64,7 +64,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=20.0.0 <21.0.0-0`
@@ -73,7 +73,7 @@ source: test_support/src/lib.rs
   - Reusing Node.js 20.19.1 (<arch>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.31.0`
 - Found `packageManager` set to `pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b` in `package.json`
@@ -89,7 +89,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Restoring pnpm content-addressable store from cache

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js pnpm Install
+## Heroku Node.js pnpm Install
 
 - Setting up pnpm dependency store
   - Creating new pnpm content-addressable store

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack output changes. ([#1093](https://github.com/heroku/buildpacks-nodejs/pull/1093))
+
 ## [3.6.1] - 2025-04-24
 
 ### Added 

--- a/buildpacks/nodejs-yarn/Cargo.toml
+++ b/buildpacks/nodejs-yarn/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-bullet_stream = "0.7"
+bullet_stream = "0.8"
 fun_run = "0.5"
 heroku-nodejs-utils.workspace = true
 indoc = "2"

--- a/buildpacks/nodejs-yarn/src/cmd.rs
+++ b/buildpacks/nodejs-yarn/src/cmd.rs
@@ -105,15 +105,5 @@ pub(crate) fn yarn_install(
 
 /// Execute `yarn run` commands like `build`.
 pub(crate) fn yarn_run(yarn_env: &Env, script: &str) -> Result<(), CmdError> {
-    print::sub_stream_cmd(
-        Command::new("yarn")
-            .arg("run")
-            .arg(script)
-            .envs(yarn_env)
-            .named(format!(
-                "Running {script} script",
-                script = style::value(script)
-            )),
-    )
-    .map(|_| ())
+    print::sub_stream_cmd(Command::new("yarn").arg("run").arg(script).envs(yarn_env)).map(|_| ())
 }

--- a/buildpacks/nodejs-yarn/src/cmd.rs
+++ b/buildpacks/nodejs-yarn/src/cmd.rs
@@ -1,6 +1,5 @@
 use crate::yarn::Yarn;
 use bullet_stream::global::print;
-use bullet_stream::style;
 use fun_run::{CmdError, CommandWithName};
 use heroku_nodejs_utils::vrs::{Version, VersionError};
 use libcnb::Env;

--- a/buildpacks/nodejs-yarn/src/cmd.rs
+++ b/buildpacks/nodejs-yarn/src/cmd.rs
@@ -1,10 +1,9 @@
 use crate::yarn::Yarn;
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::global::print;
+use bullet_stream::style;
 use fun_run::{CmdError, CommandWithName};
 use heroku_nodejs_utils::vrs::{Version, VersionError};
 use libcnb::Env;
-use std::io::Stderr;
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -54,8 +53,7 @@ pub(crate) fn yarn_set_cache(
     yarn_line: &Yarn,
     cache_path: &Path,
     env: &Env,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, CmdError> {
+) -> Result<(), CmdError> {
     let cache_path_string = cache_path.to_string_lossy();
     let mut args = vec!["config", "set"];
     if yarn_line == &Yarn::Yarn1 {
@@ -63,8 +61,7 @@ pub(crate) fn yarn_set_cache(
     } else {
         args.append(&mut vec!["cacheFolder", &cache_path_string]);
     }
-    log.stream_cmd(Command::new("yarn").args(args).envs(env))?;
-    Ok(log)
+    print::sub_stream_cmd(Command::new("yarn").args(args).envs(env)).map(|_| ())
 }
 
 /// Execute `yarn config set enableGlobalCache false`. This setting is
@@ -73,20 +70,16 @@ pub(crate) fn yarn_set_cache(
 /// Yarn cache (`$HOME/.yarn/berry/cache` by default), which isn't
 /// persisted into the build cache or the final image. Yarn 2.x and 3.x have
 /// a default value to `false`. Yarn 4.x has a default value of `true`.
-pub(crate) fn yarn_disable_global_cache(
-    yarn_line: &Yarn,
-    env: &Env,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, CmdError> {
+pub(crate) fn yarn_disable_global_cache(yarn_line: &Yarn, env: &Env) -> Result<(), CmdError> {
     if yarn_line == &Yarn::Yarn1 {
-        return Ok(log);
+        return Ok(());
     }
-    log.stream_cmd(
+    print::sub_stream_cmd(
         Command::new("yarn")
             .args(["config", "set", "enableGlobalCache", "false"])
             .envs(env),
-    )?;
-    Ok(log)
+    )
+    .map(|_| ())
 }
 
 /// Execute `yarn install` to install dependencies for a yarn project.
@@ -94,8 +87,7 @@ pub(crate) fn yarn_install(
     yarn_line: &Yarn,
     zero_install: bool,
     yarn_env: &Env,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, CmdError> {
+) -> Result<(), CmdError> {
     let mut args = vec!["install"];
     if yarn_line == &Yarn::Yarn1 {
         args.push("--production=false");
@@ -108,26 +100,20 @@ pub(crate) fn yarn_install(
         }
     }
 
-    log.stream_cmd(Command::new("yarn").args(args).envs(yarn_env))?;
-
-    Ok(log)
+    print::sub_stream_cmd(Command::new("yarn").args(args).envs(yarn_env)).map(|_| ())
 }
 
 /// Execute `yarn run` commands like `build`.
-pub(crate) fn yarn_run(
-    yarn_env: &Env,
-    script: &str,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<Print<SubBullet<Stderr>>, CmdError> {
-    log.stream_with(
-        format!("Running {script} script", script = style::value(script)),
-        |stdout, stderr| {
-            Command::new("yarn")
-                .arg("run")
-                .arg(script)
-                .envs(yarn_env)
-                .stream_output(stdout, stderr)
-        },
-    )?;
-    Ok(log)
+pub(crate) fn yarn_run(yarn_env: &Env, script: &str) -> Result<(), CmdError> {
+    print::sub_stream_cmd(
+        Command::new("yarn")
+            .arg("run")
+            .arg(script)
+            .envs(yarn_env)
+            .named(format!(
+                "Running {script} script",
+                script = style::value(script)
+            )),
+    )
+    .map(|_| ())
 }

--- a/buildpacks/nodejs-yarn/src/install_yarn.rs
+++ b/buildpacks/nodejs-yarn/src/install_yarn.rs
@@ -1,5 +1,4 @@
-use bullet_stream::state::SubBullet;
-use bullet_stream::Print;
+use bullet_stream::global::print;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
@@ -11,7 +10,6 @@ use libherokubuildpack::fs::move_directory_contents;
 use libherokubuildpack::tar::decompress_tarball;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::io::Stderr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
@@ -23,8 +21,7 @@ use crate::{YarnBuildpack, YarnBuildpackError};
 pub(crate) fn install_yarn(
     context: &BuildContext<YarnBuildpack>,
     release: &Release,
-    mut log: Print<SubBullet<Stderr>>,
-) -> Result<(LayerEnv, Print<SubBullet<Stderr>>), libcnb::Error<YarnBuildpackError>> {
+) -> Result<LayerEnv, libcnb::Error<YarnBuildpackError>> {
     let new_metadata = CliLayerMetadata {
         yarn_version: release.version.to_string(),
         layer_version: LAYER_VERSION.to_string(),
@@ -50,22 +47,22 @@ pub(crate) fn install_yarn(
 
     match dist_layer.state {
         LayerState::Restored { .. } => {
-            log = log.sub_bullet(format!("Reusing yarn {}", release.version));
+            print::sub_bullet(format!("Reusing yarn {}", release.version));
         }
         LayerState::Empty { .. } => {
             dist_layer.write_metadata(new_metadata)?;
 
             let yarn_tgz = NamedTempFile::new().map_err(CliLayerError::TempFile)?;
 
-            let timer = log.start_timer(format!("Downloading yarn {}", release.version));
+            let timer = print::sub_start_timer(format!("Downloading yarn {}", release.version));
             download_file(&release.url, yarn_tgz.path()).map_err(CliLayerError::Download)?;
-            log = timer.done();
+            let _ = timer.done();
 
-            log = log.sub_bullet(format!("Extracting yarn {}", release.version));
+            print::sub_bullet(format!("Extracting yarn {}", release.version));
             decompress_tarball(&mut yarn_tgz.into_file(), dist_layer.path())
                 .map_err(|e| CliLayerError::Untar(dist_layer.path(), e))?;
 
-            log = log.sub_bullet(format!("Installing yarn {}", release.version));
+            print::sub_bullet(format!("Installing yarn {}", release.version));
 
             let dist_name = if dist_layer.path().join("package").exists() {
                 "package".to_string()
@@ -84,7 +81,7 @@ pub(crate) fn install_yarn(
         }
     }
 
-    dist_layer.read_env().map(|env| (env, log))
+    dist_layer.read_env()
 }
 
 const LAYER_VERSION: &str = "1";

--- a/buildpacks/nodejs-yarn/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@4.2.2` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 4.2.2 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-yarn/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@4.2.2` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 4.2.2 mode.
 - Setting up yarn dependency cache
@@ -66,7 +66,7 @@ source: test_support/src/lib.rs
 
 --------------------------------------------- REBUILD ---------------------------------------------
 
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -75,7 +75,7 @@ source: test_support/src/lib.rs
   - Reusing Node.js 22.15.0 (<arch>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@4.2.2` in `package.json`
@@ -91,7 +91,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 4.2.2 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-yarn/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@4.2.2` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 4.2.2 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-yarn/tests/snapshots/yarn_1_typescript.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/yarn_1_typescript.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=16.0.0 <17.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `16.20.2 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Detecting yarn CLI version to install
   - No yarn engine range detected in package.json, using default (1.22.x)
@@ -44,7 +44,7 @@ source: test_support/src/lib.rs
 
   - Done (<time_elapsed>)
 - Running scripts
-  - Running `build` script
+  - Running `yarn run build`
 
       yarn run v1.22.22
       $ tsc

--- a/buildpacks/nodejs-yarn/tests/snapshots/yarn_2_modules_nonzero.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/yarn_2_modules_nonzero.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Detecting yarn CLI version to install
   - Detected yarn engine version range >=2.4.0 <2.5.0-0 in package.json

--- a/buildpacks/nodejs-yarn/tests/snapshots/yarn_2_pnp_zero.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/yarn_2_pnp_zero.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@2.4.1` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 2.4.1 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-yarn/tests/snapshots/yarn_3_modules_zero.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/yarn_3_modules_zero.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=18.0.0 <19.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `18.20.8 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@3.2.4` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 3.2.4 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-yarn/tests/snapshots/yarn_3_pnp_nonzero.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/yarn_3_pnp_nonzero.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@3.2.0` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 3.2.0 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-yarn/tests/snapshots/yarn_4_modules_zero.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/yarn_4_modules_zero.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Detected Node.js version range: `>=18.0.0 <19.0.0-0`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `18.20.8 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@4.0.0` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 4.0.0 mode.
 - Setting up yarn dependency cache

--- a/buildpacks/nodejs-yarn/tests/snapshots/yarn_4_pnp_nonzero.snap
+++ b/buildpacks/nodejs-yarn/tests/snapshots/yarn_4_pnp_nonzero.snap
@@ -1,7 +1,7 @@
 ---
 source: test_support/src/lib.rs
 ---
-# Heroku Node.js Engine
+## Heroku Node.js Engine
 
 - Checking Node.js version
   - Node.js version not specified, using `22.x`
@@ -13,7 +13,7 @@ source: test_support/src/lib.rs
   - Installing Node.js `22.15.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Corepack
+## Heroku Node.js Corepack
 
 - Using Corepack version `0.32.0`
 - Found `packageManager` set to `yarn@4.0.0` in `package.json`
@@ -29,7 +29,7 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
-# Heroku Node.js Yarn
+## Heroku Node.js Yarn
 
 - Yarn CLI operating in yarn 4.0.0 mode.
 - Setting up yarn dependency cache


### PR DESCRIPTION
This PR might looks like a lot but the individual commits are logically separated. What's happening here is, all of the state-based output functions from `bullet_stream` have been replaced with their `bullet_stream::global::print` counterparts. This removes a lot of the clutter added to weave the state-based logger throughout each buildpack's codebase. 

The end result is the same build output (which you can see in the snapshots), except for:
- the buildpack headers which are now prefixed with `##` instead of `#` in `bullet_stream@0.8.0`
- the custom command names used for executing pnpm and Yarn build scripts have been dropped in favor of the default command name provided by `fun_run`