### PR TITLE
Remove unused test helpers

### DIFF
--- a/crates/test_support/src/lib.rs
+++ b/crates/test_support/src/lib.rs
@@ -15,20 +15,14 @@ use libcnb_test::{
     BuildConfig, BuildpackReference, ContainerConfig, ContainerContext, TestContext, TestRunner,
     assert_contains,
 };
+use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
-use std::{fs, panic};
+use std::time::Duration;
 
-const DEFAULT_BUILDER: &str = "heroku/builder:22";
 const PORT: u16 = 8080;
 pub const DEFAULT_RETRIES: u32 = 10;
 pub const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
-
-#[must_use]
-fn get_integration_test_builder() -> String {
-    std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap_or(DEFAULT_BUILDER.to_string())
-}
 
 pub fn nodejs_integration_test(fixture: &str, test_body: fn(TestContext)) {
     nodejs_integration_test_with_config(fixture, |_| {}, test_body);
@@ -45,30 +39,6 @@ pub fn nodejs_integration_test_with_config(
         test_body,
         &[BuildpackReference::WorkspaceBuildpack(buildpack_id!(
             "heroku/nodejs"
-        ))],
-    );
-}
-
-pub fn function_integration_test(fixture: &str, test_body: fn(TestContext)) {
-    function_integration_test_with_config(fixture, |_| {}, test_body);
-}
-
-fn function_integration_test_with_config(
-    fixture: &str,
-    with_config: fn(&mut BuildConfig),
-    test_body: fn(TestContext),
-) {
-    if get_integration_test_builder() != "heroku/builder:22" {
-        // only heroku/builder:22 supports functions
-        // https://github.com/heroku/cnb-builder-images/blob/main/salesforce-functions/builder.toml
-        return;
-    }
-    integration_test_with_config(
-        fixture,
-        with_config,
-        test_body,
-        &[BuildpackReference::WorkspaceBuildpack(buildpack_id!(
-            "heroku/nodejs-function"
         ))],
     );
 }
@@ -173,29 +143,6 @@ pub fn assert_web_response(ctx: &TestContext, expected_response_body: &'static s
         let response_body = response.body_mut().read_to_string().unwrap();
         assert_contains!(response_body, expected_response_body);
     });
-}
-
-pub fn wait_for<F>(condition: F, max_wait_time: Duration)
-where
-    F: Fn() + panic::RefUnwindSafe,
-{
-    let mut error = None;
-    let start_time = SystemTime::now();
-    while SystemTime::now()
-        .duration_since(start_time)
-        .expect("should not be an earlier time")
-        < max_wait_time
-    {
-        match panic::catch_unwind(&condition) {
-            Ok(()) => return,
-            Err(err) => error = Some(err),
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    match error {
-        None => panic!("timeout exceeded"),
-        Some(error) => panic::resume_unwind(error),
-    }
 }
 
 pub fn set_node_engine(app_dir: &Path, version_range: &str) {


### PR DESCRIPTION
## Summary

- Remove `function_integration_test` and `function_integration_test_with_config` helpers (Salesforce Functions support is no longer active)
- Remove `wait_for` utility (no callers in the test suite)
- Remove associated dead code: `DEFAULT_BUILDER` constant, `get_integration_test_builder()`, and unused imports