### PR TITLE
Pruning dev dependencies with npm

### DIFF
--- a/buildpacks/nodejs-corepack/tests/snapshots/corepack_npm_10.snap
+++ b/buildpacks/nodejs-corepack/tests/snapshots/corepack_npm_10.snap
@@ -36,9 +36,8 @@ source: test_support/src/lib.rs
   - Using npm version `10.2.0`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
 
       added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
 
@@ -47,6 +46,15 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-corepack/tests/snapshots/corepack_npm_8.snap
+++ b/buildpacks/nodejs-corepack/tests/snapshots/corepack_npm_8.snap
@@ -36,9 +36,8 @@ source: test_support/src/lib.rs
   - Using npm version `8.19.4`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
 
       added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
 
@@ -47,6 +46,15 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-engine/tests/snapshots/npm_engine_install.snap
+++ b/buildpacks/nodejs-npm-engine/tests/snapshots/npm_engine_install.snap
@@ -35,9 +35,8 @@ source: test_support/src/lib.rs
   - Using npm version `9.6.6`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
       npm WARN old lockfile 
       npm WARN old lockfile The package-lock.json file was created with an old version of npm,
       npm WARN old lockfile so supplemental metadata must be fetched from the registry.
@@ -52,6 +51,21 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+      npm WARN old lockfile 
+      npm WARN old lockfile The package-lock.json file was created with an old version of npm,
+      npm WARN old lockfile so supplemental metadata must be fetched from the registry.
+      npm WARN old lockfile 
+      npm WARN old lockfile This is a one-time fix-up, please be patient...
+      npm WARN old lockfile 
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-engine/tests/snapshots/test_node_version_change_invalidates_npm_engine_cache.snap
+++ b/buildpacks/nodejs-npm-engine/tests/snapshots/test_node_version_change_invalidates_npm_engine_cache.snap
@@ -35,9 +35,8 @@ source: test_support/src/lib.rs
   - Using npm version `9.6.6`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
       npm WARN old lockfile 
       npm WARN old lockfile The package-lock.json file was created with an old version of npm,
       npm WARN old lockfile so supplemental metadata must be fetched from the registry.
@@ -52,6 +51,21 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+      npm WARN old lockfile 
+      npm WARN old lockfile The package-lock.json file was created with an old version of npm,
+      npm WARN old lockfile so supplemental metadata must be fetched from the registry.
+      npm WARN old lockfile 
+      npm WARN old lockfile This is a one-time fix-up, please be patient...
+      npm WARN old lockfile 
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)
@@ -93,9 +107,8 @@ source: test_support/src/lib.rs
   - Using npm version `9.6.6`
   - Restoring npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
       npm WARN old lockfile 
       npm WARN old lockfile The package-lock.json file was created with an old version of npm,
       npm WARN old lockfile so supplemental metadata must be fetched from the registry.
@@ -110,6 +123,21 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+      npm WARN old lockfile 
+      npm WARN old lockfile The package-lock.json file was created with an old version of npm,
+      npm WARN old lockfile so supplemental metadata must be fetched from the registry.
+      npm WARN old lockfile 
+      npm WARN old lockfile This is a one-time fix-up, please be patient...
+      npm WARN old lockfile 
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-engine/tests/snapshots/test_npm_engine_caching.snap
+++ b/buildpacks/nodejs-npm-engine/tests/snapshots/test_npm_engine_caching.snap
@@ -35,9 +35,8 @@ source: test_support/src/lib.rs
   - Using npm version `9.6.6`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
       npm WARN old lockfile 
       npm WARN old lockfile The package-lock.json file was created with an old version of npm,
       npm WARN old lockfile so supplemental metadata must be fetched from the registry.
@@ -52,6 +51,21 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+      npm WARN old lockfile 
+      npm WARN old lockfile The package-lock.json file was created with an old version of npm,
+      npm WARN old lockfile so supplemental metadata must be fetched from the registry.
+      npm WARN old lockfile 
+      npm WARN old lockfile This is a one-time fix-up, please be patient...
+      npm WARN old lockfile 
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)
@@ -85,9 +99,8 @@ source: test_support/src/lib.rs
   - Using npm version `9.6.6`
   - Restoring npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
       npm WARN old lockfile 
       npm WARN old lockfile The package-lock.json file was created with an old version of npm,
       npm WARN old lockfile so supplemental metadata must be fetched from the registry.
@@ -102,6 +115,21 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+      npm WARN old lockfile 
+      npm WARN old lockfile The package-lock.json file was created with an old version of npm,
+      npm WARN old lockfile so supplemental metadata must be fetched from the registry.
+      npm WARN old lockfile 
+      npm WARN old lockfile This is a one-time fix-up, please be patient...
+      npm WARN old lockfile 
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-engine/tests/snapshots/test_npm_version_change_invalidates_npm_engine_cache.snap
+++ b/buildpacks/nodejs-npm-engine/tests/snapshots/test_npm_version_change_invalidates_npm_engine_cache.snap
@@ -35,9 +35,8 @@ source: test_support/src/lib.rs
   - Using npm version `9.6.6`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
       npm WARN old lockfile 
       npm WARN old lockfile The package-lock.json file was created with an old version of npm,
       npm WARN old lockfile so supplemental metadata must be fetched from the registry.
@@ -52,6 +51,21 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+      npm WARN old lockfile 
+      npm WARN old lockfile The package-lock.json file was created with an old version of npm,
+      npm WARN old lockfile so supplemental metadata must be fetched from the registry.
+      npm WARN old lockfile 
+      npm WARN old lockfile This is a one-time fix-up, please be patient...
+      npm WARN old lockfile 
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)
@@ -89,9 +103,8 @@ source: test_support/src/lib.rs
   - Using npm version `9.6.5`
   - Restoring npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm WARN config production Use `--omit=dev` instead.
       npm WARN old lockfile 
       npm WARN old lockfile The package-lock.json file was created with an old version of npm,
       npm WARN old lockfile so supplemental metadata must be fetched from the registry.
@@ -106,6 +119,21 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+      npm WARN old lockfile 
+      npm WARN old lockfile The package-lock.json file was created with an old version of npm,
+      npm WARN old lockfile so supplemental metadata must be fetched from the registry.
+      npm WARN old lockfile 
+      npm WARN old lockfile This is a one-time fix-up, please be patient...
+      npm WARN old lockfile 
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-install/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-install/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- This buildpack now prunes npm dev dependencies at the end of its build to reduce the final image size. ([#1126](https://github.com/heroku/buildpacks-nodejs/pull/1126))
+
 ## [3.6.8] - 2025-06-19
 
 - No changes.

--- a/buildpacks/nodejs-npm-install/src/npm.rs
+++ b/buildpacks/nodejs-npm-install/src/npm.rs
@@ -93,3 +93,23 @@ impl<'a> From<RunScript<'a>> for Command {
         cmd
     }
 }
+
+pub(crate) struct Prune<'a> {
+    pub(crate) env: &'a Env,
+}
+
+impl Prune<'_> {
+    pub(crate) fn into_command(self) -> Command {
+        self.into()
+    }
+}
+
+impl<'a> From<Prune<'a>> for Command {
+    fn from(value: Prune<'a>) -> Self {
+        let mut cmd = Command::new("npm");
+        cmd.arg("prune");
+        cmd.arg("--production");
+        cmd.envs(value.env);
+        cmd
+    }
+}

--- a/buildpacks/nodejs-npm-install/src/npm.rs
+++ b/buildpacks/nodejs-npm-install/src/npm.rs
@@ -68,7 +68,6 @@ impl<'a> From<Install<'a>> for Command {
     fn from(value: Install<'a>) -> Self {
         let mut cmd = Command::new("npm");
         cmd.arg("ci");
-        cmd.arg("--production=false");
         cmd.envs(value.env);
         cmd
     }
@@ -108,7 +107,7 @@ impl<'a> From<Prune<'a>> for Command {
     fn from(value: Prune<'a>) -> Self {
         let mut cmd = Command::new("npm");
         cmd.arg("prune");
-        cmd.arg("--production");
+        cmd.env("NODE_ENV", "production");
         cmd.envs(value.env);
         cmd
     }

--- a/buildpacks/nodejs-npm-install/src/snapshots/errors___npm_install_node_build_scripts_metadata_error_for_invalid_enabled_value.snap
+++ b/buildpacks/nodejs-npm-install/src/snapshots/errors___npm_install_node_build_scripts_metadata_error_for_invalid_enabled_value.snap
@@ -1,0 +1,17 @@
+---
+source: buildpacks/nodejs-npm-install/src/errors.rs
+---
+! Invalid build plan metadata
+!
+! A participating buildpack has set invalid `[requires.metadata]` for the build plan named `node_build_scripts`.
+!
+! Expected metadata format:
+! [requires.metadata]
+! enabled = <bool>
+! skip_pruning = <bool>
+!
+! But configured with:
+! enabled = "test" <string>
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-nodejs/issues

--- a/buildpacks/nodejs-npm-install/src/snapshots/errors___npm_install_node_build_scripts_metadata_error_for_invalid_skip_pruning_value.snap
+++ b/buildpacks/nodejs-npm-install/src/snapshots/errors___npm_install_node_build_scripts_metadata_error_for_invalid_skip_pruning_value.snap
@@ -8,10 +8,10 @@ source: buildpacks/nodejs-npm-install/src/errors.rs
 ! Expected metadata format:
 ! [requires.metadata]
 ! enabled = <bool>
+! skip_pruning = <bool>
 !
-! But was:
-! [requires.metadata]
-! enabled = <string>
+! But configured with:
+! skip_pruning = "test" <string>
 !
 ! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
 ! https://github.com/heroku/buildpacks-nodejs/issues

--- a/buildpacks/nodejs-npm-install/src/snapshots/errors___npm_install_prune_dev_dependencies_error.snap
+++ b/buildpacks/nodejs-npm-install/src/snapshots/errors___npm_install_prune_dev_dependencies_error.snap
@@ -1,0 +1,17 @@
+---
+source: buildpacks/nodejs-npm-install/src/errors.rs
+---
+- Debug Info:
+  - Command failed `npm prune --production`
+    exit status: 1
+    stdout: <empty>
+    stderr: <empty>
+
+! Failed to install Node modules
+!
+! The Heroku Node.js npm Install buildpack uses the command `npm prune --production` to prune your Node modules for the production environment. This command failed and the buildpack cannot continue. See the log output above for more information.
+!
+! Suggestions:
+! - Ensure that this command runs locally without error (exit status = 0).
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/buildpacks/nodejs-npm-install/tests/fixtures/npm-project/package-lock.json
+++ b/buildpacks/nodejs-npm-install/tests/fixtures/npm-project/package-lock.json
@@ -1,32 +1,74 @@
 {
   "name": "npm-project",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
+  "packages": {
+    "": {
+      "name": "npm-project",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1"
+      },
+      "devDependencies": {
+        "dotenv": "^16.5.0"
+      },
+      "engines": {
+        "node": "^23.0"
       }
     },
-    "tr46": {
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
-    "webidl-conversions": {
+    "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
-    "whatwg-url": {
+    "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }

--- a/buildpacks/nodejs-npm-install/tests/fixtures/npm-project/package.json
+++ b/buildpacks/nodejs-npm-install/tests/fixtures/npm-project/package.json
@@ -3,10 +3,13 @@
   "version": "1.0.0",
   "license": "MIT",
   "engines": {
-    "node": "^14.0"
+    "node": "^22.0"
   },
   "dependencies": {
     "node-fetch": "^2.6.1"
+  },
+  "devDependencies": {
+    "dotenv": "^16.5.0"
   },
   "scripts": {}
 }

--- a/buildpacks/nodejs-npm-install/tests/integration_test.rs
+++ b/buildpacks/nodejs-npm-install/tests/integration_test.rs
@@ -42,14 +42,15 @@ fn test_npm_install_new_package() {
 
         let mut config = ctx.config.clone();
         config.app_dir_preprocessor(|app_dir| {
-            add_package_json_dependency(&app_dir, "dotenv", "16.3.1");
+            add_package_json_dependency(&app_dir, "environment", "1.1.0");
             add_lockfile_entry(
                 &app_dir,
-                "dotenv",
+                "environment",
                 json!({
-                    "version": "16.3.1",
-                    "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-                    "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+                    "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+                    "license": "MIT"
                 })
             );
         });
@@ -223,7 +224,7 @@ fn test_default_web_process_registration_is_skipped_if_procfile_exists() {
 
 fn add_lockfile_entry(app_dir: &Path, package_name: &str, lockfile_entry: serde_json::Value) {
     update_json_file(&app_dir.join("package-lock.json"), |json| {
-        let dependencies = json["dependencies"].as_object_mut().unwrap();
-        dependencies.insert(package_name.to_string(), lockfile_entry);
+        let packages = json["packages"].as_object_mut().unwrap();
+        packages.insert(format!("node_modules/{package_name}"), lockfile_entry);
     });
 }

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
@@ -5,13 +5,13 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.17.0/node-v22.17.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `22.16.0 (<arch>)`
-  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.17.0 (<arch>)`
+  - Installing Node.js `22.17.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
@@ -4,29 +4,41 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v14.21.3/node-v14.21.3-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `14.21.3 (<arch>)`
-  - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.16.0 (<arch>)`
+  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (Procfile detected)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
@@ -20,9 +20,8 @@ source: test_support/src/lib.rs
   - Using npm version `10.8.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm warn config production Use `--omit=dev` instead.
 
       > dtrace-provider@0.8.8 install
       > node-gyp rebuild || node suppress-error.js
@@ -36,6 +35,15 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)
@@ -57,9 +65,8 @@ source: test_support/src/lib.rs
   - Using npm version `10.8.2`
   - Restoring npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      npm warn config production Use `--omit=dev` instead.
 
       > dtrace-provider@0.8.8 install
       > node-gyp rebuild || node suppress-error.js
@@ -73,6 +80,15 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts.snap
@@ -5,13 +5,13 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.17.0/node-v22.17.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `22.16.0 (<arch>)`
-  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.17.0 (<arch>)`
+  - Installing Node.js `22.17.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts.snap
@@ -4,32 +4,35 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v14.21.3/node-v14.21.3-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `14.21.3 (<arch>)`
-  - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.16.0 (<arch>)`
+  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - Running `npm run heroku-prebuild`
 
 
-      > npm-project@1.0.0 heroku-prebuild /workspace
+      > npm-project@1.0.0 heroku-prebuild
       > echo 'executed heroku-prebuild'
 
       executed heroku-prebuild
@@ -38,7 +41,7 @@ source: test_support/src/lib.rs
   - Running `npm run build`
 
 
-      > npm-project@1.0.0 build /workspace
+      > npm-project@1.0.0 build
       > echo 'executed build'
 
       executed build
@@ -47,10 +50,19 @@ source: test_support/src/lib.rs
   - Running `npm run heroku-postbuild`
 
 
-      > npm-project@1.0.0 heroku-postbuild /workspace
+      > npm-project@1.0.0 heroku-postbuild
       > echo 'executed heroku-postbuild'
 
       executed heroku-postbuild
+
+  - Done (<time_elapsed>)
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Configuring default processes

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts_prefers_heroku_build_over_build.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts_prefers_heroku_build_over_build.snap
@@ -4,35 +4,47 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v14.21.3/node-v14.21.3-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `14.21.3 (<arch>)`
-  - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.16.0 (<arch>)`
+  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - Running `npm run heroku-build`
 
 
-      > npm-project@1.0.0 heroku-build /workspace
+      > npm-project@1.0.0 heroku-build
       > echo 'executed heroku-build'
 
       executed heroku-build
+
+  - Done (<time_elapsed>)
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Configuring default processes

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts_prefers_heroku_build_over_build.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_build_scripts_prefers_heroku_build_over_build.snap
@@ -5,13 +5,13 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.17.0/node-v22.17.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `22.16.0 (<arch>)`
-  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.17.0 (<arch>)`
+  - Installing Node.js `22.17.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_caching.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_caching.snap
@@ -5,13 +5,13 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.17.0/node-v22.17.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `22.16.0 (<arch>)`
-  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.17.0 (<arch>)`
+  - Installing Node.js `22.17.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
@@ -49,9 +49,9 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - Reusing Node.js 22.16.0 (<arch>)
+  - Reusing Node.js 22.17.0 (<arch>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_caching.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_caching.snap
@@ -4,29 +4,41 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v14.21.3/node-v14.21.3-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `14.21.3 (<arch>)`
-  - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.16.0 (<arch>)`
+  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)
@@ -36,25 +48,37 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - Reusing Node.js 14.21.3 (<arch>)
+  - Reusing Node.js 22.16.0 (<arch>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Restoring npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_new_package.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_new_package.snap
@@ -5,13 +5,13 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.17.0/node-v22.17.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `22.16.0 (<arch>)`
-  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.17.0 (<arch>)`
+  - Installing Node.js `22.17.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
@@ -49,9 +49,9 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - Reusing Node.js 22.16.0 (<arch>)
+  - Reusing Node.js 22.17.0 (<arch>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_new_package.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_new_package.snap
@@ -4,29 +4,41 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v14.21.3/node-v14.21.3-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `14.21.3 (<arch>)`
-  - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.16.0 (<arch>)`
+  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)
@@ -36,25 +48,37 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - Reusing Node.js 14.21.3 (<arch>)
+  - Reusing Node.js 22.16.0 (<arch>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Restoring npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_with_lockfile.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_with_lockfile.snap
@@ -5,13 +5,13 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.17.0/node-v22.17.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `22.16.0 (<arch>)`
-  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.17.0 (<arch>)`
+  - Installing Node.js `22.17.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_with_lockfile.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_install_with_lockfile.snap
@@ -4,29 +4,41 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v14.21.3/node-v14.21.3-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `14.21.3 (<arch>)`
-  - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.16.0 (<arch>)`
+  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_start_script_creates_a_web_process_launcher.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_start_script_creates_a_web_process_launcher.snap
@@ -5,13 +5,13 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.17.0/node-v22.17.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `22.16.0 (<arch>)`
-  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.17.0 (<arch>)`
+  - Installing Node.js `22.17.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_start_script_creates_a_web_process_launcher.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_npm_start_script_creates_a_web_process_launcher.snap
@@ -4,29 +4,41 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v14.21.3/node-v14.21.3-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `14.21.3 (<arch>)`
-  - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.16.0 (<arch>)`
+  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `npm prune`
+
+
+      up to date, audited <N> packages in <time_elapsed>
+
+      found 0 vulnerabilities
+
+  - Done (<time_elapsed>)
 - Configuring default processes
   - Adding default web process for `npm start`
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
@@ -5,13 +5,13 @@ source: test_support/src/lib.rs
 
 - Checking Node.js version
   - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
-  - Resolved Node.js version: `22.16.0`
+  - Resolved Node.js version: `22.17.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.17.0/node-v22.17.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `22.16.0 (<arch>)`
-  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.17.0 (<arch>)`
+  - Installing Node.js `22.17.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install

--- a/buildpacks/nodejs-npm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
+++ b/buildpacks/nodejs-npm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
@@ -4,31 +4,36 @@ source: test_support/src/lib.rs
 ## Heroku Node.js Engine
 
 - Checking Node.js version
-  - Detected Node.js version range: `>=14.0.0 <15.0.0-0`
-  - Resolved Node.js version: `14.21.3`
+  - Detected Node.js version range: `>=22.0.0 <23.0.0-0`
+  - Resolved Node.js version: `22.16.0`
 - Installing Node.js distribution
-  - GET https://nodejs.org/download/release/v14.21.3/node-v14.21.3-<arch>.tar.gz ... (OK)
+  - GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-<arch>.tar.gz ... (OK)
   - Downloading ... (<time_elapsed>)
   - Verifying checksum
-  - Extracting Node.js `14.21.3 (<arch>)`
-  - Installing Node.js `14.21.3 (<arch>)` ... (<time_elapsed>)
+  - Extracting Node.js `22.16.0 (<arch>)`
+  - Installing Node.js `22.16.0 (<arch>)` ... (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 ## Heroku Node.js npm Install
 
 - Installing node modules
-  - Using npm version `6.14.18`
+  - Using npm version `10.9.2`
   - Creating npm cache
   - Configuring npm cache directory
-  - Running `npm ci "--production=false"`
+  - Running `npm ci`
 
-      added <NUMBER> packages in <time_elapsed>
+
+      added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>
+
+      found 0 vulnerabilities
 
   - Done (<time_elapsed>)
 - Running scripts
   - Not running `heroku-prebuild` as it was disabled by a participating buildpack
   - Not running `build` as it was disabled by a participating buildpack
   - Not running `heroku-postbuild` as it was disabled by a participating buildpack
+- Pruning dev dependencies
+  - Skipping as pruning was disabled by a participating buildpack
 - Configuring default processes
   - Skipping default web process (no start script defined)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_node_build_scripts_metadata_error_for_invalid_enabled_value.snap
+++ b/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_node_build_scripts_metadata_error_for_invalid_enabled_value.snap
@@ -1,0 +1,17 @@
+---
+source: buildpacks/nodejs-pnpm-install/src/errors.rs
+---
+! Invalid build plan metadata
+!
+! A participating buildpack has set invalid `[requires.metadata]` for the build plan named `node_build_scripts`.
+!
+! Expected metadata format:
+! [requires.metadata]
+! enabled = <bool>
+! skip_pruning = <bool>
+!
+! But configured with:
+! enabled = "test" <string>
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-nodejs/issues

--- a/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_node_build_scripts_metadata_error_for_invalid_skip_pruning_value.snap
+++ b/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_node_build_scripts_metadata_error_for_invalid_skip_pruning_value.snap
@@ -8,10 +8,10 @@ source: buildpacks/nodejs-pnpm-install/src/errors.rs
 ! Expected metadata format:
 ! [requires.metadata]
 ! enabled = <bool>
+! skip_pruning = <bool>
 !
-! But was:
-! [requires.metadata]
-! enabled = <string>
+! But configured with:
+! skip_pruning = "test" <string>
 !
 ! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
 ! https://github.com/heroku/buildpacks-nodejs/issues

--- a/buildpacks/nodejs-yarn/src/errors.rs
+++ b/buildpacks/nodejs-yarn/src/errors.rs
@@ -273,29 +273,44 @@ fn on_yarn_default_parse_error(error: &VersionError) -> ErrorMessage {
 }
 
 fn on_node_build_scripts_metadata_error(error: NodeBuildScriptsMetadataError) -> ErrorMessage {
-    let NodeBuildScriptsMetadataError::InvalidEnabledValue(value) = error;
-    let value_type = value.type_str();
     let requires_metadata = style::value("[requires.metadata]");
     let buildplan_name = style::value(NODE_BUILD_SCRIPTS_BUILD_PLAN_NAME);
-    error_message()
-        .error_type(ErrorType::UserFacing(
-            SuggestRetryBuild::No,
-            SuggestSubmitIssue::Yes,
-        ))
-        .header("Invalid build plan metadata")
-        .body(formatdoc! {"
-            A participating buildpack has set invalid {requires_metadata} for the \
-            build plan named {buildplan_name}.
 
-            Expected metadata format:
-            [requires.metadata]
-            enabled = <bool>
+    match error {
+        NodeBuildScriptsMetadataError::InvalidEnabledValue(value) => error_message()
+            .error_type(UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::Yes))
+            .header("Invalid build plan metadata")
+            .body(formatdoc! { "
+                A participating buildpack has set invalid {requires_metadata} for the build plan \
+                named {buildplan_name}.
+                
+                Expected metadata format:
+                [requires.metadata]
+                enabled = <bool>
+                skip_pruning = <bool>
+                
+                But configured with:
+                enabled = {value} <{value_type}>     
+            ", value_type = value.type_str() })
+            .create(),
 
-            But was:
-            [requires.metadata]
-            enabled = <{value_type}>
-        "})
-        .create()
+        NodeBuildScriptsMetadataError::InvalidSkipPruningValue(value) => error_message()
+            .error_type(UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::Yes))
+            .header("Invalid build plan metadata")
+            .body(formatdoc! { "
+                A participating buildpack has set invalid {requires_metadata} for the build plan \
+                named {buildplan_name}.
+                
+                Expected metadata format:
+                [requires.metadata]
+                enabled = <bool>
+                skip_pruning = <bool>
+                
+                But configured with:
+                skip_pruning = {value} <{value_type}>     
+            ", value_type = value.type_str() })
+            .create(),
+    }
 }
 
 fn on_fetch_yarn_packument_error(error: &PackumentLayerError) -> ErrorMessage {
@@ -457,10 +472,19 @@ mod tests {
     }
 
     #[test]
-    fn test_yarn_node_build_scripts_metadata_error() {
+    fn test_yarn_node_build_scripts_metadata_error_for_invalid_enabled_value() {
         assert_error_snapshot(YarnBuildpackError::NodeBuildScriptsMetadata(
-            NodeBuildScriptsMetadataError::InvalidEnabledValue(toml::Value::String(
-                "not a boolean".into(),
+            NodeBuildScriptsMetadataError::InvalidEnabledValue(toml::value::Value::String(
+                "test".to_string(),
+            )),
+        ));
+    }
+
+    #[test]
+    fn test_yarn_node_build_scripts_metadata_error_for_invalid_skip_pruning_value() {
+        assert_error_snapshot(YarnBuildpackError::NodeBuildScriptsMetadata(
+            NodeBuildScriptsMetadataError::InvalidSkipPruningValue(toml::value::Value::String(
+                "test".to_string(),
             )),
         ));
     }

--- a/buildpacks/nodejs-yarn/src/snapshots/errors___yarn_node_build_scripts_metadata_error_for_invalid_enabled_value.snap
+++ b/buildpacks/nodejs-yarn/src/snapshots/errors___yarn_node_build_scripts_metadata_error_for_invalid_enabled_value.snap
@@ -1,0 +1,17 @@
+---
+source: buildpacks/nodejs-yarn/src/errors.rs
+---
+! Invalid build plan metadata
+!
+! A participating buildpack has set invalid `[requires.metadata]` for the build plan named `node_build_scripts`.
+!
+! Expected metadata format:
+! [requires.metadata]
+! enabled = <bool>
+! skip_pruning = <bool>
+!
+! But configured with:
+! enabled = "test" <string>
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-nodejs/issues

--- a/buildpacks/nodejs-yarn/src/snapshots/errors___yarn_node_build_scripts_metadata_error_for_invalid_skip_pruning_value.snap
+++ b/buildpacks/nodejs-yarn/src/snapshots/errors___yarn_node_build_scripts_metadata_error_for_invalid_skip_pruning_value.snap
@@ -8,10 +8,10 @@ source: buildpacks/nodejs-yarn/src/errors.rs
 ! Expected metadata format:
 ! [requires.metadata]
 ! enabled = <bool>
+! skip_pruning = <bool>
 !
-! But was:
-! [requires.metadata]
-! enabled = <string>
+! But configured with:
+! skip_pruning = "test" <string>
 !
 ! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
 ! https://github.com/heroku/buildpacks-nodejs/issues

--- a/common/nodejs-utils/src/buildplan.rs
+++ b/common/nodejs-utils/src/buildplan.rs
@@ -3,10 +3,12 @@ use libcnb_data::buildpack_plan::BuildpackPlan;
 #[derive(Debug, Default, PartialEq)]
 pub struct NodeBuildScriptsMetadata {
     pub enabled: Option<bool>,
+    pub skip_pruning: Option<bool>,
 }
 
 pub const NODE_BUILD_SCRIPTS_BUILD_PLAN_NAME: &str = "node_build_scripts";
 const NODE_BUILD_SCRIPTS_METADATA_ENABLED_KEY: &str = "enabled";
+const NODE_BUILD_SCRIPTS_METADATA_SKIP_PRUNING_KEY: &str = "skip_pruning";
 
 pub fn read_node_build_scripts_metadata(
     buildpack_plan: &BuildpackPlan,
@@ -29,6 +31,27 @@ pub fn read_node_build_scripts_metadata(
                     }
                     None => {}
                 }
+                match entry
+                    .metadata
+                    .get(NODE_BUILD_SCRIPTS_METADATA_SKIP_PRUNING_KEY)
+                {
+                    Some(toml::Value::Boolean(enabled)) => {
+                        node_build_hooks_metadata.skip_pruning = Some(*enabled);
+                    }
+                    Some(value) => {
+                        Err(NodeBuildScriptsMetadataError::InvalidSkipPruningValue(
+                            value.clone(),
+                        ))?;
+                    }
+                    None => {
+                        // As the front-end buildpacks are the only ones that are likely to
+                        // using the buildplan metadata, if the build scripts are disabled,
+                        // there's a good chance that we need to also skip pruning.
+                        if node_build_hooks_metadata.enabled == Some(false) {
+                            node_build_hooks_metadata.skip_pruning = Some(true);
+                        }
+                    }
+                }
                 Ok(node_build_hooks_metadata)
             },
         )
@@ -37,6 +60,7 @@ pub fn read_node_build_scripts_metadata(
 #[derive(Debug)]
 pub enum NodeBuildScriptsMetadataError {
     InvalidEnabledValue(toml::Value),
+    InvalidSkipPruningValue(toml::Value),
 }
 
 #[cfg(test)]
@@ -81,7 +105,8 @@ mod test {
         assert_eq!(
             read_node_build_scripts_metadata(&buildpack_plan).unwrap(),
             NodeBuildScriptsMetadata {
-                enabled: Some(false)
+                enabled: Some(false),
+                skip_pruning: None
             }
         );
     }
@@ -111,7 +136,8 @@ mod test {
         assert_eq!(
             read_node_build_scripts_metadata(&buildpack_plan).unwrap(),
             NodeBuildScriptsMetadata {
-                enabled: Some(true)
+                enabled: Some(true),
+                skip_pruning: None
             }
         );
     }
@@ -128,6 +154,9 @@ mod test {
         };
         match read_node_build_scripts_metadata(&buildpack_plan).unwrap_err() {
             NodeBuildScriptsMetadataError::InvalidEnabledValue(_) => {}
+            e @ NodeBuildScriptsMetadataError::InvalidSkipPruningValue(_) => {
+                panic!("Unexpected error: {e:?}")
+            }
         }
     }
 }

--- a/common/nodejs-utils/src/buildplan.rs
+++ b/common/nodejs-utils/src/buildplan.rs
@@ -49,6 +49,8 @@ pub fn read_node_build_scripts_metadata(
                         // there's a good chance that we need to also skip pruning.
                         if node_build_hooks_metadata.enabled == Some(false) {
                             node_build_hooks_metadata.skip_pruning = Some(true);
+                        } else {
+                            node_build_hooks_metadata.skip_pruning = None;
                         }
                     }
                 }
@@ -99,6 +101,7 @@ mod test {
                 name: NODE_BUILD_SCRIPTS_BUILD_PLAN_NAME.to_string(),
                 metadata: toml! {
                     enabled = false
+                    skip_pruning = false
                 },
             }],
         };
@@ -106,7 +109,7 @@ mod test {
             read_node_build_scripts_metadata(&buildpack_plan).unwrap(),
             NodeBuildScriptsMetadata {
                 enabled: Some(false),
-                skip_pruning: None
+                skip_pruning: Some(false)
             }
         );
     }
@@ -143,7 +146,7 @@ mod test {
     }
 
     #[test]
-    fn read_node_build_scripts_when_entry_contains_invalid_metadata() {
+    fn read_node_build_scripts_when_entry_contains_invalid_metadata_for_enabled() {
         let buildpack_plan = BuildpackPlan {
             entries: vec![Entry {
                 name: NODE_BUILD_SCRIPTS_BUILD_PLAN_NAME.to_string(),
@@ -155,6 +158,25 @@ mod test {
         match read_node_build_scripts_metadata(&buildpack_plan).unwrap_err() {
             NodeBuildScriptsMetadataError::InvalidEnabledValue(_) => {}
             e @ NodeBuildScriptsMetadataError::InvalidSkipPruningValue(_) => {
+                panic!("Unexpected error: {e:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn read_node_build_scripts_when_entry_contains_invalid_metadata_for_skip_pruning() {
+        let buildpack_plan = BuildpackPlan {
+            entries: vec![Entry {
+                name: NODE_BUILD_SCRIPTS_BUILD_PLAN_NAME.to_string(),
+                metadata: toml! {
+                    enabled = false
+                    skip_pruning = 0
+                },
+            }],
+        };
+        match read_node_build_scripts_metadata(&buildpack_plan).unwrap_err() {
+            NodeBuildScriptsMetadataError::InvalidSkipPruningValue(_) => {}
+            e @ NodeBuildScriptsMetadataError::InvalidEnabledValue(_) => {
                 panic!("Unexpected error: {e:?}")
             }
         }

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -97,6 +97,8 @@ pub fn integration_test_with_config(
     //       prevent from being emitted in test scenarios. By setting the following
     //       environment variable, we can suppress this message in both npm & pnpm.
     build_config.env("npm_config_update_notifier", "false");
+    // similar for the message looking for funding which doesn't need to appear in testing scenarios
+    build_config.env("npm_config_fund", "false");
 
     with_config(&mut build_config);
 

--- a/test_support/src/snapshot_filters.rs
+++ b/test_support/src/snapshot_filters.rs
@@ -135,8 +135,9 @@ pub(super) fn create_snapshot_filters() -> Vec<(String, String)> {
 
     // [npm] Up to date messaging from `npm prune` command. e.g.;
     // - up to date, audited 6 packages in 817ms
+    // - up to date, audited 5 packages in 1s
     filters.push((
-        r"up to date, audited \d+ packages in \d+ms",
+        r"up to date, audited \d+ packages in \d+m?s",
         "up to date, audited <N> packages in <time_elapsed>",
     ));
 

--- a/test_support/src/snapshot_filters.rs
+++ b/test_support/src/snapshot_filters.rs
@@ -38,8 +38,9 @@ pub(super) fn create_snapshot_filters() -> Vec<(String, String)> {
 
     // [Yarn] Post `yarn install` timer output when warnings are present. e.g.;
     // - Done with warnings in 30s 9ms
+    // - Done with warnings in 2s
     filters.push((
-        r"Done with warnings in \d+s \d+ms",
+        r"Done with warnings in \d+s(?: \d+ms)?",
         "Done with warnings in <time_elapsed>",
     ));
 

--- a/test_support/src/snapshot_filters.rs
+++ b/test_support/src/snapshot_filters.rs
@@ -133,6 +133,13 @@ pub(super) fn create_snapshot_filters() -> Vec<(String, String)> {
         "added <NUMBER> packages, and audited <NUMBER> packages in <time_elapsed>",
     ));
 
+    // [npm] Up to date messaging from `npm prune` command. e.g.;
+    // - up to date, audited 6 packages in 817ms
+    filters.push((
+        r"up to date, audited \d+ packages in \d+ms",
+        "up to date, audited <N> packages in <time_elapsed>",
+    ));
+
     // [npm] Native module compilation output from node-gyp. e.g.;
     // -     gyp info it worked if it ends with ok
     //       gyp info using node-gyp@10.1.0


### PR DESCRIPTION
This PR adds functionality to the `heroku/nodejs-npm-install` buildpack to prune dev dependencies at the end of it's build. This will ensure that only production dependencies are stored in the exported image, reducing the overall image size.

Accommodations have also been made for the [frontend-web](https://github.com/heroku/buildpacks-frontend-web) buildpacks which rely on dev dependencies not being pruned. As these buildpacks leverage buildplan metadata to opt-out of build lifecycle tasks, I've chosen to piggyback on this mechanism to provide a similar opt-out for pruning. 