### PR TITLE
Add warnings for unsupported npm versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Report bundled npm version in build output. ([#1366](https://github.com/heroku/buildpacks-nodejs/pull/1366))
+- Added warnings for unsupported npm versions. ([#1367](https://github.com/heroku/buildpacks-nodejs/pull/1367))
 
 ## [5.5.8] - 2026-04-16
 

--- a/crates/nodejs-data/src/lib.rs
+++ b/crates/nodejs-data/src/lib.rs
@@ -190,6 +190,13 @@ pub static RECOMMENDED_LTS_VERSION: LazyLock<VersionRange> = LazyLock::new(|| {
 // Update when versions enter or leave LTS.
 pub const SUPPORTED_NODEJS_VERSIONS: [u64; 4] = [20, 22, 24, 25];
 
+// Minimum npm version supported on Heroku.
+// npm 9.6.4 shipped with Node.js 20.0.0, the oldest currently supported Node.js version.
+// Update when the oldest supported Node.js version changes.
+pub static MINIMUM_SUPPORTED_NPM_VERSION: LazyLock<Version> = LazyLock::new(|| {
+    Version::new(9, 6, 4)
+});
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nodejs-data/src/lib.rs
+++ b/crates/nodejs-data/src/lib.rs
@@ -193,9 +193,8 @@ pub const SUPPORTED_NODEJS_VERSIONS: [u64; 4] = [20, 22, 24, 25];
 // Minimum npm version supported on Heroku.
 // npm 9.6.4 shipped with Node.js 20.0.0, the oldest currently supported Node.js version.
 // Update when the oldest supported Node.js version changes.
-pub static MINIMUM_SUPPORTED_NPM_VERSION: LazyLock<Version> = LazyLock::new(|| {
-    Version::new(9, 6, 4)
-});
+pub static MINIMUM_SUPPORTED_NPM_VERSION: LazyLock<Version> =
+    LazyLock::new(|| Version::new(9, 6, 4));
 
 #[cfg(test)]
 mod tests {

--- a/src/__snapshots/support_status_npm_unsupported_warning.snap
+++ b/src/__snapshots/support_status_npm_unsupported_warning.snap
@@ -1,0 +1,8 @@
+---
+source: src/support_status.rs
+---
+npm `8.19.4` is no longer supported on Heroku. The npm maintainers only make regular releases to the most recent major release-line and recommend using the latest version of npm.
+
+Please upgrade to npm `9.6.4` or later to avoid build failures in a future buildpack release.
+
+https://devcenter.heroku.com/articles/nodejs-support#npm-version-policy

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ impl libcnb::Buildpack for NodeJsBuildpack {
         ))
         .inspect(package_manager::log_requested_package_manager)
         .and_then(|requested_package_manager| {
-            package_manager::resolve_package_manager(&context, &mut env, &requested_package_manager)
+            package_manager::resolve_package_manager(&context, &env, &requested_package_manager)
         })
         .inspect(package_manager::log_resolved_package_manager)
         .and_then(package_manager::check_package_manager_support_status)

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,10 +167,7 @@ impl libcnb::Buildpack for NodeJsBuildpack {
             package_manager::resolve_package_manager(&context, &mut env, &requested_package_manager)
         })
         .inspect(package_manager::log_resolved_package_manager)
-        .and_then(|resolved_package_manager| {
-            package_manager::check_package_manager_support_status(&resolved_package_manager)
-                .map(|()| resolved_package_manager)
-        })
+        .and_then(package_manager::check_package_manager_support_status)
         .and_then(|resolved_package_manager| {
             package_manager::install_package_manager(&context, &mut env, &resolved_package_manager)
         })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,10 @@ impl libcnb::Buildpack for NodeJsBuildpack {
         })
         .inspect(package_manager::log_resolved_package_manager)
         .and_then(|resolved_package_manager| {
+            package_manager::check_package_manager_support_status(&resolved_package_manager)
+                .map(|()| resolved_package_manager)
+        })
+        .and_then(|resolved_package_manager| {
             package_manager::install_package_manager(&context, &mut env, &resolved_package_manager)
         })?;
 

--- a/src/o11y.rs
+++ b/src/o11y.rs
@@ -40,6 +40,8 @@ pub(crate) const PACKAGE_MANAGER_REQUESTED_VERSION: &str =
 pub(crate) const PACKAGE_MANAGER_NAME: &str = formatcp!("{PACKAGE_MANAGER}.name");
 pub(crate) const PACKAGE_MANAGER_VERSION: &str = formatcp!("{PACKAGE_MANAGER}.version");
 pub(crate) const PACKAGE_MANAGER_VERSION_MAJOR: &str = formatcp!("{PACKAGE_MANAGER}.version_major");
+pub(crate) const PACKAGE_MANAGER_NPM_SUPPORT_STATUS: &str =
+    formatcp!("{PACKAGE_MANAGER}.npm_support_status");
 
 const CONFIG: &str = formatcp!("{NAMESPACE}.config");
 

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -7,6 +7,7 @@ use crate::utils::error_handling::{
     ErrorMessage, ErrorType, SuggestRetryBuild, SuggestSubmitIssue, error_message,
 };
 use crate::utils::npm_registry::PackagePackument;
+use crate::support_status::check_npm_support_status;
 use crate::{BuildpackBuildContext, BuildpackResult};
 use bullet_stream::global::print;
 use bullet_stream::style;
@@ -345,6 +346,23 @@ pub(crate) fn log_resolved_package_manager(resolved_package_manager: &ResolvedPa
                 style::value(yarn_path.to_string_lossy())
             ));
         }
+    }
+}
+
+#[instrument(skip_all)]
+pub(crate) fn check_package_manager_support_status(
+    resolved_package_manager: &ResolvedPackageManager,
+) -> BuildpackResult<()> {
+    match resolved_package_manager {
+        ResolvedPackageManager::Npm(_, packument) => {
+            check_npm_support_status(&packument.version)
+        }
+        ResolvedPackageManager::NpmBundled(bundled_version) => {
+            check_npm_support_status(bundled_version)
+        }
+        ResolvedPackageManager::Pnpm(_, _)
+        | ResolvedPackageManager::Yarn(_, _)
+        | ResolvedPackageManager::YarnVendored(_) => Ok(()),
     }
 }
 

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -3,11 +3,11 @@ use crate::o11y::*;
 use crate::package_json::{PackageJson, PackageManagerField, PackageManagerFieldPackageManager};
 use crate::package_managers::{npm, pnpm, yarn};
 use crate::runtimes::nodejs;
+use crate::support_status::check_npm_support_status;
 use crate::utils::error_handling::{
     ErrorMessage, ErrorType, SuggestRetryBuild, SuggestSubmitIssue, error_message,
 };
 use crate::utils::npm_registry::PackagePackument;
-use crate::support_status::check_npm_support_status;
 use crate::{BuildpackBuildContext, BuildpackResult};
 use bullet_stream::global::print;
 use bullet_stream::style;
@@ -213,8 +213,8 @@ pub(crate) fn resolve_package_manager(
     match requested_package_manager {
         RequestedPackageManager::BundledNpm => {
             let npm_version = npm::get_version(env)?;
+            tracing::info!({ { PACKAGE_MANAGER_NAME } = "npm", "package_manager" });
             tracing::info!({
-                { PACKAGE_MANAGER_NAME } = "npm",
                 { PACKAGE_MANAGER_VERSION } = npm_version.to_string(),
                 { PACKAGE_MANAGER_VERSION_MAJOR } = npm_version.major(),
                 "package_manager"
@@ -351,18 +351,20 @@ pub(crate) fn log_resolved_package_manager(resolved_package_manager: &ResolvedPa
 
 #[instrument(skip_all)]
 pub(crate) fn check_package_manager_support_status(
-    resolved_package_manager: &ResolvedPackageManager,
-) -> BuildpackResult<()> {
-    match resolved_package_manager {
+    resolved_package_manager: ResolvedPackageManager,
+) -> BuildpackResult<ResolvedPackageManager> {
+    match &resolved_package_manager {
         ResolvedPackageManager::Npm(_, packument) => {
-            check_npm_support_status(&packument.version)
+            check_npm_support_status(&packument.version)?;
+            Ok(resolved_package_manager)
         }
         ResolvedPackageManager::NpmBundled(bundled_version) => {
-            check_npm_support_status(bundled_version)
+            check_npm_support_status(bundled_version)?;
+            Ok(resolved_package_manager)
         }
         ResolvedPackageManager::Pnpm(_, _)
         | ResolvedPackageManager::Yarn(_, _)
-        | ResolvedPackageManager::YarnVendored(_) => Ok(()),
+        | ResolvedPackageManager::YarnVendored(_) => Ok(resolved_package_manager),
     }
 }
 
@@ -374,6 +376,10 @@ pub(crate) fn install_package_manager(
 ) -> BuildpackResult<InstalledPackageManager> {
     match resolved_package_manager {
         ResolvedPackageManager::NpmBundled(bundled_version) => {
+            // print::sub_bullet(format!(
+            //     "Skipping, bundled {} will be used",
+            //     style::value(format!("npm@{npm_version}"))
+            // ));
             Ok(InstalledPackageManager::Npm(bundled_version.clone()))
         }
         ResolvedPackageManager::Npm(_, npm_package_packument) => {

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -207,14 +207,14 @@ pub(crate) enum ResolvedPackageManager {
 #[instrument(skip_all)]
 pub(crate) fn resolve_package_manager(
     context: &BuildpackBuildContext,
-    env: &mut Env,
+    env: &Env,
     requested_package_manager: &RequestedPackageManager,
 ) -> BuildpackResult<ResolvedPackageManager> {
     match requested_package_manager {
         RequestedPackageManager::BundledNpm => {
             let npm_version = npm::get_version(env)?;
-            tracing::info!({ { PACKAGE_MANAGER_NAME } = "npm", "package_manager" });
             tracing::info!({
+                { PACKAGE_MANAGER_NAME } = "npm",
                 { PACKAGE_MANAGER_VERSION } = npm_version.to_string(),
                 { PACKAGE_MANAGER_VERSION_MAJOR } = npm_version.major(),
                 "package_manager"
@@ -376,10 +376,6 @@ pub(crate) fn install_package_manager(
 ) -> BuildpackResult<InstalledPackageManager> {
     match resolved_package_manager {
         ResolvedPackageManager::NpmBundled(bundled_version) => {
-            // print::sub_bullet(format!(
-            //     "Skipping, bundled {} will be used",
-            //     style::value(format!("npm@{npm_version}"))
-            // ));
             Ok(InstalledPackageManager::Npm(bundled_version.clone()))
         }
         ResolvedPackageManager::Npm(_, npm_package_packument) => {

--- a/src/support_status.rs
+++ b/src/support_status.rs
@@ -57,7 +57,8 @@ pub(crate) fn check_npm_support_status(npm_version: &Version) -> BuildpackResult
 fn create_npm_unsupported_warning(npm_version: &Version) -> String {
     let npm_version = style::value(npm_version.to_string());
     let minimum_version = style::value(MINIMUM_SUPPORTED_NPM_VERSION.to_string());
-    let support_url = style::url(NPM_SUPPORT_URL);
+    let support_url =
+        style::url("https://devcenter.heroku.com/articles/nodejs-support#npm-version-policy");
     formatdoc! {"
         npm {npm_version} is no longer supported on Heroku. The npm maintainers only \
         make regular releases to the most recent major release-line and recommend \
@@ -70,78 +71,13 @@ fn create_npm_unsupported_warning(npm_version: &Version) -> String {
     "}
 }
 
-const NPM_SUPPORT_URL: &str =
-    "https://devcenter.heroku.com/articles/nodejs-support#npm-version-policy";
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bullet_stream::global;
-    use bullet_stream::strip_ansi;
-    use insta::{assert_snapshot, with_settings};
-    use std::path::PathBuf;
-    use test_support::test_name;
-
-    fn assert_warning_snapshot(warning: &str) {
-        let warning = strip_ansi(warning);
-        let test_name = test_name()
-            .replace("::", "_")
-            .replace("_tests", "")
-            .replace("_test", "");
-        let snapshot_path = std::env::var("CARGO_MANIFEST_DIR")
-            .map(PathBuf::from)
-            .expect("CARGO_MANIFEST_DIR should be set by Cargo")
-            .join("src/__snapshots");
-        with_settings!({
-            prepend_module_to_snapshot => false,
-            omit_expression => true,
-            snapshot_path => snapshot_path,
-        }, {
-            assert_snapshot!(test_name, warning);
-        });
-    }
+    use crate::utils::error_handling::test_util::assert_warning_snapshot;
 
     #[test]
     fn npm_unsupported_warning() {
         assert_warning_snapshot(&create_npm_unsupported_warning(&Version::new(8, 19, 4)));
-    }
-
-    #[test]
-    fn npm_version_below_minimum_emits_warning() {
-        let log = global::with_locked_writer(Vec::<u8>::new(), || {
-            let result = check_npm_support_status(&Version::new(8, 19, 4));
-            assert!(result.is_ok());
-        });
-        let output = String::from_utf8_lossy(&log);
-        assert!(
-            output.contains("no longer supported"),
-            "expected warning in output, got: {output}"
-        );
-    }
-
-    #[test]
-    fn npm_version_at_minimum_no_warning() {
-        let log = global::with_locked_writer(Vec::<u8>::new(), || {
-            let result = check_npm_support_status(&Version::new(9, 6, 4));
-            assert!(result.is_ok());
-        });
-        let output = String::from_utf8_lossy(&log);
-        assert!(
-            !output.contains("no longer supported"),
-            "unexpected warning in output: {output}"
-        );
-    }
-
-    #[test]
-    fn npm_version_above_minimum_no_warning() {
-        let log = global::with_locked_writer(Vec::<u8>::new(), || {
-            let result = check_npm_support_status(&Version::new(11, 0, 0));
-            assert!(result.is_ok());
-        });
-        let output = String::from_utf8_lossy(&log);
-        assert!(
-            !output.contains("no longer supported"),
-            "unexpected warning in output: {output}"
-        );
     }
 }

--- a/src/support_status.rs
+++ b/src/support_status.rs
@@ -36,7 +36,6 @@ fn create_eol_warning(version: &nodejs_data::Version) -> String {
     "}
 }
 
-#[allow(dead_code)]
 #[instrument(skip_all)]
 pub(crate) fn check_npm_support_status(npm_version: &Version) -> BuildpackResult<()> {
     if npm_version >= &*MINIMUM_SUPPORTED_NPM_VERSION {

--- a/src/support_status.rs
+++ b/src/support_status.rs
@@ -1,9 +1,11 @@
 use crate::BuildpackResult;
-use crate::o11y::RUNTIME_SUPPORT_STATUS;
+use crate::o11y::{PACKAGE_MANAGER_NPM_SUPPORT_STATUS, RUNTIME_SUPPORT_STATUS};
 use bullet_stream::global::print;
 use bullet_stream::style;
 use indoc::formatdoc;
-use nodejs_data::{NodejsArtifact, SUPPORTED_NODEJS_VERSIONS};
+use nodejs_data::{
+    MINIMUM_SUPPORTED_NPM_VERSION, NodejsArtifact, SUPPORTED_NODEJS_VERSIONS, Version,
+};
 use tracing::instrument;
 
 #[instrument(skip_all)]
@@ -32,4 +34,115 @@ fn create_eol_warning(version: &nodejs_data::Version) -> String {
 
         {support_url}
     "}
+}
+
+#[allow(dead_code)]
+#[instrument(skip_all)]
+pub(crate) fn check_npm_support_status(npm_version: &Version) -> BuildpackResult<()> {
+    if npm_version >= &*MINIMUM_SUPPORTED_NPM_VERSION {
+        tracing::info!(
+            { PACKAGE_MANAGER_NPM_SUPPORT_STATUS } = "supported",
+            "package_manager"
+        );
+        Ok(())
+    } else {
+        tracing::info!(
+            { PACKAGE_MANAGER_NPM_SUPPORT_STATUS } = "unsupported_warning",
+            "package_manager"
+        );
+        print::warning(create_npm_unsupported_warning(npm_version));
+        Ok(())
+    }
+}
+
+fn create_npm_unsupported_warning(npm_version: &Version) -> String {
+    let npm_version = style::value(npm_version.to_string());
+    let minimum_version = style::value(MINIMUM_SUPPORTED_NPM_VERSION.to_string());
+    let support_url = style::url(NPM_SUPPORT_URL);
+    formatdoc! {"
+        npm {npm_version} is no longer supported on Heroku. The npm maintainers only \
+        make regular releases to the most recent major release-line and recommend \
+        using the latest version of npm.
+
+        Please upgrade to npm {minimum_version} or later to avoid build failures in a \
+        future buildpack release.
+
+        {support_url}
+    "}
+}
+
+const NPM_SUPPORT_URL: &str =
+    "https://devcenter.heroku.com/articles/nodejs-support#npm-version-policy";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bullet_stream::global;
+    use bullet_stream::strip_ansi;
+    use insta::{assert_snapshot, with_settings};
+    use std::path::PathBuf;
+    use test_support::test_name;
+
+    fn assert_warning_snapshot(warning: &str) {
+        let warning = strip_ansi(warning);
+        let test_name = test_name()
+            .replace("::", "_")
+            .replace("_tests", "")
+            .replace("_test", "");
+        let snapshot_path = std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .expect("CARGO_MANIFEST_DIR should be set by Cargo")
+            .join("src/__snapshots");
+        with_settings!({
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+            snapshot_path => snapshot_path,
+        }, {
+            assert_snapshot!(test_name, warning);
+        });
+    }
+
+    #[test]
+    fn npm_unsupported_warning() {
+        assert_warning_snapshot(&create_npm_unsupported_warning(&Version::new(8, 19, 4)));
+    }
+
+    #[test]
+    fn npm_version_below_minimum_emits_warning() {
+        let log = global::with_locked_writer(Vec::<u8>::new(), || {
+            let result = check_npm_support_status(&Version::new(8, 19, 4));
+            assert!(result.is_ok());
+        });
+        let output = String::from_utf8_lossy(&log);
+        assert!(
+            output.contains("no longer supported"),
+            "expected warning in output, got: {output}"
+        );
+    }
+
+    #[test]
+    fn npm_version_at_minimum_no_warning() {
+        let log = global::with_locked_writer(Vec::<u8>::new(), || {
+            let result = check_npm_support_status(&Version::new(9, 6, 4));
+            assert!(result.is_ok());
+        });
+        let output = String::from_utf8_lossy(&log);
+        assert!(
+            !output.contains("no longer supported"),
+            "unexpected warning in output: {output}"
+        );
+    }
+
+    #[test]
+    fn npm_version_above_minimum_no_warning() {
+        let log = global::with_locked_writer(Vec::<u8>::new(), || {
+            let result = check_npm_support_status(&Version::new(11, 0, 0));
+            assert!(result.is_ok());
+        });
+        let output = String::from_utf8_lossy(&log);
+        assert!(
+            !output.contains("no longer supported"),
+            "unexpected warning in output: {output}"
+        );
+    }
 }

--- a/src/utils/error_handling.rs
+++ b/src/utils/error_handling.rs
@@ -152,23 +152,29 @@ pub(crate) mod test_util {
     use test_support::test_name;
 
     pub(crate) fn assert_error_snapshot(error: &ErrorMessage) {
-        let error_message = strip_ansi(error.to_string());
+        assert_snapshot_message(error.to_string());
+    }
+
+    pub(crate) fn assert_warning_snapshot(warning: &str) {
+        assert_snapshot_message(warning);
+    }
+
+    fn assert_snapshot_message(message: impl AsRef<str>) {
+        let message = strip_ansi(message.as_ref());
         let test_name = test_name()
             .replace("::", "_")
             .replace("_tests", "")
             .replace("_test", "");
         let snapshot_path = std::env::var("CARGO_MANIFEST_DIR")
             .map(PathBuf::from)
-            .expect(
-                "The CARGO_MANIFEST_DIR should be automatically set by Cargo when running tests",
-            )
+            .expect("CARGO_MANIFEST_DIR should be set by Cargo")
             .join("src/__snapshots");
         with_settings!({
             prepend_module_to_snapshot => false,
             omit_expression => true,
             snapshot_path => snapshot_path,
         }, {
-            assert_snapshot!(test_name, error_message);
+            assert_snapshot!(test_name, message);
         });
     }
 

--- a/tests/snapshots/node_eol_warning.snap
+++ b/tests/snapshots/node_eol_warning.snap
@@ -31,6 +31,13 @@ heroku/nodejs <buildpack-version>
 - Determining npm package information
   - No npm version requested
   - Using bundled npm version `9.6.3`
+
+! npm `9.6.3` is no longer supported on Heroku. The npm maintainers only make regular releases to the most recent major release-line and recommend using the latest version of npm.
+!
+! Please upgrade to npm `9.6.4` or later to avoid build failures in a future buildpack release.
+!
+! https://devcenter.heroku.com/articles/nodejs-support#npm-version-policy
+
 - Done (finished in <time_elapsed>)
 ===> EXPORTING
 Adding layer 'heroku/nodejs:available_parallelism'


### PR DESCRIPTION
## Summary
- Adds a minimum supported npm version constant (`9.6.4`, matching Node.js 20.0.0) to the `nodejs-data` crate
- Emits a build warning when the resolved npm version is below the minimum supported version
- Applies to both bundled and explicitly requested npm versions
- Adds telemetry tracking for npm support status

W-19793270