### PR TITLE
Skip changelog edits when no releases to add/remove

### DIFF
--- a/crates/xtask-update-nodejs-inventory/src/output.rs
+++ b/crates/xtask-update-nodejs-inventory/src/output.rs
@@ -189,7 +189,10 @@ fn write_classic_changelog_format(
     // insert a single trailing blank line
     changelog.insert(index + lines_of_content, String::new());
 
-    fs::write(changelog_path, changelog.join("\n")).unwrap_or_else(|_| {
+    // ensure that the final changelog ends with a single trailing blank line
+    let changelog_contents = format!("{}\n", changelog.join("\n").trim_end());
+
+    fs::write(changelog_path, changelog_contents).unwrap_or_else(|_| {
         panic!(
             "Failed to write to changelog at '{}'",
             changelog_path.display()


### PR DESCRIPTION
The current script is removing the trailing blank line if there are no releases to add/remove when writing the "classic" buildpack CHANGELOG.md. This ends up causing inventory automation to create PRs like https://github.com/heroku/heroku-buildpack-nodejs/pull/1487.