### PR TITLE
Warn when building with End-of-Life Node.js versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Warn when deploying with end-of-life Node.js versions. ([#1353](https://github.com/heroku/buildpacks-nodejs/pull/1353))
+
 ### Changed
 
 - Extracted shared Node.js version types into `nodejs-data` crate. ([#1328](https://github.com/heroku/buildpacks-nodejs/pull/1328))

--- a/crates/nodejs-data/src/lib.rs
+++ b/crates/nodejs-data/src/lib.rs
@@ -1,6 +1,7 @@
 use fun_run::NamedOutput;
 use libherokubuildpack::inventory::version::VersionRequirement;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 use std::{error::Error, fmt, str::FromStr};
 
 #[derive(Debug, PartialEq)]
@@ -156,6 +157,17 @@ pub type NodejsArtifact =
     libherokubuildpack::inventory::artifact::Artifact<Version, sha2::Sha256, Option<()>>;
 pub type NodejsInventory =
     libherokubuildpack::inventory::Inventory<Version, sha2::Sha256, Option<()>>;
+
+// Shared with the classic CNB buildpack.
+// Update when the active LTS line changes.
+pub static RECOMMENDED_LTS_VERSION: LazyLock<VersionRange> = LazyLock::new(|| {
+    VersionRange::parse("24.x").expect("Recommended Node.js version should be valid")
+});
+
+// Major versions currently supported on Heroku.
+// Shared with the classic CNB buildpack.
+// Update when versions enter or leave LTS.
+pub const SUPPORTED_NODEJS_VERSIONS: [u64; 3] = [20, 22, 24];
 
 #[cfg(test)]
 mod tests {

--- a/crates/nodejs-data/src/lib.rs
+++ b/crates/nodejs-data/src/lib.rs
@@ -167,7 +167,7 @@ pub static RECOMMENDED_LTS_VERSION: LazyLock<VersionRange> = LazyLock::new(|| {
 // Major versions currently supported on Heroku.
 // Shared with the classic CNB buildpack.
 // Update when versions enter or leave LTS.
-pub const SUPPORTED_NODEJS_VERSIONS: [u64; 3] = [20, 22, 24];
+pub const SUPPORTED_NODEJS_VERSIONS: [u64; 4] = [20, 22, 24, 25];
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod package_manager;
 mod package_managers;
 mod runtime;
 mod runtimes;
+mod support_status;
 mod utils;
 
 type BuildpackDetectContext = libcnb::detect::DetectContext<NodeJsBuildpack>;
@@ -107,6 +108,7 @@ impl libcnb::Buildpack for NodeJsBuildpack {
             .inspect(runtime::log_requested_runtime)
             .and_then(runtime::resolve_runtime)
             .inspect(runtime::log_resolved_runtime)
+            .and_then(runtime::check_runtime_support_status)
             .and_then(|resolved_runtime| {
                 runtime::install_runtime(&context, &mut env, resolved_runtime)
             })?;

--- a/src/o11y.rs
+++ b/src/o11y.rs
@@ -26,6 +26,8 @@ pub(crate) const RUNTIME_VERSION_MAJOR: &str = formatcp!("{RUNTIME}.version_majo
 
 pub(crate) const RUNTIME_URL: &str = formatcp!("{RUNTIME}.url");
 
+pub(crate) const RUNTIME_SUPPORT_STATUS: &str = formatcp!("{RUNTIME}.support_status");
+
 const PACKAGE_MANAGER: &str = formatcp!("{NAMESPACE}.package_manager");
 
 pub(crate) const PACKAGE_MANAGER_REQUESTED_SOURCE: &str =

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::o11y::*;
 use crate::package_json::PackageJson;
-use crate::runtimes::nodejs::{DEFAULT_NODEJS_REQUIREMENT, NODEJS_INVENTORY, NodejsArtifact};
+use crate::runtimes::nodejs::NODEJS_INVENTORY;
 use crate::utils::error_handling::ErrorType::UserFacing;
 use crate::utils::error_handling::{
     ErrorMessage, SuggestRetryBuild, SuggestSubmitIssue, error_message,
@@ -11,7 +11,7 @@ use bullet_stream::style;
 use indoc::formatdoc;
 use libcnb::Env;
 use libherokubuildpack::inventory::artifact::{Arch, Os};
-use nodejs_data::VersionRange;
+use nodejs_data::{NodejsArtifact, RECOMMENDED_LTS_VERSION, VersionRange};
 use std::env::consts;
 use std::sync::LazyLock;
 use tracing::instrument;
@@ -56,7 +56,7 @@ pub(crate) fn log_requested_runtime(requested_runtime: &RequestedRuntime) {
         RequestedRuntime::NodeJsDefault => {
             print::sub_bullet(format!(
                 "Node.js version not specified, using {}",
-                style::value(DEFAULT_NODEJS_REQUIREMENT.to_string())
+                style::value(RECOMMENDED_LTS_VERSION.to_string())
             ));
         }
     }
@@ -66,13 +66,24 @@ pub(crate) enum ResolvedRuntime {
     Nodejs(NodejsArtifact),
 }
 
+pub(crate) fn check_runtime_support_status(
+    resolved_runtime: ResolvedRuntime,
+) -> BuildpackResult<ResolvedRuntime> {
+    match &resolved_runtime {
+        ResolvedRuntime::Nodejs(artifact) => {
+            crate::support_status::check_nodejs_support_status(artifact)?;
+        }
+    }
+    Ok(resolved_runtime)
+}
+
 #[instrument(skip_all)]
 pub(crate) fn resolve_runtime(
     requested_runtime: RequestedRuntime,
 ) -> BuildpackResult<ResolvedRuntime> {
     match requested_runtime {
         RequestedRuntime::NodeJsEngine(requirement) => resolve_nodejs_runtime(&requirement),
-        RequestedRuntime::NodeJsDefault => resolve_nodejs_runtime(&DEFAULT_NODEJS_REQUIREMENT),
+        RequestedRuntime::NodeJsDefault => resolve_nodejs_runtime(&RECOMMENDED_LTS_VERSION),
     }
 }
 

--- a/src/runtimes/nodejs.rs
+++ b/src/runtimes/nodejs.rs
@@ -16,7 +16,7 @@ use libcnb::layer::{
     CachedLayerDefinition, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libcnb::layer_env::Scope;
-use nodejs_data::{Version, VersionCommandError, VersionRange};
+use nodejs_data::{NodejsArtifact, NodejsInventory, Version, VersionCommandError};
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 use std::sync::LazyLock;
@@ -25,11 +25,6 @@ pub(crate) static NODEJS_INVENTORY: LazyLock<NodejsInventory> = LazyLock::new(||
     toml::from_str(include_str!("../../inventory/nodejs.toml"))
         .expect("Inventory file should be valid")
 });
-
-pub(crate) static DEFAULT_NODEJS_REQUIREMENT: LazyLock<VersionRange> =
-    LazyLock::new(|| VersionRange::parse("24.x").expect("Default Node.js version should be valid"));
-
-pub(crate) use nodejs_data::{NodejsArtifact, NodejsInventory};
 
 pub(crate) fn install(
     context: &BuildpackBuildContext,

--- a/src/support_status.rs
+++ b/src/support_status.rs
@@ -1,0 +1,35 @@
+use crate::BuildpackResult;
+use crate::o11y::RUNTIME_SUPPORT_STATUS;
+use bullet_stream::global::print;
+use bullet_stream::style;
+use indoc::formatdoc;
+use nodejs_data::{NodejsArtifact, SUPPORTED_NODEJS_VERSIONS};
+use tracing::instrument;
+
+#[instrument(skip_all)]
+pub(crate) fn check_nodejs_support_status(artifact: &NodejsArtifact) -> BuildpackResult<()> {
+    if SUPPORTED_NODEJS_VERSIONS.contains(&artifact.version.major()) {
+        tracing::info!({ RUNTIME_SUPPORT_STATUS } = "supported", "support_status");
+        Ok(())
+    } else {
+        tracing::info!({ RUNTIME_SUPPORT_STATUS } = "eol_warning", "support_status");
+        print::warning(create_eol_warning(&artifact.version));
+        Ok(())
+    }
+}
+
+fn create_eol_warning(version: &nodejs_data::Version) -> String {
+    let version = style::value(version.to_string());
+    let support_url = style::url(
+        "https://devcenter.heroku.com/articles/nodejs-support#supported-node-js-versions",
+    );
+    formatdoc! {"
+        Node.js {version} is now End-of-Life (EOL). It no longer receives security \
+        updates, bug fixes, or support from the Node.js project and is no longer supported on Heroku.
+
+        In a future buildpack release, this warning will become a build error. Please upgrade to a supported \
+        version as soon as possible to avoid build failures.
+
+        {support_url}
+    "}
+}

--- a/tests/engine_integration_test.rs
+++ b/tests/engine_integration_test.rs
@@ -3,6 +3,7 @@
 
 use libcnb::data::buildpack_id;
 use libcnb_test::{BuildpackReference, assert_contains, assert_contains_match};
+use nodejs_data::SUPPORTED_NODEJS_VERSIONS;
 use test_support::{
     assert_web_response, create_build_snapshot, integration_test_with_config,
     nodejs_integration_test, nodejs_integration_test_with_config, print_build_env_buildpack,
@@ -106,6 +107,24 @@ fn node_25() {
         |ctx| {
             create_build_snapshot(&ctx.pack_stdout).assert();
             assert_web_response(&ctx, "node-with-serverjs");
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn node_eol_warning() {
+    nodejs_integration_test_with_config(
+        "./fixtures/node-with-serverjs",
+        |config| {
+            config.app_dir_preprocessor(|app_dir| {
+                // Assumes the version one below the lowest supported major is EOL and present in the inventory.
+                let unsupported_version = format!("{}.x", SUPPORTED_NODEJS_VERSIONS[0] - 1);
+                set_node_engine(&app_dir, &unsupported_version);
+            });
+        },
+        |ctx| {
+            create_build_snapshot(&ctx.pack_stdout).assert();
         },
     );
 }

--- a/tests/snapshots/node_eol_warning.snap
+++ b/tests/snapshots/node_eol_warning.snap
@@ -1,0 +1,51 @@
+---
+source: crates/test_support/src/lib.rs
+---
+===> ANALYZING
+Image with name "<image-name>" not found
+===> DETECTING
+heroku/nodejs <buildpack-version>
+===> RESTORING
+<restoring-output>
+===> BUILDING
+
+## Heroku Node.js
+
+- Checking Node.js version
+  - Detected Node.js version range: `19.x`
+  - Resolved Node.js version: `19.9.0`
+
+! Node.js `19.9.0` is now End-of-Life (EOL). It no longer receives security updates, bug fixes, or support from the Node.js project and is no longer supported on Heroku.
+!
+! In a future buildpack release, this warning will become a build error. Please upgrade to a supported version as soon as possible to avoid build failures.
+!
+! https://devcenter.heroku.com/articles/nodejs-support#supported-node-js-versions
+
+- Installing Node.js distribution
+  - GET https://nodejs.org/download/release/v19.9.0/node-v19.9.0-<arch>.tar.gz ... (<time_elapsed>)
+  - Validating ... (<time_elapsed>)
+  - Extracting ... (<time_elapsed>)
+  - Verifying checksum
+  - Extracting Node.js `19.9.0 (<arch>)`
+  - Installing Node.js `19.9.0 (<arch>)` ... (<time_elapsed>)
+- Done (finished in <time_elapsed>)
+===> EXPORTING
+Adding layer 'heroku/nodejs:available_parallelism'
+Adding layer 'heroku/nodejs:dist'
+Adding layer 'heroku/nodejs:web_env'
+Adding layer 'heroku/nodejs:z_node_module_bins'
+Adding layer 'buildpacksio/lifecycle:launch.sbom'
+Added 1/1 app layer(s)
+Adding layer 'buildpacksio/lifecycle:launcher'
+Adding layer 'buildpacksio/lifecycle:config'
+Adding layer 'buildpacksio/lifecycle:process-types'
+Adding label 'io.buildpacks.lifecycle.metadata'
+Adding label 'io.buildpacks.build.metadata'
+Adding label 'io.buildpacks.project.metadata'
+Adding label 'io.buildpacks.exec-env'
+Setting default process type 'web'
+Saving <image-name>...
+*** Images (<random-hex>):
+      <image-name>
+Adding cache layer 'heroku/nodejs:dist'
+Successfully built image '<image-name>'


### PR DESCRIPTION
## Summary

- Add a build warning when the resolved Node.js version is EOL and no longer supported on Heroku
- Move `RECOMMENDED_LTS_VERSION` and add `SUPPORTED_NODEJS_VERSIONS` to the `nodejs-data` crate for sharing with the classic CNB buildpack
- Include telemetry tracking via `RUNTIME_SUPPORT_STATUS` observability attribute

## Test plan

- [x] Integration test `node_eol_warning` validates the warning output via snapshot
- [x] Verify no warning is emitted for supported Node.js versions (existing tests)
- [x] CI passes

W-21451605