### PR TITLE
Accept valid signatures from expired Node.js release keys

### DIFF
--- a/crates/xtask-update-nodejs-inventory/src/trusted_release_keys.rs
+++ b/crates/xtask-update-nodejs-inventory/src/trusted_release_keys.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 use sequoia_net::KeyServer;
-use sequoia_openpgp::parse::stream::{MessageLayer, MessageStructure, VerificationHelper};
+use sequoia_openpgp::parse::stream::{
+    MessageLayer, MessageStructure, VerificationError, VerificationHelper,
+};
 use sequoia_openpgp::{Cert, KeyHandle};
 use std::str::FromStr;
 
@@ -14,6 +16,7 @@ pub(super) async fn import() -> NodeReleaseKeys {
         gpg --keyserver hkps://keys.openpgp.org --recv-keys 890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 # Rafael Gonzaga
         gpg --keyserver hkps://keys.openpgp.org --recv-keys C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C # Richard Lau
         gpg --keyserver hkps://keys.openpgp.org --recv-keys 108F52B48DB57BB0CC439B2997B01419BD92F80A # Ruy Adorno
+        gpg --keyserver hkps://keys.openpgp.org --recv-keys 655F3B5C1FB3FA8D1A0CA6BDE4A7D232B936D2FD # Stewart X Addison
         gpg --keyserver hkps://keys.openpgp.org --recv-keys A363A499291CBBC940DD62E41F10027AF002F8B0 # Ulises Gascón
     ".trim().lines().map(|line| {
         let captures = Regex::from_str("gpg --keyserver (?<key_server>.*) --recv-keys (?<key>.*) # (?<owner>.*)")
@@ -80,7 +83,13 @@ impl VerificationHelper for NodeReleaseKeys {
                 MessageLayer::SignatureGroup { results } => {
                     for result in results {
                         if let Err(e) = result {
-                            panic!("Signature error: {e}")
+                            if is_acceptable_expired_key_signature(&e) {
+                                eprintln!(
+                                    "Warning: accepting a signature from an expired Node.js release key (the signature is still cryptographically valid): {e}"
+                                );
+                            } else {
+                                panic!("Signature error: {e}")
+                            }
                         }
                     }
                 }
@@ -89,5 +98,112 @@ impl VerificationHelper for NodeReleaseKeys {
             }
         }
         Ok(())
+    }
+}
+
+/// `gpg --verify` treats a signature from an expired key as valid (with a warning) as long as the
+/// signature itself is cryptographically sound. This has happened with a real Node.js release: the
+/// SHASUMS for v26.5.1 were signed on 2026-07-29 by a key that expired 2026-07-08. Sequoia's
+/// verifier is stricter — it short-circuits on the expired key and never reaches the cryptographic
+/// check, surfacing it as `VerificationError::BadKey`. To match `gpg`'s behavior without weakening
+/// our integrity guarantee, we accept a `BadKey` failure *only* when the key is expired (not revoked
+/// or otherwise unusable) *and* the signature is still cryptographically valid against the signed
+/// data.
+fn is_acceptable_expired_key_signature(error: &VerificationError<'_>) -> bool {
+    let VerificationError::BadKey { sig, ka, error } = error else {
+        return false;
+    };
+    // `BadKey` also covers revocation and non-signing-capable keys, which must remain hard failures.
+    // Only an expiration error (wrapped by Sequoia in a "not live" context) is acceptable.
+    let is_expired = error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<sequoia_openpgp::Error>(),
+            Some(sequoia_openpgp::Error::Expired(_))
+        )
+    });
+    // Re-run the cryptographic verification that Sequoia skipped once it decided the key was expired.
+    // The signature's digest was computed during streaming, so this checks the signature against the
+    // actual signed content.
+    is_expired && sig.verify_document(ka.key()).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sequoia_openpgp::cert::CertBuilder;
+    use sequoia_openpgp::crypto::HashAlgorithm;
+    use sequoia_openpgp::parse::Parse;
+    use sequoia_openpgp::parse::stream::DetachedVerifierBuilder;
+    use sequoia_openpgp::policy::StandardPolicy;
+    use sequoia_openpgp::serialize::stream::{Message, Signer};
+    use sequoia_openpgp::types::KeyFlags;
+    use std::io::Write;
+    use std::time::{Duration, SystemTime};
+
+    // Builds a signing-capable certificate that expired an hour ago, then produces a detached
+    // signature over `payload`. This mirrors the real Node.js scenario where a release signer's key
+    // has lapsed but they keep signing new releases with it.
+    fn expired_key_detached_signature(payload: &[u8]) -> (Cert, Vec<u8>) {
+        let created = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
+        let cert = CertBuilder::new()
+            .set_creation_time(created)
+            .set_validity_period(Duration::from_secs(60 * 60 * 23))
+            .set_primary_key_flags(KeyFlags::empty().set_signing())
+            .generate()
+            .expect("should generate a certificate")
+            .0;
+
+        let keypair = cert
+            .primary_key()
+            .key()
+            .clone()
+            .parts_into_secret()
+            .expect("generated cert should have a secret key")
+            .into_keypair()
+            .expect("should build a keypair");
+
+        let mut signature = vec![];
+        let message = Message::new(&mut signature);
+        let mut signer = Signer::new(message, keypair)
+            .expect("should build a signer")
+            .detached()
+            .build()
+            .expect("should build a detached signer");
+        signer.write_all(payload).expect("should sign payload");
+        signer.finalize().expect("should finalize signature");
+
+        (cert, signature)
+    }
+
+    fn verify(cert: &Cert, signature: &[u8], payload: &[u8]) -> sequoia_openpgp::Result<()> {
+        let mut policy = StandardPolicy::new();
+        policy.accept_hash(HashAlgorithm::SHA1);
+        let keys = NodeReleaseKeys {
+            certs: vec![cert.clone()],
+        };
+        DetachedVerifierBuilder::from_bytes(signature)?
+            .with_policy(&policy, None, keys)?
+            .verify_bytes(payload)
+    }
+
+    // A cryptographically valid signature from an expired key is accepted, matching `gpg --verify`,
+    // which treats key expiration as a warning rather than a failure.
+    #[test]
+    fn accepts_valid_signature_from_expired_key() {
+        let payload = b"deadbeef  node-v99.0.0-linux-x64.tar.gz\n";
+        let (cert, signature) = expired_key_detached_signature(payload);
+        verify(&cert, &signature, payload)
+            .expect("valid signature from an expired key is accepted");
+    }
+
+    // A tampered payload must still be rejected even when the signing key is expired — the expired
+    // key exception must not become a way to accept unverified content.
+    #[test]
+    #[should_panic(expected = "Signature error")]
+    fn rejects_tampered_payload_from_expired_key() {
+        let payload = b"deadbeef  node-v99.0.0-linux-x64.tar.gz\n";
+        let (cert, signature) = expired_key_detached_signature(payload);
+        let tampered = b"ba5eba11  node-v99.0.0-linux-x64.tar.gz\n";
+        let _ = verify(&cert, &signature, tampered);
     }
 }


### PR DESCRIPTION
gpg treats a signature from an expired key as valid — emitting a warning but still verifying the release — as long as the signature itself is cryptographically sound. Our inventory updater is stricter and treats any verification error as fatal, so it panics instead. This happened with a real release: the v26.5.1 SHASUMS were signed on 2026-07-29 by a key that expired 2026-07-08, which blocked the scheduled inventory update until the signer rotated their key.

This makes releases succeed the way gpg does, without weakening our integrity guarantee: an expired key is only accepted when its signature is still cryptographically valid, and revoked or otherwise-invalid keys remain hard failures. The accepted-expired-key path is logged as a warning so the condition stays visible in the update runs.

W-23632862