### PR TITLE
Work around Dependabot grouping bug preventing libcnb updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,20 @@ updates:
     groups:
       libcnb:
         patterns:
-          - "libcnb*"
+          - "libcnb"
+          - "libcnb-*"
           - "libherokubuildpack"
           - "sha2"
       rust-dependencies:
         update-types:
           - "minor"
           - "patch"
+        # Work around: https://github.com/dependabot/dependabot-core/issues/11093
+        exclude-patterns:
+          - "libcnb"
+          - "libcnb-*"
+          - "libherokubuildpack"
+          - "sha2"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The Dependabot grouping docs state that when multiple groups are specified, the first group defined wins:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

However, in practice this is broken and PRs are compared against all groups, and so can end up being placed in a later group - even one whose settings doesn't allow the PR to be opened during a later phase. This results in no PRs being opened for major libcnb version updates, since the PRs are misrouted to the main `rust-dependencies` group, but later filtered out by its `update-types: ["minor", "patch"]` rule.

See:
https://github.com/dependabot/dependabot-core/issues/11093

To work around this, we have to make the groups non-overlapping, by adding an explicit `exclude-patterns` to the other group.

GUS-W-23329202.
