### PR TITLE
Pruning dev dependencies with pnpm

### DIFF
--- a/buildpacks/nodejs-pnpm-install/Cargo.toml
+++ b/buildpacks/nodejs-pnpm-install/Cargo.toml
@@ -13,6 +13,7 @@ heroku-nodejs-utils.workspace = true
 indoc = "2"
 libcnb = { version = "=0.29.0", features = ["trace"] }
 serde = "1"
+serde_json = "1"
 toml = "0.8"
 
 [dev-dependencies]

--- a/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_pnpm_version_command_error.snap
+++ b/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_pnpm_version_command_error.snap
@@ -1,0 +1,17 @@
+---
+source: buildpacks/nodejs-pnpm-install/src/errors.rs
+---
+- Debug Info:
+  - Command failed `pnpm --version`
+    exit status: 1
+    stdout: <empty>
+    stderr: <empty>
+
+! Failed to determine pnpm version
+!
+! An unexpected error occurred while attempting to determine the current pnpm version from the system.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-nodejs/issues
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_pnpm_version_parse_error.snap
+++ b/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_pnpm_version_parse_error.snap
@@ -1,0 +1,14 @@
+---
+source: buildpacks/nodejs-pnpm-install/src/errors.rs
+---
+- Debug Info:
+  - Failed to parse version.
+
+! Failed to parse pnpm version
+!
+! An unexpected error occurred while parsing pnpm version information from 'not.a.version'.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-nodejs/issues
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_prune_dev_dependencies_error.snap
+++ b/buildpacks/nodejs-pnpm-install/src/snapshots/errors___pnpm_install_prune_dev_dependencies_error.snap
@@ -1,0 +1,17 @@
+---
+source: buildpacks/nodejs-pnpm-install/src/errors.rs
+---
+- Debug Info:
+  - Command failed `pnpm prune --prod --ignore-scripts`
+    exit status: 1
+    stdout: <empty>
+    stderr: <empty>
+
+! Failed to install Node modules
+!
+! The Heroku Node.js pnpm Install buildpack uses the command `pnpm prune --prod --ignore-scripts` to prune your Node modules for the production environment. This command failed and the buildpack cannot continue. See the log output above for more information.
+!
+! Suggestions:
+! - Ensure that this command runs locally without error (exit status = 0).
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/buildpacks/nodejs-pnpm-install/tests/fixtures/pnpm-9/package.json
+++ b/buildpacks/nodejs-pnpm-install/tests/fixtures/pnpm-9/package.json
@@ -5,5 +5,8 @@
   "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b",
   "dependencies": {
     "dotenv": "16.4.5"
+  },
+  "devDependencies": {
+    "environment": "^1.1.0"
   }
 }

--- a/buildpacks/nodejs-pnpm-install/tests/fixtures/pnpm-9/pnpm-lock.yaml
+++ b/buildpacks/nodejs-pnpm-install/tests/fixtures/pnpm-9/pnpm-lock.yaml
@@ -11,6 +11,10 @@ importers:
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
+    devDependencies:
+      environment:
+        specifier: ^1.1.0
+        version: 1.1.0
 
 packages:
 
@@ -18,6 +22,12 @@ packages:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
 snapshots:
 
   dotenv@16.4.5: {}
+
+  environment@1.1.0: {}

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_7_pnp.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_7_pnp.snap
@@ -58,4 +58,13 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm prune --prod`
+
+      Lockfile is up to date, resolution step is skipped
+      Already up to date
+
+      devDependencies: skipped
+
+  - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_8_hoist.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_8_hoist.snap
@@ -61,4 +61,13 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm prune --prod`
+
+      Lockfile is up to date, resolution step is skipped
+      Already up to date
+
+      devDependencies: skipped
+
+  - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_8_nuxt.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/pnpm_8_nuxt.snap
@@ -84,4 +84,17 @@ source: test_support/src/lib.rs
       <NUXT BUILD OUTPUT>
 
   - Done (<time_elapsed>)
+- Pruning dev dependencies
+
+! Pruning skipped due to presence of lifecycle scripts
+!
+! The version of pnpm used (8.11.0) will execute the following lifecycle scripts declared in package.json during pruning which can cause build failures:
+! - pnpm:devPreinstall
+! - preinstall
+! - install
+! - postinstall
+! - prepare
+!
+! Since pruning can't be done safely for your build, it will be skipped. To fix this you must upgrade your version of pnpm to 8.15.6 or higher.
+
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/test_default_web_process_registration_is_skipped_if_procfile_exists.snap
@@ -39,11 +39,14 @@ source: test_support/src/lib.rs
   - Running `pnpm install --frozen-lockfile`
 
       Lockfile is up to date, resolution step is skipped
-      Packages: +1
-      +
+      Packages: +2
+      ++
 
       dependencies:
       + dotenv 16.4.5
+
+      devDependencies:
+      + environment 1.1.0
 
       Done in <time_elapsed>
 
@@ -58,5 +61,16 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm prune --prod --ignore-scripts`
+
+      Lockfile is up to date, resolution step is skipped
+      Packages: -1
+      -
+
+      devDependencies:
+      - environment 1.1.0
+
+  - Done (<time_elapsed>)
 - Skipping default web process (Procfile detected)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/test_native_modules_are_recompiled_even_on_cache_restore.snap
@@ -61,6 +61,15 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm prune --prod --ignore-scripts`
+
+      Lockfile is up to date, resolution step is skipped
+      Already up to date
+
+      devDependencies: skipped
+
+  - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)
 
 --------------------------------------------- REBUILD ---------------------------------------------
@@ -113,4 +122,13 @@ source: test_support/src/lib.rs
   - Done (<time_elapsed>)
 - Running scripts
   - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm prune --prod --ignore-scripts`
+
+      Lockfile is up to date, resolution step is skipped
+      Already up to date
+
+      devDependencies: skipped
+
+  - Done (<time_elapsed>)
 - Done (finished in <time_elapsed>)

--- a/buildpacks/nodejs-pnpm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
+++ b/buildpacks/nodejs-pnpm-install/tests/snapshots/test_skip_build_scripts_from_buildplan.snap
@@ -39,11 +39,14 @@ source: test_support/src/lib.rs
   - Running `pnpm install --frozen-lockfile`
 
       Lockfile is up to date, resolution step is skipped
-      Packages: +1
-      +
+      Packages: +2
+      ++
 
       dependencies:
       + dotenv 16.4.5
+
+      devDependencies:
+      + environment 1.1.0
 
       Done in <time_elapsed>
 
@@ -60,4 +63,6 @@ source: test_support/src/lib.rs
   - ! Not running `heroku-prebuild` as it was disabled by a participating buildpack
   - ! Not running `build` as it was disabled by a participating buildpack
   - ! Not running `heroku-postbuild` as it was disabled by a participating buildpack
+- Pruning dev dependencies
+  - Skipping as pruning was disabled by a participating buildpack
 - Done (finished in <time_elapsed>)


### PR DESCRIPTION
This PR adds functionality to the `heroku/nodejs-pnpm-install` buildpack to prune dev dependencies at the end of it's build. This will ensure that only production dependencies are stored in the exported image, reducing the overall image size.

Accommodations have also been made for the [frontend-web](https://github.com/heroku/buildpacks-frontend-web) buildpacks which rely on dev dependencies not being pruned. As these buildpacks leverage buildplan metadata to opt-out of build lifecycle tasks, I've chosen to piggyback on this mechanism to provide a similar opt-out for pruning.