### PR TITLE
Add Heroku-26 CNB support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder:24", "builder:22"]
+        builder: ["builder:26", "builder:24", "builder:22"]
         arch: ["amd64", "arm64"]
         exclude:
           - builder: "builder:22"

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -13,7 +13,7 @@ jobs:
     name: Update Node.js Inventory
     runs-on: pub-hk-ubuntu-24.04-ip
     env:
-      INTEGRATION_TEST_CNB_BUILDER: heroku/builder:24
+      INTEGRATION_TEST_CNB_BUILDER: heroku/builder:26
 
     steps:
       - uses: actions/create-github-app-token@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for the `heroku/builder:26` builder image. ([#1355](https://github.com/heroku/buildpacks-nodejs/pull/1355))
+
 ## [5.5.7] - 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Support for the `heroku/builder:26` builder image. ([#1355](https://github.com/heroku/buildpacks-nodejs/pull/1355))
-
 ## [5.5.7] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build a Node.js application codebase into a production image:
 
 ```bash
 $ cd ~/workdir/sample-nodejs-app
-$ pack build sample-app --builder heroku/builder:24
+$ pack build sample-app --builder heroku/builder:26
 ```
 
 Then run the image:

--- a/crates/test_support/src/test_builder.rs
+++ b/crates/test_support/src/test_builder.rs
@@ -3,13 +3,14 @@ use std::fmt::Display;
 pub(super) fn get_test_builder() -> TestBuilder {
     std::env::var("INTEGRATION_TEST_CNB_BUILDER")
         .map(TestBuilder::from)
-        .unwrap_or(TestBuilder::Heroku24)
+        .unwrap_or(TestBuilder::Heroku26)
 }
 
 #[derive(Debug, Eq, PartialEq)]
 pub(super) enum TestBuilder {
     Heroku22,
     Heroku24,
+    Heroku26,
     Other(String),
 }
 
@@ -18,6 +19,7 @@ impl Display for TestBuilder {
         match self {
             TestBuilder::Heroku22 => write!(f, "heroku/builder:22"),
             TestBuilder::Heroku24 => write!(f, "heroku/builder:24"),
+            TestBuilder::Heroku26 => write!(f, "heroku/builder:26"),
             TestBuilder::Other(name) => write!(f, "{name}"),
         }
     }
@@ -35,6 +37,8 @@ impl From<String> for TestBuilder {
             TestBuilder::Heroku22
         } else if value == TestBuilder::Heroku24.to_string() {
             TestBuilder::Heroku24
+        } else if value == TestBuilder::Heroku26.to_string() {
+            TestBuilder::Heroku26
         } else {
             TestBuilder::Other(value)
         }


### PR DESCRIPTION
## Summary

- Add `heroku/builder:26` to the CI integration test matrix (amd64 + arm64)
- Add `Heroku26` variant to `TestBuilder` enum and update default builder
- Update inventory workflow to use `heroku/builder:26`
- Update README usage example and add CHANGELOG entry

Fixes W-20776130