### PR TITLE
Use OS certificate store for http requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,11 +1145,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -1745,7 +1755,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2288,6 +2298,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2305,7 +2316,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -2409,6 +2419,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.3.0",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,7 +2502,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2711,7 +2746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3252,7 +3287,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf-8",
- "webpki-roots 0.26.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3482,15 +3517,6 @@ name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/buildpacks/nodejs-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use OS certificate store for HTTP requests when downloading Node.js. ([#1164](https://github.com/heroku/buildpacks-nodejs/pull/1164))
+
 ## [4.1.2] - 2025-08-15
 
 ### Added

--- a/buildpacks/nodejs-npm-engine/CHANGELOG.md
+++ b/buildpacks/nodejs-npm-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use OS certificate store for HTTP requests when downloading npm. ([#1164](https://github.com/heroku/buildpacks-nodejs/pull/1164))
+
 ## [4.1.2] - 2025-08-15
 
 - No changes.

--- a/buildpacks/nodejs-yarn/CHANGELOG.md
+++ b/buildpacks/nodejs-yarn/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use OS certificate store for HTTP requests when downloading Yarn. ([#1164](https://github.com/heroku/buildpacks-nodejs/pull/1164))
+
 ## [4.1.2] - 2025-08-15
 
 - No changes.

--- a/common/nodejs-utils/Cargo.toml
+++ b/common/nodejs-utils/Cargo.toml
@@ -25,7 +25,7 @@ libherokubuildpack = { version = "=0.29.1", default-features = false, features =
 ] }
 node-semver = "2"
 regex = "1"
-reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls-native-roots"] }
 reqwest-middleware = "0.4"
 reqwest-retry = "0.7"
 serde = { version = "1", features = ['derive'] }

--- a/common/nodejs-utils/src/http.rs
+++ b/common/nodejs-utils/src/http.rs
@@ -368,10 +368,12 @@ mod test {
         // since this is the only test that sets this env var
         env::remove_var("SSL_CERT_FILE");
 
-        assert!(get("https://self-signed.badssl.com")
-            .max_retries(0)
-            .call_sync()
-            .is_err());
+        global::with_locked_writer(Vec::<u8>::new(), || {
+            assert!(get("https://self-signed.badssl.com")
+                .max_retries(0)
+                .call_sync()
+                .is_err());
+        });
 
         let badssl_self_signed_cert_dir = tempfile::tempdir().unwrap();
         let badssl_self_signed_cert = badssl_self_signed_cert_dir
@@ -409,10 +411,14 @@ mod test {
 
         env::set_var("SSL_CERT_FILE", badssl_self_signed_cert);
 
-        assert!(get("https://self-signed.badssl.com")
-            .max_retries(0)
-            .call_sync()
-            .is_ok());
+        global::with_locked_writer(Vec::<u8>::new(), || {
+            assert!(get("https://self-signed.badssl.com")
+                .max_retries(0)
+                .call_sync()
+                .is_ok());
+        });
+
+        env::remove_var("SSL_CERT_FILE");
     }
 
     #[bon::builder]

--- a/common/nodejs-utils/src/lib.rs
+++ b/common/nodejs-utils/src/lib.rs
@@ -4,6 +4,7 @@ use hex as _;
 use keep_a_changelog_file as _;
 use regex as _;
 use sha2 as _;
+use ureq as _;
 
 pub mod application;
 pub mod available_parallelism;


### PR DESCRIPTION
Enables the [`rustls-tls-native-roots` feature of `reqwest`](https://docs.rs/reqwest/latest/reqwest/#optional-features) so that the [rusttls-native-certs](https://github.com/rustls/rustls-native-certs) crate will be used for TLS verification.

[W-19388322](https://gus.lightning.force.com/a07EE00002KTChQYAX)