### PR TITLE
Report bundled npm version in build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - Report bundled npm version in build output. ([#1366](https://github.com/heroku/buildpacks-nodejs/pull/1366))
 
 ## [5.5.8] - 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Report bundled npm version in build output. ([#1366](https://github.com/heroku/buildpacks-nodejs/pull/1366))
+
 ## [5.5.8] - 2026-04-16
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ impl libcnb::Buildpack for NodeJsBuildpack {
         ))
         .inspect(package_manager::log_requested_package_manager)
         .and_then(|requested_package_manager| {
-            package_manager::resolve_package_manager(&context, &requested_package_manager)
+            package_manager::resolve_package_manager(&context, &mut env, &requested_package_manager)
         })
         .inspect(package_manager::log_resolved_package_manager)
         .and_then(|resolved_package_manager| {

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -144,24 +144,17 @@ pub(crate) fn determine_package_manager(
 }
 
 pub(crate) fn log_requested_package_manager(requested_package_manager: &RequestedPackageManager) {
-    // TODO: change this output to something more generic
     if requested_package_manager.is_yarn() {
         print::bullet("Determining Yarn information");
     } else if requested_package_manager.is_pnpm() {
         print::bullet("Determining pnpm package information");
-    } else if requested_package_manager.is_npm()
-        && !matches!(
-            requested_package_manager,
-            RequestedPackageManager::BundledNpm
-        )
-    {
+    } else if requested_package_manager.is_npm() {
         print::bullet("Determining npm package information");
     }
 
     match requested_package_manager {
         RequestedPackageManager::BundledNpm => {
-            // TODO: this should be reported but will be addressed later
-            // E.g.; print::sub_bullet("No npm version requested")
+            print::sub_bullet("No npm version requested");
         }
         RequestedPackageManager::NpmEngine(requirement) => print::sub_bullet(format!(
             "Found {} version {} declared in {}",
@@ -204,7 +197,7 @@ pub(crate) fn log_requested_package_manager(requested_package_manager: &Requeste
 
 pub(crate) enum ResolvedPackageManager {
     Npm(VersionRange, PackagePackument),
-    NpmBundled,
+    NpmBundled(Version),
     Pnpm(VersionRange, PackagePackument),
     Yarn(VersionRange, PackagePackument),
     YarnVendored(PathBuf),
@@ -213,12 +206,19 @@ pub(crate) enum ResolvedPackageManager {
 #[instrument(skip_all)]
 pub(crate) fn resolve_package_manager(
     context: &BuildpackBuildContext,
+    env: &mut Env,
     requested_package_manager: &RequestedPackageManager,
 ) -> BuildpackResult<ResolvedPackageManager> {
     match requested_package_manager {
         RequestedPackageManager::BundledNpm => {
-            tracing::info!({ { PACKAGE_MANAGER_NAME } = "npm", "package_manager" });
-            Ok(ResolvedPackageManager::NpmBundled)
+            let npm_version = npm::get_version(env)?;
+            tracing::info!({
+                { PACKAGE_MANAGER_NAME } = "npm",
+                { PACKAGE_MANAGER_VERSION } = npm_version.to_string(),
+                { PACKAGE_MANAGER_VERSION_MAJOR } = npm_version.major(),
+                "package_manager"
+            });
+            Ok(ResolvedPackageManager::NpmBundled(npm_version))
         }
         RequestedPackageManager::NpmEngine(requirement) => {
             npm::resolve_npm_package_packument(context, requirement).map(|npm_package_packument| {
@@ -312,9 +312,11 @@ pub(crate) fn resolve_package_manager(
 
 pub(crate) fn log_resolved_package_manager(resolved_package_manager: &ResolvedPackageManager) {
     match resolved_package_manager {
-        ResolvedPackageManager::NpmBundled => {
-            // TODO: this should be reported but will be addressed later
-            // E.g.; print::sub_bullet("Using bundled npm");
+        ResolvedPackageManager::NpmBundled(bundled_version) => {
+            print::sub_bullet(format!(
+                "Using bundled npm version {}",
+                style::value(bundled_version.to_string()),
+            ));
         }
         ResolvedPackageManager::Npm(requested_version, npm_package_packument) => {
             print::sub_bullet(format!(
@@ -353,20 +355,8 @@ pub(crate) fn install_package_manager(
     resolved_package_manager: &ResolvedPackageManager,
 ) -> BuildpackResult<InstalledPackageManager> {
     match resolved_package_manager {
-        ResolvedPackageManager::NpmBundled => {
-            // TODO: this needs to be reported but will be addressed later
-            // E.g.; print::bullet("Installing npm");
-            let npm_version = npm::get_version(env)?;
-            tracing::info!({
-                { PACKAGE_MANAGER_VERSION } = npm_version.to_string(),
-                { PACKAGE_MANAGER_VERSION_MAJOR } = npm_version.major(),
-                "package_manager"
-            });
-            // print::sub_bullet(format!(
-            //     "Skipping, bundled {} will be used",
-            //     style::value(format!("npm@{npm_version}"))
-            // ));
-            Ok(InstalledPackageManager::Npm(npm_version))
+        ResolvedPackageManager::NpmBundled(bundled_version) => {
+            Ok(InstalledPackageManager::Npm(bundled_version.clone()))
         }
         ResolvedPackageManager::Npm(_, npm_package_packument) => {
             print::bullet("Installing npm");

--- a/tests/snapshots/node_24.snap
+++ b/tests/snapshots/node_24.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `24.15.0 (<arch>)`
   - Installing Node.js `24.15.0 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `11.12.1`
 - Done (finished in <time_elapsed>)
 ===> EXPORTING
 Adding layer 'heroku/nodejs:available_parallelism'

--- a/tests/snapshots/node_25.snap
+++ b/tests/snapshots/node_25.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `25.9.0 (<arch>)`
   - Installing Node.js `25.9.0 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `11.12.1`
 - Done (finished in <time_elapsed>)
 ===> EXPORTING
 Adding layer 'heroku/nodejs:available_parallelism'

--- a/tests/snapshots/node_build_and_runtime_env.snap
+++ b/tests/snapshots/node_build_and_runtime_env.snap
@@ -22,6 +22,9 @@ test/print-build-env 0.0.0
   - Verifying checksum
   - Extracting Node.js `24.15.0 (<arch>)`
   - Installing Node.js `24.15.0 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `11.12.1`
 - Done (finished in <time_elapsed>)
 HEROKU_AVAILABLE_PARALLELISM=<number>
 PATH=/workspace/node_modules/.bin:/layers/heroku_nodejs/dist/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/tests/snapshots/node_eol_warning.snap
+++ b/tests/snapshots/node_eol_warning.snap
@@ -28,6 +28,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `19.9.0 (<arch>)`
   - Installing Node.js `19.9.0 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `9.6.3`
 - Done (finished in <time_elapsed>)
 ===> EXPORTING
 Adding layer 'heroku/nodejs:available_parallelism'

--- a/tests/snapshots/reinstalls_node_if_version_changes.snap
+++ b/tests/snapshots/reinstalls_node_if_version_changes.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `20.20.2 (<arch>)`
   - Installing Node.js `20.20.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.8.2`
 - Done (finished in <time_elapsed>)
 ===> EXPORTING
 Adding layer 'heroku/nodejs:available_parallelism'
@@ -64,6 +67,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Done (finished in <time_elapsed>)
 ===> EXPORTING
 Reusing layer 'heroku/nodejs:available_parallelism'

--- a/tests/snapshots/simple_indexjs.snap
+++ b/tests/snapshots/simple_indexjs.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `24.15.0 (<arch>)`
   - Installing Node.js `24.15.0 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `11.12.1`
 - Done (finished in <time_elapsed>)
 ===> EXPORTING
 Adding layer 'heroku/nodejs:available_parallelism'

--- a/tests/snapshots/simple_serverjs.snap
+++ b/tests/snapshots/simple_serverjs.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Done (finished in <time_elapsed>)
 ===> EXPORTING
 Adding layer 'heroku/nodejs:available_parallelism'

--- a/tests/snapshots/test_npm_build_scripts.snap
+++ b/tests/snapshots/test_npm_build_scripts.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache

--- a/tests/snapshots/test_npm_build_scripts_prefers_heroku_build_over_build.snap
+++ b/tests/snapshots/test_npm_build_scripts_prefers_heroku_build_over_build.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache

--- a/tests/snapshots/test_npm_default_web_process_registration_is_skipped_if_procfile_exists.snap
+++ b/tests/snapshots/test_npm_default_web_process_registration_is_skipped_if_procfile_exists.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache

--- a/tests/snapshots/test_npm_install_caching.snap
+++ b/tests/snapshots/test_npm_install_caching.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache
@@ -87,6 +90,9 @@ heroku/nodejs <buildpack-version>
   - Resolved Node.js version: `22.22.2`
 - Installing Node.js distribution
   - Reusing Node.js 22.22.2 (<arch>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Restoring npm cache

--- a/tests/snapshots/test_npm_install_new_package.snap
+++ b/tests/snapshots/test_npm_install_new_package.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache
@@ -87,6 +90,9 @@ heroku/nodejs <buildpack-version>
   - Resolved Node.js version: `22.22.2`
 - Installing Node.js distribution
   - Reusing Node.js 22.22.2 (<arch>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Restoring npm cache

--- a/tests/snapshots/test_npm_install_with_lockfile.snap
+++ b/tests/snapshots/test_npm_install_with_lockfile.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache

--- a/tests/snapshots/test_npm_native_modules_are_recompiled_even_on_cache_restore.snap
+++ b/tests/snapshots/test_npm_native_modules_are_recompiled_even_on_cache_restore.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `20.20.2 (<arch>)`
   - Installing Node.js `20.20.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.8.2`
 - Installing node modules
   - Using npm version `10.8.2`
   - Creating npm cache
@@ -92,6 +95,9 @@ heroku/nodejs <buildpack-version>
   - Resolved Node.js version: `20.20.2`
 - Installing Node.js distribution
   - Reusing Node.js 20.20.2 (<arch>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.8.2`
 - Installing node modules
   - Using npm version `10.8.2`
   - Restoring npm cache

--- a/tests/snapshots/test_npm_prune_dev_dependencies_config.snap
+++ b/tests/snapshots/test_npm_prune_dev_dependencies_config.snap
@@ -22,6 +22,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache

--- a/tests/snapshots/test_npm_skip_build_scripts_from_buildplan.snap
+++ b/tests/snapshots/test_npm_skip_build_scripts_from_buildplan.snap
@@ -22,6 +22,9 @@ test/skip-build-scripts 0.0.0
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache

--- a/tests/snapshots/test_npm_start_script_creates_a_web_process_launcher.snap
+++ b/tests/snapshots/test_npm_start_script_creates_a_web_process_launcher.snap
@@ -21,6 +21,9 @@ heroku/nodejs <buildpack-version>
   - Verifying checksum
   - Extracting Node.js `22.22.2 (<arch>)`
   - Installing Node.js `22.22.2 (<arch>)` ... (<time_elapsed>)
+- Determining npm package information
+  - No npm version requested
+  - Using bundled npm version `10.9.7`
 - Installing node modules
   - Using npm version `10.9.7`
   - Creating npm cache


### PR DESCRIPTION
## Summary

- Move npm version detection from `install_package_manager` into `resolve_package_manager` so the bundled version is known earlier in the build flow
- Change `NpmBundled` from a unit variant to `NpmBundled(Version)`, enabling build output and telemetry for bundled npm builds
- Add "Determining npm package information" and "Using bundled npm version X" output for bundled npm builds (previously silent)

Extracted as a standalone PR to keep snapshot churn out of the W-19793270 (npm version warnings) PR.