### PR TITLE
Classify npm install-block failures into actionable build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - 26.4.0 (linux-amd64, linux-arm64)
+- Clearer build errors when npm blocks install scripts (`ESTRICTALLOWSCRIPTS`), git dependencies (`EALLOWGIT`), or remote-URL dependencies (`EALLOWREMOTE`). ([#1401](https://github.com/heroku/buildpacks-nodejs/pull/1401))
 
 ## [5.7.8] - 2026-06-24
 

--- a/src/__snapshots/package_managers_npm_npm_install_error_allow_git.snap
+++ b/src/__snapshots/package_managers_npm_npm_install_error_allow_git.snap
@@ -1,0 +1,18 @@
+---
+source: src/utils/error_handling.rs
+---
+- Debug Info:
+  - Command failed `npm ci`
+    exit status: 1
+    stdout: <empty>
+    stderr: npm error code EALLOWGIT
+
+! Failed to install Node modules (git dependency blocked)
+!
+! npm refused to fetch a dependency that points to a git repository, because git dependencies are disabled by default in npm 12+. Check the log output above for the offending package.
+!
+! Suggestions:
+! - Replace the git dependency with a published registry version.
+! - Set "allow-git" in your .npmrc to permit it.
+!
+! See https://docs.npmjs.com/cli/v11/using-npm/config#allow-git

--- a/src/__snapshots/package_managers_npm_npm_install_error_allow_remote.snap
+++ b/src/__snapshots/package_managers_npm_npm_install_error_allow_remote.snap
@@ -1,0 +1,18 @@
+---
+source: src/utils/error_handling.rs
+---
+- Debug Info:
+  - Command failed `npm ci`
+    exit status: 1
+    stdout: <empty>
+    stderr: npm error code EALLOWREMOTE
+
+! Failed to install Node modules (remote dependency blocked)
+!
+! npm refused to fetch a dependency that points to a remote URL (for example an https tarball), because remote dependencies are disabled by default in npm 12+. Check the log output above for the offending package.
+!
+! Suggestions:
+! - Replace the remote dependency with a published registry version.
+! - Set "allow-remote" in your .npmrc to permit it.
+!
+! See https://docs.npmjs.com/cli/v11/using-npm/config#allow-remote

--- a/src/__snapshots/package_managers_npm_npm_install_error_strict_allow_scripts.snap
+++ b/src/__snapshots/package_managers_npm_npm_install_error_strict_allow_scripts.snap
@@ -1,0 +1,17 @@
+---
+source: src/utils/error_handling.rs
+---
+- Debug Info:
+  - Command failed `npm ci`
+    exit status: 1
+    stdout: <empty>
+    stderr: npm error code ESTRICTALLOWSCRIPTS
+
+! Failed to install Node modules (install scripts blocked)
+!
+! npm blocked one or more dependencies' install scripts because they are not covered by the "allowScripts" policy in your package.json. Native modules that compile on install (for example via node-gyp) will not be built until you approve them.
+!
+! Suggestions:
+! - Run `npm approve-scripts <package>` locally to review and allow the trusted packages listed in the log output above, then commit the updated package.json and redeploy.
+!
+! See https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts

--- a/src/package_managers/npm.rs
+++ b/src/package_managers/npm.rs
@@ -2,7 +2,7 @@ use crate::cleanup::{CleanupTask, NodeGypArtifactLocation};
 use crate::utils::build_env::node_gyp_env;
 use crate::utils::error_handling::ErrorType::Internal;
 use crate::utils::error_handling::{
-    ErrorMessage, ErrorType, SuggestRetryBuild, SuggestSubmitIssue, error_message,
+    ErrorMessage, ErrorType, SuggestRetryBuild, SuggestSubmitIssue, error_codes, error_message,
 };
 use crate::utils::npm_registry;
 use crate::{BuildpackBuildContext, BuildpackResult};
@@ -169,51 +169,35 @@ fn create_set_npm_cache_directory_command_error(error: &fun_run::CmdError) -> Er
         .create()
 }
 
-/// Classification of an `npm ci` failure. Recognised npm 12 install-blocking modes plus a
-/// catch-all `Unknown` so the match in `create_npm_install_error` is total and any
-/// unrecognised failure deterministically falls back to the generic message.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub(crate) enum NpmInstallError {
-    /// ESTRICTALLOWSCRIPTS — install scripts blocked unless covered by the allowScripts policy.
-    StrictAllowScripts,
-    /// EALLOWGIT — git dependencies refused (allow-git not set).
-    AllowGit,
-    /// EALLOWREMOTE — remote-URL/tarball dependencies refused (allow-remote not set).
-    AllowRemote,
-    /// Any failure we do not specifically classify (network error, E404, ETARGET, etc.).
-    Unknown,
-}
+error_codes!(NpmError {
+    StrictAllowScripts => ESTRICTALLOWSCRIPTS,
+    AllowGit           => EALLOWGIT,
+    AllowRemote        => EALLOWREMOTE,
+});
 
-/// Pure classifier: maps an `npm ci` failure's captured output to an `NpmInstallError`.
-/// npm writes its `npm error code <CODE>` summary line to stderr, but stdout is matched too
-/// for robustness. Keyed on npm's stable error codes.
-fn determine_npm_install_error(std_out: &str, std_err: &str) -> NpmInstallError {
-    let combined = format!("{std_out}\n{std_err}");
-    if combined.contains("code ESTRICTALLOWSCRIPTS") {
-        NpmInstallError::StrictAllowScripts
-    } else if combined.contains("code EALLOWGIT") {
-        NpmInstallError::AllowGit
-    } else if combined.contains("code EALLOWREMOTE") {
-        NpmInstallError::AllowRemote
-    } else {
-        NpmInstallError::Unknown
-    }
-}
-
-fn cmd_error_output(error: &fun_run::CmdError) -> (String, String) {
-    match error {
-        fun_run::CmdError::NonZeroExitNotStreamed(out)
-        | fun_run::CmdError::NonZeroExitAlreadyStreamed(out) => {
-            (out.stdout_lossy(), out.stderr_lossy())
-        }
-        fun_run::CmdError::SystemError(_, _) => (String::new(), String::new()),
-    }
+/// Pure classifier: maps an `npm ci` failure's captured stderr to a recognised `NpmError`, or
+/// `None` for any failure we don't specifically classify (network error, E404, ETARGET, etc.).
+///
+/// npm writes its `npm error code <CODE>` summary line to stderr (it routes through `log.error`,
+/// which npm's display layer always sends to stderr). The code token following `npm error code `
+/// is extracted and matched exactly via `NpmError::from_code`, so one code can't match another by
+/// prefix.
+fn determine_npm_install_error(std_err: &str) -> Option<NpmError> {
+    std_err
+        .lines()
+        .filter_map(|line| line.split("npm error code ").nth(1))
+        .filter_map(|rest| rest.split_whitespace().next())
+        .find_map(NpmError::from_code)
 }
 
 fn create_npm_install_error(error: &fun_run::CmdError) -> ErrorMessage {
-    let (stdout, stderr) = cmd_error_output(error);
-    match determine_npm_install_error(&stdout, &stderr) {
-        NpmInstallError::StrictAllowScripts => error_message()
+    let stderr = match error {
+        fun_run::CmdError::NonZeroExitNotStreamed(out)
+        | fun_run::CmdError::NonZeroExitAlreadyStreamed(out) => out.stderr_lossy(),
+        fun_run::CmdError::SystemError(_, _) => String::new(),
+    };
+    match determine_npm_install_error(&stderr) {
+        Some(NpmError::StrictAllowScripts) => error_message()
             .id("package_manager/npm/install/strict_allow_scripts")
             .error_type(ErrorType::UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
             .header("Failed to install Node modules (install scripts blocked)")
@@ -230,7 +214,7 @@ fn create_npm_install_error(error: &fun_run::CmdError) -> ErrorMessage {
             " })
             .debug_info(error.to_string())
             .create(),
-        NpmInstallError::AllowGit => error_message()
+        Some(NpmError::AllowGit) => error_message()
             .id("package_manager/npm/install/allow_git")
             .error_type(ErrorType::UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
             .header("Failed to install Node modules (git dependency blocked)")
@@ -246,7 +230,7 @@ fn create_npm_install_error(error: &fun_run::CmdError) -> ErrorMessage {
             " })
             .debug_info(error.to_string())
             .create(),
-        NpmInstallError::AllowRemote => error_message()
+        Some(NpmError::AllowRemote) => error_message()
             .id("package_manager/npm/install/allow_remote")
             .error_type(ErrorType::UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
             .header("Failed to install Node modules (remote dependency blocked)")
@@ -263,7 +247,7 @@ fn create_npm_install_error(error: &fun_run::CmdError) -> ErrorMessage {
             " })
             .debug_info(error.to_string())
             .create(),
-        NpmInstallError::Unknown => {
+        None => {
             let npm_install = style::value(error.name());
             error_message()
                 .id("package_manager/npm/install")
@@ -389,40 +373,29 @@ mod tests {
     #[test]
     fn determine_npm_install_error_strict_allow_scripts() {
         assert_eq!(
-            determine_npm_install_error("", "npm error code ESTRICTALLOWSCRIPTS\n"),
-            NpmInstallError::StrictAllowScripts
+            determine_npm_install_error("npm error code ESTRICTALLOWSCRIPTS\n"),
+            Some(NpmError::StrictAllowScripts)
         );
     }
 
     #[test]
     fn determine_npm_install_error_allow_git() {
         assert_eq!(
-            determine_npm_install_error("", "npm error code EALLOWGIT\n"),
-            NpmInstallError::AllowGit
+            determine_npm_install_error("npm error code EALLOWGIT\n"),
+            Some(NpmError::AllowGit)
         );
     }
 
     #[test]
     fn determine_npm_install_error_allow_remote() {
         assert_eq!(
-            determine_npm_install_error("", "npm error code EALLOWREMOTE\n"),
-            NpmInstallError::AllowRemote
+            determine_npm_install_error("npm error code EALLOWREMOTE\n"),
+            Some(NpmError::AllowRemote)
         );
     }
 
     #[test]
     fn determine_npm_install_error_unknown() {
-        assert_eq!(
-            determine_npm_install_error("", "npm error code E404\n"),
-            NpmInstallError::Unknown
-        );
-    }
-
-    #[test]
-    fn determine_npm_install_error_matches_stdout() {
-        assert_eq!(
-            determine_npm_install_error("npm error code EALLOWGIT\n", ""),
-            NpmInstallError::AllowGit
-        );
+        assert_eq!(determine_npm_install_error("npm error code E404\n"), None);
     }
 }

--- a/src/package_managers/npm.rs
+++ b/src/package_managers/npm.rs
@@ -172,7 +172,6 @@ fn create_set_npm_cache_directory_command_error(error: &fun_run::CmdError) -> Er
 /// Classification of an `npm ci` failure. Recognised npm 12 install-blocking modes plus a
 /// catch-all `Unknown` so the match in `create_npm_install_error` is total and any
 /// unrecognised failure deterministically falls back to the generic message.
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(crate) enum NpmInstallError {
     /// ESTRICTALLOWSCRIPTS — install scripts blocked unless covered by the allowScripts policy.
@@ -188,7 +187,6 @@ pub(crate) enum NpmInstallError {
 /// Pure classifier: maps an `npm ci` failure's captured output to an `NpmInstallError`.
 /// npm writes its `npm error code <CODE>` summary line to stderr, but stdout is matched too
 /// for robustness. Keyed on npm's stable error codes.
-#[cfg_attr(not(test), allow(dead_code))]
 fn determine_npm_install_error(std_out: &str, std_err: &str) -> NpmInstallError {
     let combined = format!("{std_out}\n{std_err}");
     if combined.contains("code ESTRICTALLOWSCRIPTS") {
@@ -202,22 +200,87 @@ fn determine_npm_install_error(std_out: &str, std_err: &str) -> NpmInstallError 
     }
 }
 
-fn create_npm_install_error(error: &fun_run::CmdError) -> ErrorMessage {
-    let npm_install = style::value(error.name());
-    error_message()
-        .id("package_manager/npm/install")
-        .error_type(ErrorType::UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
-        .header("Failed to install Node modules")
-        .body(formatdoc! { "
-            The Heroku Node.js buildpack uses the command {npm_install} to install your Node modules. This command \
-            failed and the buildpack cannot continue. This error can occur due to an unstable network connection. See the log output above for more information.
+fn cmd_error_output(error: &fun_run::CmdError) -> (String, String) {
+    match error {
+        fun_run::CmdError::NonZeroExitNotStreamed(out)
+        | fun_run::CmdError::NonZeroExitAlreadyStreamed(out) => {
+            (out.stdout_lossy(), out.stderr_lossy())
+        }
+        fun_run::CmdError::SystemError(_, _) => (String::new(), String::new()),
+    }
+}
 
-            Suggestions:
-            - Ensure that this command runs locally without error (exit status = 0).
-            - Check the status of the upstream Node module repository service at https://status.npmjs.org/
-        " })
-        .debug_info(error.to_string())
-        .create()
+fn create_npm_install_error(error: &fun_run::CmdError) -> ErrorMessage {
+    let (stdout, stderr) = cmd_error_output(error);
+    match determine_npm_install_error(&stdout, &stderr) {
+        NpmInstallError::StrictAllowScripts => error_message()
+            .id("package_manager/npm/install/strict_allow_scripts")
+            .error_type(ErrorType::UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
+            .header("Failed to install Node modules (install scripts blocked)")
+            .body(formatdoc! { "
+                npm blocked one or more dependencies' install scripts because they are not covered by the \
+                \"allowScripts\" policy in your package.json. Native modules that compile on install (for \
+                example via node-gyp) will not be built until you approve them.
+
+                Suggestions:
+                - Run `npm approve-scripts <package>` locally to review and allow the trusted packages \
+                listed in the log output above, then commit the updated package.json and redeploy.
+
+                See https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts
+            " })
+            .debug_info(error.to_string())
+            .create(),
+        NpmInstallError::AllowGit => error_message()
+            .id("package_manager/npm/install/allow_git")
+            .error_type(ErrorType::UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
+            .header("Failed to install Node modules (git dependency blocked)")
+            .body(formatdoc! { "
+                npm refused to fetch a dependency that points to a git repository, because git dependencies \
+                are disabled by default in npm 12+. Check the log output above for the offending package.
+
+                Suggestions:
+                - Replace the git dependency with a published registry version.
+                - Set \"allow-git\" in your .npmrc to permit it.
+
+                See https://docs.npmjs.com/cli/v11/using-npm/config#allow-git
+            " })
+            .debug_info(error.to_string())
+            .create(),
+        NpmInstallError::AllowRemote => error_message()
+            .id("package_manager/npm/install/allow_remote")
+            .error_type(ErrorType::UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
+            .header("Failed to install Node modules (remote dependency blocked)")
+            .body(formatdoc! { "
+                npm refused to fetch a dependency that points to a remote URL (for example an https tarball), \
+                because remote dependencies are disabled by default in npm 12+. Check the log output above for \
+                the offending package.
+
+                Suggestions:
+                - Replace the remote dependency with a published registry version.
+                - Set \"allow-remote\" in your .npmrc to permit it.
+
+                See https://docs.npmjs.com/cli/v11/using-npm/config#allow-remote
+            " })
+            .debug_info(error.to_string())
+            .create(),
+        NpmInstallError::Unknown => {
+            let npm_install = style::value(error.name());
+            error_message()
+                .id("package_manager/npm/install")
+                .error_type(ErrorType::UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                .header("Failed to install Node modules")
+                .body(formatdoc! { "
+                    The Heroku Node.js buildpack uses the command {npm_install} to install your Node modules. This command \
+                    failed and the buildpack cannot continue. This error can occur due to an unstable network connection. See the log output above for more information.
+
+                    Suggestions:
+                    - Ensure that this command runs locally without error (exit status = 0).
+                    - Check the status of the upstream Node module repository service at https://status.npmjs.org/
+                " })
+                .debug_info(error.to_string())
+                .create()
+        }
+    }
 }
 
 const NPM_CACHE_DIRECTORY_LAYER_VERSION: &str = "1";
@@ -252,6 +315,24 @@ mod tests {
     use super::*;
     use crate::utils::error_handling::test_util::{assert_error_snapshot, create_cmd_error};
 
+    // Builds a CmdError whose captured stderr contains `output`, so error-classification
+    // paths can be exercised. `create_cmd_error` (which runs `false`) yields empty output.
+    fn cmd_error_with_output(name: &str, stderr: &str) -> fun_run::CmdError {
+        use fun_run::CommandWithName;
+        std::process::Command::new("sh")
+            .args([
+                "-c",
+                &format!("printf '%s' {} >&2; exit 1", shell_quote(stderr)),
+            ])
+            .named(name)
+            .named_output()
+            .unwrap_err()
+    }
+
+    fn shell_quote(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
     #[test]
     fn version_parse_error() {
         assert_error_snapshot(&create_get_npm_version_command_error(
@@ -279,6 +360,30 @@ mod tests {
     #[test]
     fn npm_install_error() {
         assert_error_snapshot(&create_npm_install_error(&create_cmd_error("npm ci")));
+    }
+
+    #[test]
+    fn npm_install_error_strict_allow_scripts() {
+        assert_error_snapshot(&create_npm_install_error(&cmd_error_with_output(
+            "npm ci",
+            "npm error code ESTRICTALLOWSCRIPTS\n",
+        )));
+    }
+
+    #[test]
+    fn npm_install_error_allow_git() {
+        assert_error_snapshot(&create_npm_install_error(&cmd_error_with_output(
+            "npm ci",
+            "npm error code EALLOWGIT\n",
+        )));
+    }
+
+    #[test]
+    fn npm_install_error_allow_remote() {
+        assert_error_snapshot(&create_npm_install_error(&cmd_error_with_output(
+            "npm ci",
+            "npm error code EALLOWREMOTE\n",
+        )));
     }
 
     #[test]

--- a/src/package_managers/npm.rs
+++ b/src/package_managers/npm.rs
@@ -169,6 +169,39 @@ fn create_set_npm_cache_directory_command_error(error: &fun_run::CmdError) -> Er
         .create()
 }
 
+/// Classification of an `npm ci` failure. Recognised npm 12 install-blocking modes plus a
+/// catch-all `Unknown` so the match in `create_npm_install_error` is total and any
+/// unrecognised failure deterministically falls back to the generic message.
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum NpmInstallError {
+    /// ESTRICTALLOWSCRIPTS — install scripts blocked unless covered by the allowScripts policy.
+    StrictAllowScripts,
+    /// EALLOWGIT — git dependencies refused (allow-git not set).
+    AllowGit,
+    /// EALLOWREMOTE — remote-URL/tarball dependencies refused (allow-remote not set).
+    AllowRemote,
+    /// Any failure we do not specifically classify (network error, E404, ETARGET, etc.).
+    Unknown,
+}
+
+/// Pure classifier: maps an `npm ci` failure's captured output to an `NpmInstallError`.
+/// npm writes its `npm error code <CODE>` summary line to stderr, but stdout is matched too
+/// for robustness. Keyed on npm's stable error codes.
+#[cfg_attr(not(test), allow(dead_code))]
+fn determine_npm_install_error(std_out: &str, std_err: &str) -> NpmInstallError {
+    let combined = format!("{std_out}\n{std_err}");
+    if combined.contains("code ESTRICTALLOWSCRIPTS") {
+        NpmInstallError::StrictAllowScripts
+    } else if combined.contains("code EALLOWGIT") {
+        NpmInstallError::AllowGit
+    } else if combined.contains("code EALLOWREMOTE") {
+        NpmInstallError::AllowRemote
+    } else {
+        NpmInstallError::Unknown
+    }
+}
+
 fn create_npm_install_error(error: &fun_run::CmdError) -> ErrorMessage {
     let npm_install = style::value(error.name());
     error_message()
@@ -246,5 +279,45 @@ mod tests {
     #[test]
     fn npm_install_error() {
         assert_error_snapshot(&create_npm_install_error(&create_cmd_error("npm ci")));
+    }
+
+    #[test]
+    fn determine_npm_install_error_strict_allow_scripts() {
+        assert_eq!(
+            determine_npm_install_error("", "npm error code ESTRICTALLOWSCRIPTS\n"),
+            NpmInstallError::StrictAllowScripts
+        );
+    }
+
+    #[test]
+    fn determine_npm_install_error_allow_git() {
+        assert_eq!(
+            determine_npm_install_error("", "npm error code EALLOWGIT\n"),
+            NpmInstallError::AllowGit
+        );
+    }
+
+    #[test]
+    fn determine_npm_install_error_allow_remote() {
+        assert_eq!(
+            determine_npm_install_error("", "npm error code EALLOWREMOTE\n"),
+            NpmInstallError::AllowRemote
+        );
+    }
+
+    #[test]
+    fn determine_npm_install_error_unknown() {
+        assert_eq!(
+            determine_npm_install_error("", "npm error code E404\n"),
+            NpmInstallError::Unknown
+        );
+    }
+
+    #[test]
+    fn determine_npm_install_error_matches_stdout() {
+        assert_eq!(
+            determine_npm_install_error("npm error code EALLOWGIT\n", ""),
+            NpmInstallError::AllowGit
+        );
     }
 }

--- a/src/utils/error_handling.rs
+++ b/src/utils/error_handling.rs
@@ -151,12 +151,10 @@ pub(crate) enum SuggestSubmitIssue {
 /// });
 /// ```
 ///
-/// The generated enum provides:
-/// - `code(self) -> &'static str` — the error code for a variant (exhaustive `match`, so omitting
-///   a variant won't compile).
-/// - `iter() -> impl Iterator<Item = Self>` — every variant, generated from the same list as
-///   `code()` so the two cannot drift as codes are added.
-/// - `from_code(&str) -> Option<Self>` — the variant for a code, or `None` if unrecognised.
+/// The generated enum provides `from_code(&str) -> Option<Self>`, returning the variant for a code
+/// or `None` if unrecognised. Generating the enum and `from_code` from the same list keeps the
+/// variants and their codes as a single source of truth, so adding a variant can't drift into a
+/// missing match arm.
 macro_rules! error_codes {
     ($name:ident { $($variant:ident => $code:ident),+ $(,)? }) => {
         #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -165,18 +163,11 @@ macro_rules! error_codes {
         }
 
         impl $name {
-            fn iter() -> impl Iterator<Item = $name> {
-                [$($name::$variant),+].into_iter()
-            }
-
-            fn code(self) -> &'static str {
-                match self {
-                    $($name::$variant => stringify!($code)),+
-                }
-            }
-
             fn from_code(code: &str) -> Option<$name> {
-                $name::iter().find(|e| e.code() == code)
+                match code {
+                    $(stringify!($code) => Some($name::$variant),)+
+                    _ => None,
+                }
             }
         }
     };

--- a/src/utils/error_handling.rs
+++ b/src/utils/error_handling.rs
@@ -141,6 +141,49 @@ pub(crate) enum SuggestSubmitIssue {
     No,
 }
 
+/// Defines a package-manager error enum keyed on the stable string error codes a package manager
+/// prints to its logs (e.g. npm's `ESTRICTALLOWSCRIPTS`). Each variant is paired with its code:
+///
+/// ```ignore
+/// error_codes!(NpmError {
+///     StrictAllowScripts => ESTRICTALLOWSCRIPTS,
+///     AllowGit           => EALLOWGIT,
+/// });
+/// ```
+///
+/// The generated enum provides:
+/// - `code(self) -> &'static str` — the error code for a variant (exhaustive `match`, so omitting
+///   a variant won't compile).
+/// - `iter() -> impl Iterator<Item = Self>` — every variant, generated from the same list as
+///   `code()` so the two cannot drift as codes are added.
+/// - `from_code(&str) -> Option<Self>` — the variant for a code, or `None` if unrecognised.
+macro_rules! error_codes {
+    ($name:ident { $($variant:ident => $code:ident),+ $(,)? }) => {
+        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+        pub(crate) enum $name {
+            $($variant),+
+        }
+
+        impl $name {
+            fn iter() -> impl Iterator<Item = $name> {
+                [$($name::$variant),+].into_iter()
+            }
+
+            fn code(self) -> &'static str {
+                match self {
+                    $($name::$variant => stringify!($code)),+
+                }
+            }
+
+            fn from_code(code: &str) -> Option<$name> {
+                $name::iter().find(|e| e.code() == code)
+            }
+        }
+    };
+}
+
+pub(crate) use error_codes;
+
 #[cfg(test)]
 pub(crate) mod test_util {
     use crate::utils::error_handling::ErrorMessage;


### PR DESCRIPTION
[npm v12 will refuse install scripts, git dependencies, and remote-URL dependencies by default](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/) unless an app explicitly opts in. Today these failures all surface as the buildpack's single generic "Failed to install Node modules" error, which tells a user nothing about why the install was rejected or how to unblock it — they're left to guess from the raw npm output.

This routes the three install-blocking npm error codes (`ESTRICTALLOWSCRIPTS`, `EALLOWGIT`, `EALLOWREMOTE`) into specific build errors that name what npm refused and point to the relevant remediation (approving scripts, or permitting git/remote dependencies in `.npmrc`), rather than nudging users to disable npm's protections buildpack-wide. Any unrecognized install failure still falls through to the existing generic message unchanged.

W-23160935