### PR TITLE
Capture dependency information from `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+- Capture dependency information from `package.json`. ([#1228](https://github.com/heroku/buildpacks-nodejs/pull/1228))
+
 ## [5.2.4] - 2025-11-07
 
 ### Added

--- a/src/o11y.rs
+++ b/src/o11y.rs
@@ -57,3 +57,14 @@ pub(crate) const BUILD_SCRIPTS_PREBUILD: &str = formatcp!("{BUILD_SCRIPTS}.prebu
 pub(crate) const BUILD_SCRIPTS_BUILD: &str = formatcp!("{BUILD_SCRIPTS}.build");
 
 pub(crate) const BUILD_SCRIPTS_POSTBUILD: &str = formatcp!("{BUILD_SCRIPTS}.postbuild");
+
+const DEPENDENCIES: &str = formatcp!("{NAMESPACE}.dependencies");
+
+pub(crate) const DEPENDENCIES_REQUESTED_PACKAGE_NAME: &str =
+    formatcp!("{DEPENDENCIES}.requested_package_name");
+
+pub(crate) const DEPENDENCIES_REQUESTED_PACKAGE_VERSION: &str =
+    formatcp!("{DEPENDENCIES}.requested_package_version");
+
+pub(crate) const DEPENDENCIES_REQUESTED_DEPENDENCY_SOURCE_FIELD: &str =
+    formatcp!("{DEPENDENCIES}.requested_dependency_source_field");

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -73,6 +73,17 @@ impl TryFrom<PathBuf> for PackageJson {
         tracing::info!({ PACKAGE_JSON_CONTENTS } = contents);
         let json = serde_json::from_str::<serde_json::Value>(&contents)
             .map_err(|e| package_json_parse_error_message(&value, &e))?;
+        for dependency_type in ["dependencies", "devDependencies", "peerDependencies"] {
+            if let Some(deps) = json.get(dependency_type).and_then(|v| v.as_object()) {
+                for (name, version) in deps {
+                    tracing::info!(
+                        { DEPENDENCIES_REQUESTED_PACKAGE_NAME } = name,
+                        { DEPENDENCIES_REQUESTED_PACKAGE_VERSION } = version.to_string(),
+                        { DEPENDENCIES_REQUESTED_DEPENDENCY_SOURCE_FIELD } = dependency_type
+                    );
+                }
+            }
+        }
         Ok(Self(json))
     }
 }


### PR DESCRIPTION
For each package requested in `dependencies`, `devDependencies`, and `peerDependencies` declared in `package.json` record:
- the package name
- the requested version
- the source field it's declared in

[W-20173993](https://gus.lightning.force.com/a07EE00002P2hx4YAB)