### PR TITLE
Heroku-20 Stack End-of-life

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
             | jq -nRc '[inputs] 
                 | map({ dir: ., name: split("/") | last | split("nodejs-") | last } 
                 | [
-                  . + { builder_tag: 20, arch: "amd64" },
                   . + { builder_tag: 22, arch: "amd64" },
                   . + { builder_tag: 24, arch: "amd64" },
                   . + { builder_tag: 24, arch: "arm64" } 
@@ -147,7 +146,6 @@ jobs:
     strategy:
       matrix:
         stack-version:
-          - '20'
           - '22'
         buildpack-dir:
           - buildpacks/npm


### PR DESCRIPTION
As [announced here](https://devcenter.heroku.com/changelog-items/3230), the `heroku-20` stack is no longer supported for builds on Heroku. This PR drops all references for the now end-of-life stack.