### PR TITLE
Remove references to CNBs being in preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ into application images with minimal configuration.
 
 > [!IMPORTANT]
 > This is a collection of [Cloud Native Buildpacks][cnb], and is a component of 
-> the [Heroku Cloud Native Buildpacks][heroku-buildpacks] project, which is in preview. 
-> If you are instead looking for the Heroku Classic Buildpack for Node.js (for use on 
-> the Heroku platform), you may find it [here][classic-buildpack].
+> the [Heroku Cloud Native Buildpacks][heroku-buildpacks] project. 
+> If you are instead looking for the Heroku Classic Buildpack for Node.js,
+> you may find it [here][classic-buildpack].
 
 ## Usage
 


### PR DESCRIPTION
Since they've been generally available for some time now:
https://www.heroku.com/blog/heroku-fir-generally-available-new-platform-capabilities/

GUS-W-20242644.