### PR TITLE
Fix pnpm 11 store dir env var and add config verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced `pnpm config set` commands with layer environment variables for configuring pnpm store and virtual store directories. This applies to all pnpm versions. ([#1369](https://github.com/heroku/buildpacks-nodejs/pull/1369))
+- Fixed pnpm 11 store directory configuration to use `pnpm_config_store_dir` env var instead of `npm_config_store_dir` which pnpm 11 no longer reads. Added runtime verification of pnpm store and virtual store directory configuration. ([#1370](https://github.com/heroku/buildpacks-nodejs/pull/1370))
 - Report bundled npm version in build output. ([#1366](https://github.com/heroku/buildpacks-nodejs/pull/1366))
 
 ## [5.5.8] - 2026-04-16

--- a/crates/test_support/src/lib.rs
+++ b/crates/test_support/src/lib.rs
@@ -72,6 +72,8 @@ pub fn integration_test_with_config(
     build_config.env("npm_config_fund", "false");
     // silence deprecation warnings from Node.js which cause unreliable output in snapshots
     build_config.env("NODE_OPTIONS", "--no-deprecation");
+    // suppress pnpm slow download warnings which cause non-deterministic output in snapshots
+    build_config.env("pnpm_config_fetch_min_speed_ki_bps", "0");
 
     with_config(&mut build_config);
 

--- a/src/package_managers/pnpm.rs
+++ b/src/package_managers/pnpm.rs
@@ -60,8 +60,11 @@ pub(crate) fn install_dependencies(
 ) -> BuildpackResult<()> {
     print::bullet("Setting up pnpm dependency store");
 
-    create_store_directory(context, env)?;
-    create_virtual_store_directory(context, env, version)?;
+    let store_dir = create_store_directory(context, env, version)?;
+    let virtual_store_dir = create_virtual_store_directory(context, env, version)?;
+
+    verify_pnpm_config(env, "store-dir", &store_dir);
+    verify_pnpm_config(env, "virtual-store-dir", &virtual_store_dir);
 
     print::bullet("Installing dependencies");
     print::sub_stream_cmd(
@@ -82,6 +85,7 @@ pub(crate) fn install_dependencies(
 fn create_store_directory(
     context: &BuildpackBuildContext,
     env: &mut Env,
+    version: &Version,
 ) -> BuildpackResult<PathBuf> {
     let new_metadata = PnpmCacheDirectoryLayerMetadata {
         layer_version: PNPM_CACHE_DIRECTORY_LAYER_VERSION.to_string(),
@@ -118,12 +122,17 @@ fn create_store_directory(
 
     let store_dir = pnpm_cache_layer.path();
 
-    // npm_config_store_dir is recognized by all pnpm versions (7+)
+    // pnpm 11 dropped npm_config_* env var support in favor of pnpm_config_*
+    let env_var_name = if version.major() >= 11 {
+        "pnpm_config_store_dir"
+    } else {
+        "npm_config_store_dir"
+    };
     let mut layer_env = LayerEnv::new();
     layer_env.insert(
         Scope::Build,
         ModificationBehavior::Override,
-        "npm_config_store_dir",
+        env_var_name,
         &store_dir,
     );
     pnpm_cache_layer.write_env(layer_env)?;
@@ -224,6 +233,22 @@ fn create_node_modules_symlink_error(error: &std::io::Error) -> ErrorMessage {
         " })
         .debug_info(error.to_string())
         .create()
+}
+
+fn verify_pnpm_config(env: &Env, config_key: &str, expected: &Path) {
+    let matches = Command::new("pnpm")
+        .args(["config", "get", config_key])
+        .envs(env)
+        .named_output()
+        .is_ok_and(|output| output.stdout_lossy().trim() == expected.to_string_lossy().as_ref());
+
+    if !matches {
+        let expected = file_value(expected);
+        print::warning(formatdoc! { "
+            pnpm config {config_key} is not set to the expected buildpack-managed directory ({expected}). \
+            This may result in slower builds due to reduced caching effectiveness.
+        "});
+    }
 }
 
 fn create_pnpm_install_command_error(error: &fun_run::CmdError) -> ErrorMessage {

--- a/tests/pnpm_integration_test.rs
+++ b/tests/pnpm_integration_test.rs
@@ -201,8 +201,13 @@ fn test_pnpm_10_workspace() {
 #[ignore = "integration test"]
 fn test_pnpm_11_workspace() {
     nodejs_integration_test("./fixtures/pnpm-11-workspace", |ctx| {
-        create_build_snapshot(&ctx.pack_stdout).assert();
+        let build_snapshot = create_build_snapshot(&ctx.pack_stdout);
         assert_web_response(&ctx, "pnpm-11-workspace");
+        let config = ctx.config.clone();
+        ctx.rebuild(config, |ctx| {
+            build_snapshot.rebuild_output(&ctx.pack_stdout).assert();
+            assert_web_response(&ctx, "pnpm-11-workspace");
+        });
     });
 }
 
@@ -210,7 +215,11 @@ fn test_pnpm_11_workspace() {
 #[ignore = "integration test"]
 fn test_pnpm_11() {
     nodejs_integration_test("./fixtures/pnpm-11", |ctx| {
-        create_build_snapshot(&ctx.pack_stdout).assert();
+        let build_snapshot = create_build_snapshot(&ctx.pack_stdout);
+        let config = ctx.config.clone();
+        ctx.rebuild(config, |ctx| {
+            build_snapshot.rebuild_output(&ctx.pack_stdout).assert();
+        });
     });
 }
 

--- a/tests/snapshots/test_pnpm_11.snap
+++ b/tests/snapshots/test_pnpm_11.snap
@@ -52,8 +52,8 @@ heroku/nodejs <buildpack-version>
   - Running `pnpm store prune`
 
       Removed all cached metadata files
-      Removed 16 files (88 kB)
-      Removed 2 packages
+      Removed 0 files (0 B)
+      Removed 0 packages
 
   - Done (<time_elapsed>)
 - Running scripts
@@ -94,5 +94,93 @@ Saving <image-name>...
 Adding cache layer 'heroku/nodejs:addressable'
 Adding cache layer 'heroku/nodejs:dist'
 Adding cache layer 'heroku/nodejs:pnpm'
+Adding cache layer 'heroku/nodejs:pnpm_packument'
+Successfully built image '<image-name>'
+
+--------------------------------------------- REBUILD ---------------------------------------------
+===> ANALYZING
+Restoring data for SBOM from previous image
+===> DETECTING
+heroku/nodejs <buildpack-version>
+===> RESTORING
+<restoring-output>
+===> BUILDING
+
+## Heroku Node.js
+
+- Checking Node.js version
+  - Detected Node.js version range: `22.x`
+  - Resolved Node.js version: `22.22.2`
+- Installing Node.js distribution
+  - Reusing Node.js 22.22.2 (<arch>)
+- Determining pnpm package information
+  - Found `packageManager` set to `pnpm@11.0.0` in `package.json`
+  - GET https://registry.npmjs.org/pnpm ... (Not Modified)
+  - Using cached packument for pnpm
+  - Resolved pnpm version `11.0.0` to `11.0.0`
+- Installing pnpm
+  - Using cached version of pnpm
+  - Successfully installed `pnpm@11.0.0`
+- Setting up pnpm dependency store
+  - Restoring pnpm content-addressable store from cache
+  - Creating pnpm virtual store
+- Installing dependencies
+  - Running `pnpm install --frozen-lockfile`
+
+      Lockfile is up to date, resolution step is skipped
+      Packages: +2
+      ++
+
+      dependencies:
+      + dotenv 16.4.5
+
+      devDependencies:
+      + environment 1.1.0
+
+      Done in <time_elapsed> using pnpm v11.0.0
+
+  - Done (<time_elapsed>)
+- Running scripts
+  - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm prune --prod --ignore-scripts`
+
+      Lockfile is up to date, resolution step is skipped
+      Packages: -1
+      -
+
+      devDependencies:
+      - environment 1.1.0
+
+  - Done (<time_elapsed>)
+- Removing non-deterministic build artifacts before export
+  - Removed pnpm metadata file node_modules/.modules.yaml
+- Done (finished in <time_elapsed>)
+===> EXPORTING
+Reusing layer 'heroku/nodejs:available_parallelism'
+Reusing layer 'heroku/nodejs:dist'
+Reusing layer 'heroku/nodejs:pnpm'
+Reusing layer 'heroku/nodejs:virtual'
+Reusing layer 'heroku/nodejs:web_env'
+Reusing layer 'heroku/nodejs:z_node_module_bins'
+Reusing layer 'buildpacksio/lifecycle:launch.sbom'
+Added 1/1 app layer(s)
+Reusing layer 'buildpacksio/lifecycle:launcher'
+Reusing layer 'buildpacksio/lifecycle:config'
+Adding label 'io.buildpacks.lifecycle.metadata'
+Adding label 'io.buildpacks.build.metadata'
+Adding label 'io.buildpacks.project.metadata'
+Adding label 'io.buildpacks.exec-env'
+no default process type
+Saving <image-name>...
+*** Images (<random-hex>):
+      <image-name>
+Reusing cache layer 'heroku/nodejs:addressable'
+Adding cache layer 'heroku/nodejs:addressable'
+Reusing cache layer 'heroku/nodejs:dist'
+Adding cache layer 'heroku/nodejs:dist'
+Reusing cache layer 'heroku/nodejs:pnpm'
+Adding cache layer 'heroku/nodejs:pnpm'
+Reusing cache layer 'heroku/nodejs:pnpm_packument'
 Adding cache layer 'heroku/nodejs:pnpm_packument'
 Successfully built image '<image-name>'

--- a/tests/snapshots/test_pnpm_11_workspace.snap
+++ b/tests/snapshots/test_pnpm_11_workspace.snap
@@ -50,8 +50,8 @@ heroku/nodejs <buildpack-version>
   - Running `pnpm store prune`
 
       Removed all cached metadata files
-      Removed 2681 files (39.6 MB)
-      Removed 86 packages
+      Removed 0 files (0 B)
+      Removed 0 packages
 
   - Done (<time_elapsed>)
 - Running scripts
@@ -95,5 +95,94 @@ Saving <image-name>...
 Adding cache layer 'heroku/nodejs:addressable'
 Adding cache layer 'heroku/nodejs:dist'
 Adding cache layer 'heroku/nodejs:pnpm'
+Adding cache layer 'heroku/nodejs:pnpm_packument'
+Successfully built image '<image-name>'
+
+--------------------------------------------- REBUILD ---------------------------------------------
+===> ANALYZING
+Restoring data for SBOM from previous image
+===> DETECTING
+heroku/nodejs <buildpack-version>
+===> RESTORING
+<restoring-output>
+===> BUILDING
+
+## Heroku Node.js
+
+- Checking Node.js version
+  - Detected Node.js version range: `22.x`
+  - Resolved Node.js version: `22.22.2`
+- Installing Node.js distribution
+  - Reusing Node.js 22.22.2 (<arch>)
+- Determining pnpm package information
+  - Found `packageManager` set to `pnpm@11.0.0` in `package.json`
+  - GET https://registry.npmjs.org/pnpm ... (Not Modified)
+  - Using cached packument for pnpm
+  - Resolved pnpm version `11.0.0` to `11.0.0`
+- Installing pnpm
+  - Using cached version of pnpm
+  - Successfully installed `pnpm@11.0.0`
+- Setting up pnpm dependency store
+  - Restoring pnpm content-addressable store from cache
+  - Creating pnpm virtual store
+- Installing dependencies
+  - Running `pnpm install --frozen-lockfile`
+
+      Scope: all 3 workspace projects
+      Lockfile is up to date, resolution step is skipped
+      Packages: +86
+      ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+      devDependencies:
+      + typescript 5.9.3
+
+      Done in <time_elapsed> using pnpm v11.0.0
+
+  - Done (<time_elapsed>)
+- Running scripts
+  - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm install --prod --frozen-lockfile`
+
+      Scope: all 3 workspace projects
+      Lockfile is up to date, resolution step is skipped
+      Packages: +70
+      ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+      devDependencies: skipped
+
+      Done in <time_elapsed> using pnpm v11.0.0
+
+  - Done (<time_elapsed>)
+- Removing non-deterministic build artifacts before export
+  - Removed pnpm metadata file node_modules/.modules.yaml
+- Done (finished in <time_elapsed>)
+===> EXPORTING
+Reusing layer 'heroku/nodejs:available_parallelism'
+Reusing layer 'heroku/nodejs:dist'
+Reusing layer 'heroku/nodejs:pnpm'
+Reusing layer 'heroku/nodejs:virtual'
+Reusing layer 'heroku/nodejs:web_env'
+Reusing layer 'heroku/nodejs:z_node_module_bins'
+Reusing layer 'buildpacksio/lifecycle:launch.sbom'
+Added 1/1 app layer(s)
+Reusing layer 'buildpacksio/lifecycle:launcher'
+Reusing layer 'buildpacksio/lifecycle:config'
+Reusing layer 'buildpacksio/lifecycle:process-types'
+Adding label 'io.buildpacks.lifecycle.metadata'
+Adding label 'io.buildpacks.build.metadata'
+Adding label 'io.buildpacks.project.metadata'
+Adding label 'io.buildpacks.exec-env'
+Setting default process type 'web'
+Saving <image-name>...
+*** Images (<random-hex>):
+      <image-name>
+Reusing cache layer 'heroku/nodejs:addressable'
+Adding cache layer 'heroku/nodejs:addressable'
+Reusing cache layer 'heroku/nodejs:dist'
+Adding cache layer 'heroku/nodejs:dist'
+Reusing cache layer 'heroku/nodejs:pnpm'
+Adding cache layer 'heroku/nodejs:pnpm'
+Reusing cache layer 'heroku/nodejs:pnpm_packument'
 Adding cache layer 'heroku/nodejs:pnpm_packument'
 Successfully built image '<image-name>'


### PR DESCRIPTION
## Summary

- Fix pnpm 11 store directory configuration to use `pnpm_config_store_dir` instead of `npm_config_store_dir` which pnpm 11 no longer reads
- Add runtime verification of pnpm store and virtual store directory configuration, emitting a warning if the values don't match the expected layer paths
- Add rebuild assertions to pnpm 11 tests to verify cache restoration works correctly
- Suppress non-deterministic pnpm slow download warnings in test output

Fixes W-22278389