### PR TITLE
Deprecate mirrored inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures 0.3.31",
+ "hex",
  "http",
  "hyper",
  "hyper-util",

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 clap = { version = "4", default-features = false, features = ["std"] }
 bullet_stream = "0.10"
 futures = { version = "0.3", default-features = false, features = ["io-compat"] }
+hex = "0.4"
 http = "1"
 indoc = "2"
 keep_a_changelog_file = "0.1.0"

--- a/common/nodejs-utils/src/bin/resolve_version.rs
+++ b/common/nodejs-utils/src/bin/resolve_version.rs
@@ -1,61 +1,72 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
+use clap::{arg, value_parser, Command};
 use heroku_nodejs_utils::vrs::Requirement;
 use heroku_nodejs_utils::vrs::Version;
 use libherokubuildpack::inventory::artifact::{Arch, Os};
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 use std::env::consts;
 
-const SUCCESS_EXIT_CODE: i32 = 0;
-const ARGS_EXIT_CODE: i32 = 1;
-const VERSION_REQS_EXIT_CODE: i32 = 2;
-const INVENTORY_EXIT_CODE: i32 = 3;
+const VERSION_REQS_EXIT_CODE: i32 = 1;
+const INVENTORY_EXIT_CODE: i32 = 2;
+const UNSUPPORTED_OS_EXIT_CODE: i32 = 3;
+const UNSUPPORTED_ARCH_EXIT_CODE: i32 = 4;
 
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
+    let matches = Command::new("resolve_version")
+        .arg(arg!(<inventory_path>))
+        .arg(arg!(<node_version>))
+        .arg(arg!(--os <os>).value_parser(value_parser!(Os)))
+        .arg(arg!(--arch <arch>).value_parser(value_parser!(Arch)))
+        .get_matches();
 
-    if &args[1] == "-v" || &args[1] == "--version" {
-        const VERSION: &str = env!("CARGO_PKG_VERSION");
-        println!("v{VERSION}");
-        std::process::exit(SUCCESS_EXIT_CODE);
-    }
+    let inventory_path = matches
+        .get_one::<String>("inventory_path")
+        .expect("required argument");
+    let node_version = matches
+        .get_one::<String>("node_version")
+        .expect("required argument");
+    let os = match matches.get_one::<Os>("os") {
+        Some(os) => *os,
+        None => consts::OS.parse::<Os>().unwrap_or_else(|e| {
+            eprintln!("Unsupported OS '{}': {e}", consts::OS);
+            std::process::exit(UNSUPPORTED_OS_EXIT_CODE);
+        }),
+    };
+    let arch = match matches.get_one::<Arch>("arch") {
+        Some(arch) => *arch,
+        None => consts::ARCH.parse::<Arch>().unwrap_or_else(|e| {
+            eprintln!("Unsupported Architecture '{}': {e}", consts::ARCH);
+            std::process::exit(UNSUPPORTED_ARCH_EXIT_CODE);
+        }),
+    };
 
-    if args.len() < 3 {
-        eprintln!("$ resolve <toml file> <version requirements>");
-        std::process::exit(ARGS_EXIT_CODE);
-    }
-
-    let filename = &args[1];
-
-    let version_requirements = Requirement::parse(&args[2]).unwrap_or_else(|e| {
-        eprintln!("Could not parse Version Requirements '{}': {e}", &args[2]);
+    let version_requirements = Requirement::parse(node_version).unwrap_or_else(|e| {
+        eprintln!("Could not parse Version Requirements '{node_version}': {e}");
         std::process::exit(VERSION_REQS_EXIT_CODE);
     });
 
-    let inv_contents = std::fs::read_to_string(filename).unwrap_or_else(|e| {
-        eprintln!("Error reading '{filename}': {e}");
+    let inv_contents = std::fs::read_to_string(inventory_path).unwrap_or_else(|e| {
+        eprintln!("Error reading '{inventory_path}': {e}");
         std::process::exit(INVENTORY_EXIT_CODE);
     });
 
     let inv: libherokubuildpack::inventory::Inventory<Version, Sha256, Option<()>> =
         toml::from_str(&inv_contents).unwrap_or_else(|e| {
-            eprintln!("Error parsing '{filename}': {e}");
+            eprintln!("Error parsing '{inventory_path}': {e}");
             std::process::exit(INVENTORY_EXIT_CODE);
         });
 
-    let version = match (consts::OS.parse::<Os>(), consts::ARCH.parse::<Arch>()) {
-        (Ok(os), Ok(arch)) => inv.resolve(os, arch, &version_requirements),
-        (_, _) => None,
-    };
+    let version = inv.resolve(os, arch, &version_requirements);
 
     if let Some(version) = version {
         println!(
-            "{} {} {} {:x}",
+            "{} {} {} {}",
             version.version,
             version.url,
             version.checksum.name,
-            Sha256::digest(&version.checksum.value)
+            hex::encode(&version.checksum.value)
         );
     } else {
         println!("No result");

--- a/common/nodejs-utils/src/bin/update_node_inventory.rs
+++ b/common/nodejs-utils/src/bin/update_node_inventory.rs
@@ -22,7 +22,7 @@ const PLATFORM_LINUX_ARM64: &str = "linux-arm64";
 
 /// Updates the local node.js inventory.toml with versions published on nodejs.org.
 fn main() -> Result<()> {
-    let matches = Command::new("nodejs-update-inventory")
+    let matches = Command::new("update_nodejs_inventory")
         .arg(arg!(<inventory_path>))
         .arg(arg!(<changelog_path>))
         .arg(

--- a/common/nodejs-utils/src/lib.rs
+++ b/common/nodejs-utils/src/lib.rs
@@ -1,4 +1,5 @@
 use clap as _;
+use hex as _;
 use keep_a_changelog_file as _;
 use sha2 as _;
 


### PR DESCRIPTION
There are four binaries in this repository which primarily support inventory management for the [classic Node.js buildpack](https://github.com/heroku/heroku-buildpack-nodejs):
- `./common/nodejs-utils/bin/diff_versions`
- `./common/nodejs-utils/bin/generate_inventory`
- `./common/nodejs-utils/bin/list_unmirrored_versions`
- `./common/nodejs-utils/bin/resolve_version`

The `diff_versions` and `generate_inventory` binaries are used directly in the GitHub Action for [classic's inventory updates workflow](https://github.com/heroku/heroku-buildpack-nodejs/blob/main/.github/workflows/inventory.yml).

> [!NOTE]
> These are also found in the [_update-inventory.yml](https://github.com/heroku/buildpacks-nodejs/blob/main/.github/workflows/_update-inventory.yml) shared action which is no longer needed since #1121 and #1122 and will be removed along with the related binaries in a subsequent cleanup PR.

The `list_unmirrored_versions` binary is used exclusively by the [_mirror-distribution.yml](https://github.com/heroku/buildpacks-nodejs/blob/main/.github/workflows/_mirror-distribution.yml) shared action as it used to handle the S3 mirroring for both the Node.js CNB and classic buildpack. Since #814 it only handles the mirroring for the classic buildpack. This workflow and binary will be removed in a subsequent cleanup PR.

The `resolve_version` binary is compiled directly into the Node.js classic buildpack (see [heroku/heroku-buildpack-nodejs#1061](https://github.com/heroku/heroku-buildpack-nodejs/pull/1061)). This binary has been updated to work with the same inventory format used by the Node.js CNB. It has also been modified to make testing easier by introducing optional arguments for `--os` and `--arch` which default to the system os/arch but, when provided, allow resolution of linux binaries from a mac (or other combinations).

Finally, the `update_node_inventory` binary has been modified to support the use cases for the Node.js classic buildpack:
- the `--platform` argument is introduced since only `linux-x86` is supported in classic
- the `--format` argument is introduced to retain the style of the classic's `CHANGELOG.md` file which is not fully Keep a Changelog compliant

[W-15573177](https://gus.lightning.force.com/a07EE00001pgu9ZYAQ)