### PR TITLE
Move libcnb dependencies to `[workspace.dependencies]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ fun_run = "0.6"
 hex = "0.4"
 http = "1"
 indoc = "2"
-libcnb = { version = "=0.30.4", features = ["trace"] }
-libherokubuildpack = { version = "=0.30.4", default-features = false, features = [
+libcnb = { workspace = true, features = ["trace"] }
+libherokubuildpack = { workspace = true, features = [
     "fs",
     "inventory",
     "inventory-sha2",
@@ -41,7 +41,7 @@ walkdir = "2.5.0"
 
 [dev-dependencies]
 insta = "1"
-libcnb-test = "=0.30.4"
+libcnb-test = { workspace = true }
 regex = "1"
 serde_json = "1"
 test_support.workspace = true
@@ -83,6 +83,9 @@ missing_panics_doc = "allow"
 available-parallelism = { path = "./crates/available-parallelism" }
 nodejs-data = { path = "./crates/nodejs-data" }
 test_support = { path = "./crates/test_support" }
+libcnb = "=0.30.4"
+libcnb-test = "=0.30.4"
+libherokubuildpack = { version = "=0.30.4", default-features = false }
 
 [profile.release]
 strip = true

--- a/crates/available-parallelism/Cargo.toml
+++ b/crates/available-parallelism/Cargo.toml
@@ -5,7 +5,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-libcnb = { version = "=0.30.4", default-features = false }
+libcnb = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/nodejs-data/Cargo.toml
+++ b/crates/nodejs-data/Cargo.toml
@@ -8,7 +8,7 @@ workspace = true
 
 [dependencies]
 fun_run = "0.6"
-libherokubuildpack = { version = "=0.30.4", default-features = false, features = [
+libherokubuildpack = { workspace = true, features = [
     "inventory",
     "inventory-sha2",
 ] }

--- a/crates/test_support/Cargo.toml
+++ b/crates/test_support/Cargo.toml
@@ -10,8 +10,8 @@ workspace = true
 bon = "3"
 indoc = "2"
 insta = { version = "1", features = ["filters"] }
-libcnb = "=0.30.4"
-libcnb-test = "=0.30.4"
+libcnb = { workspace = true }
+libcnb-test = { workspace = true }
 serde_json = "1"
 tempfile = "3"
 ureq = "3"

--- a/crates/xtask-update-nodejs-inventory/Cargo.toml
+++ b/crates/xtask-update-nodejs-inventory/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 [dependencies]
 clap = { version = "4", features = ["cargo", "derive"] }
 keep_a_changelog_file = "0.1.0"
-libherokubuildpack = { version = "=0.30.4", default-features = false, features = [
+libherokubuildpack = { workspace = true, features = [
     "inventory",
     "inventory-sha2",
 ] }


### PR DESCRIPTION
Dependabot's cargo updater can't update a manifest that is both a workspace root and a package: it routes such manifests only to the workspace-dependencies updater, so the root's own `[dependencies]` / `[dev-dependencies]` are left untouched. As a result PR #1409 bumped the member crates and `Cargo.lock` to libcnb 0.31.0 but left the root `Cargo.toml` at `=0.30.4`, which then causes an error due to lockfile out of sync.

Move `libcnb`, `libcnb-test`, and `libherokubuildpack` into `[workspace.dependencies]` and reference them via `workspace = true`, so the version is declared once (where Dependabot updates it) and inherited everywhere. Members keep their own feature sets.

`libherokubuildpack` carries `default-features = false` in the workspace entry, matching all consumers. `libcnb` defines no default feature, so dropping the members' `default-features = false` is a no-op. `Cargo.lock` is unchanged.

Upstream bug: https://github.com/dependabot/dependabot-core/issues/15410

GUS-W-23329202.
