### PR TITLE
Add pnpm 12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for pnpm 12, which distributes its native binary as a separate platform-specific package. ([#1438](https://github.com/heroku/buildpacks-nodejs/pull/1438))
+
 ## [5.7.15] - 2026-08-27
 
 ### Added

--- a/crates/test_support/src/snapshot_filters.rs
+++ b/crates/test_support/src/snapshot_filters.rs
@@ -1,4 +1,5 @@
 #[allow(clippy::vec_init_then_push)]
+#[allow(clippy::too_many_lines)]
 pub(super) fn create_snapshot_filters() -> Vec<(String, String)> {
     let mut filters: Vec<(&str, &str)> = vec![];
 
@@ -343,6 +344,41 @@ pub(super) fn create_snapshot_filters() -> Vec<(String, String)> {
     filters.push((
         r"( *).*gyp info.*\n(?:.*\n)*? *.*gyp info ok",
         "${1}<NODE-GYP BUILD OUTPUT>",
+    ));
+
+    // [pnpm] Supply-chain policy verification start line (pnpm 12+). The entry count reflects the
+    //        number of lockfile entries being verified and changes as dependencies are added or
+    //        removed. e.g.;
+    // - ? Verifying lockfile against supply-chain policies (85 entries)...
+    filters.push((
+        r"Verifying lockfile against supply-chain policies \(\d+ entries\)",
+        "Verifying lockfile against supply-chain policies (<N> entries)",
+    ));
+
+    // [pnpm] Supply-chain policy check summary plus the adjacent "lockfile is up to date" notice
+    //        (pnpm 12+). pnpm runs supply-chain verification on a task that deliberately overlaps
+    //        package fetch/link work, and its append-only reporter prints events in arrival order.
+    //        As a result this two-line block races with the "Packages are hard linked..." block and
+    //        lands before or after it non-deterministically. Since the ordering (not just the entry
+    //        count/timing content) is non-deterministic, remove the block entirely rather than
+    //        normalize it. The verification line is always emitted immediately before the buffered
+    //        "lockfile is up to date" line, so matching them adjacently keeps this scoped to pnpm 12
+    //        and leaves the standalone pnpm <= 11 "lockfile is up to date" line untouched. e.g.;
+    // -      ✓ Lockfile passes supply-chain policies (2 entries in 632ms)
+    //        Lockfile is up to date, resolution step is skipped
+    // -      ✓ Lockfile passes supply-chain policies (verified 144ms ago)
+    //        Lockfile is up to date, resolution step is skipped
+    filters.push((
+        r" *✓ Lockfile passes supply-chain policies \([^)]*\)\n *Lockfile is up to date, resolution step is skipped\n",
+        "",
+    ));
+
+    // [pnpm] Store integrity check notice (pnpm 12+). The count of files checked is
+    //        non-deterministic. e.g.;
+    // - The integrity of 2681 files was checked, because their timestamps changed since the store recorded them. A backup tool, an antivirus scan, or a copied store can cause this.
+    filters.push((
+        r"The integrity of \d+ files was checked",
+        "The integrity of <N> files was checked",
     ));
 
     // [npm] Filter out the resolved npm version when `engines.npm` is set to `11.x` (latest).

--- a/src/__snapshots/package_managers_pnpm_pnpm_native_binary_install_error.snap
+++ b/src/__snapshots/package_managers_pnpm_pnpm_native_binary_install_error.snap
@@ -1,0 +1,14 @@
+---
+source: src/utils/error_handling.rs
+---
+- Debug Info:
+  - Permission denied
+
+! Failed to install the pnpm native binary
+!
+! An unexpected I/O error occurred while installing the pnpm native binary at `/layers/heroku_nodejs/pnpm/pnpm`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-nodejs/issues
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/package_managers_pnpm_pnpm_unsupported_target_error.snap
+++ b/src/__snapshots/package_managers_pnpm_pnpm_unsupported_target_error.snap
@@ -1,0 +1,11 @@
+---
+source: src/utils/error_handling.rs
+---
+! Unsupported pnpm target
+!
+! pnpm 12 and later ship their native binary as a platform-specific package, but the buildpack does not know which package to use for the current build target (`windows-arm64`).
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-nodejs/issues
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/package_managers/pnpm.rs
+++ b/src/package_managers/pnpm.rs
@@ -4,7 +4,11 @@ use crate::utils::build_env::node_gyp_env;
 use crate::utils::error_handling::{
     ErrorMessage, ErrorType, SuggestRetryBuild, SuggestSubmitIssue, error_message, file_value,
 };
-use crate::utils::npm_registry::{PackagePackument, packument_layer, resolve_package_packument};
+use crate::utils::npm_registry::{
+    InstallPackageLayerError, PackagePackument, apply_package_layer_env, cached_package_layer,
+    exclude_package_docs, extract_package_tarball, install_package_layer_metadata,
+    link_package_bins, packument_layer, resolve_package_packument,
+};
 use crate::{BuildpackBuildContext, BuildpackResult, utils};
 use bullet_stream::global::print;
 use bullet_stream::style;
@@ -42,14 +46,148 @@ pub(crate) fn install_pnpm(
     pnpm_packument: &PackagePackument,
     node_version: &Version,
 ) -> BuildpackResult<()> {
-    utils::npm_registry::install_package_layer(
-        layer_name!("pnpm"),
-        context,
-        env,
-        pnpm_packument,
-        node_version,
-    )?;
+    // Starting with pnpm 12, the published `pnpm` npm package is a thin wrapper: its tarball ships
+    // a placeholder `pnpm` bin plus a `preinstall` script (`install.js`) that hard-links the real,
+    // platform-specific native binary — distributed separately as `@pnpm/exe.<target>` optional
+    // dependencies — over that placeholder. The buildpack installs from the tarball directly and
+    // never runs npm lifecycle scripts, so pnpm 12+ needs its own install path that relinks the
+    // native binary once the wrapper is extracted.
+    if pnpm_packument.version.major() >= 12 {
+        install_pnpm_layer_with_native_binary_overlay(context, env, pnpm_packument, node_version)
+    } else {
+        utils::npm_registry::install_package_layer(
+            layer_name!("pnpm"),
+            context,
+            env,
+            pnpm_packument,
+            node_version,
+        )?;
+        Ok(())
+    }
+}
+
+/// Installs the pnpm 12+ wrapper package into a cached layer, then overlays the platform-specific
+/// native binary over the wrapper's placeholder `pnpm` bin. This is the same composition as the
+/// generic `install_package_layer` with the native-binary overlay inserted inline in the
+/// layer-population branch: it runs only when the layer is populated (never on a cache hit) and
+/// before the layer metadata is written, so a failed overlay leaves the layer incomplete and the
+/// next build repopulates it rather than caching a broken placeholder.
+fn install_pnpm_layer_with_native_binary_overlay(
+    context: &BuildpackBuildContext,
+    env: &mut Env,
+    pnpm_packument: &PackagePackument,
+    node_version: &Version,
+) -> BuildpackResult<()> {
+    let new_metadata = install_package_layer_metadata(context, pnpm_packument, node_version);
+    let layer = cached_package_layer(layer_name!("pnpm"), context, &new_metadata)?;
+
+    if matches!(layer.state, LayerState::Empty { .. }) {
+        extract_package_tarball(
+            &pnpm_packument.dist.tarball,
+            &layer.path(),
+            exclude_package_docs,
+        )
+        .map_err(|e| InstallPackageLayerError::Download(Box::new(pnpm_packument.clone()), e))?;
+
+        link_package_bins(pnpm_packument, &layer.path())?;
+
+        // Overlay the native binary over the wrapper's placeholder before the layer is marked
+        // complete, so a failed overlay is never captured in a cached layer. The native binary is
+        // pinned to the wrapper's exact version, so it is only resolved and downloaded while
+        // (re)populating the layer — a cache hit needs neither.
+        let native_binary_packument =
+            resolve_pnpm_native_binary_packument(context, &pnpm_packument.version)?;
+        install_pnpm_native_binary(&native_binary_packument, &layer.path())?;
+
+        layer
+            .write_metadata(new_metadata)
+            .map_err(|e| InstallPackageLayerError::Layer(Box::new(e)))?;
+    }
+
+    apply_package_layer_env(&layer, env)?;
+
     Ok(())
+}
+
+/// Resolves the packument for the `@pnpm/exe.<target>` package that ships the native pnpm binary
+/// for the current build target, pinned to the same version as the wrapper package.
+fn resolve_pnpm_native_binary_packument(
+    context: &BuildpackBuildContext,
+    version: &Version,
+) -> BuildpackResult<PackagePackument> {
+    let package_name = pnpm_native_binary_package_name(&context.target.os, &context.target.arch)?;
+    let requirement = VersionRange::parse(&version.to_string())
+        .expect("A pnpm version should be a valid version requirement");
+    resolve_package_packument(
+        &packument_layer(layer_name!("pnpm_exe_packument"), context, &package_name)?,
+        &requirement,
+    )
+    .map_err(Into::into)
+}
+
+/// Maps the build target to the `@pnpm/exe.<target>` package that ships its native binary. Heroku
+/// base images are glibc-based, so the musl variants are never selected.
+fn pnpm_native_binary_package_name(os: &str, arch: &str) -> BuildpackResult<String> {
+    match (os, arch) {
+        ("linux", "amd64") => Ok("@pnpm/exe.linux-x64".to_string()),
+        ("linux", "arm64") => Ok("@pnpm/exe.linux-arm64".to_string()),
+        _ => Err(create_pnpm_unsupported_target_error(os, arch).into()),
+    }
+}
+
+/// Downloads the native pnpm binary package and moves its executable over the wrapper's placeholder
+/// bin. The wrapper's `bin/pnpm` symlink already points at `<layer>/pnpm`, so replacing that file
+/// activates the native binary.
+fn install_pnpm_native_binary(
+    native_binary_packument: &PackagePackument,
+    pnpm_layer_dir: &Path,
+) -> BuildpackResult<()> {
+    let scratch_dir = pnpm_layer_dir.join(".native-binary");
+    extract_package_tarball(
+        &native_binary_packument.dist.tarball,
+        &scratch_dir,
+        // The package ships the executable alongside license files; only the binary is needed.
+        |path| path != Path::new("pnpm"),
+    )
+    .map_err(|e| {
+        InstallPackageLayerError::Download(Box::new(native_binary_packument.clone()), e)
+    })?;
+
+    let native_pnpm_binary = scratch_dir.join("pnpm");
+    let original_pnpm_binary = pnpm_layer_dir.join("pnpm");
+    fs::rename(&native_pnpm_binary, &original_pnpm_binary)
+        .map_err(|e| create_pnpm_native_binary_install_error(&original_pnpm_binary, &e))?;
+
+    fs::remove_dir_all(&scratch_dir)
+        .map_err(|e| create_pnpm_native_binary_install_error(&scratch_dir, &e))?;
+
+    Ok(())
+}
+
+fn create_pnpm_unsupported_target_error(os: &str, arch: &str) -> ErrorMessage {
+    let target = style::value(format!("{os}-{arch}"));
+    error_message()
+        .id("package_manager/pnpm/unsupported_native_binary_target")
+        .error_type(ErrorType::Internal)
+        .header("Unsupported pnpm target")
+        .body(formatdoc! { "
+            pnpm 12 and later ship their native binary as a platform-specific package, but the \
+            buildpack does not know which package to use for the current build target ({target}).
+        " })
+        .create()
+}
+
+fn create_pnpm_native_binary_install_error(path: &Path, error: &std::io::Error) -> ErrorMessage {
+    let path = file_value(path);
+    error_message()
+        .id("package_manager/pnpm/install_native_binary")
+        .error_type(ErrorType::Internal)
+        .header("Failed to install the pnpm native binary")
+        .body(formatdoc! { "
+            An unexpected I/O error occurred while installing the pnpm native binary at {path}.
+        " })
+        .debug_info(error.to_string())
+        .create()
 }
 
 pub(crate) fn install_dependencies(
@@ -649,5 +787,18 @@ mod tests {
         let json_error =
             serde_json::from_str::<Vec<serde_json::Value>>("invalid json").unwrap_err();
         assert_error_snapshot(&create_parse_pnpm_list_output_error(&json_error));
+    }
+
+    #[test]
+    fn pnpm_unsupported_target_error() {
+        assert_error_snapshot(&create_pnpm_unsupported_target_error("windows", "arm64"));
+    }
+
+    #[test]
+    fn pnpm_native_binary_install_error() {
+        assert_error_snapshot(&create_pnpm_native_binary_install_error(
+            &PathBuf::from("/layers/heroku_nodejs/pnpm/pnpm"),
+            &std::io::Error::other("Permission denied"),
+        ));
     }
 }

--- a/src/utils/npm_registry.rs
+++ b/src/utils/npm_registry.rs
@@ -5,7 +5,7 @@ use crate::utils::error_handling::{
 use crate::utils::http::{
     DownloadError, DownloadTask, Extractor, GetError, GetRequest, GzipOptions, download, get,
 };
-use crate::{BuildpackBuildContext, BuildpackError};
+use crate::{BuildpackBuildContext, BuildpackError, NodeJsBuildpack};
 use bullet_stream::global::print;
 use bullet_stream::style;
 use http::{HeaderMap, HeaderValue, StatusCode};
@@ -13,7 +13,8 @@ use indoc::formatdoc;
 use libcnb::Env;
 use libcnb::data::layer::LayerName;
 use libcnb::layer::{
-    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
+    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerRef, LayerState,
+    RestoredLayerAction,
 };
 use libcnb::layer_env::Scope;
 use nodejs_data::{Version, VersionRange};
@@ -329,6 +330,14 @@ fn create_resolve_package_packument_error(
         .create()
 }
 
+/// A reference to the cached layer an npm-registry package is installed into. Named here so the
+/// composable install steps below can hand it between one another.
+pub(crate) type InstallPackageLayerRef = LayerRef<NodeJsBuildpack, (), Vec<String>>;
+
+/// Installs a package from the npm registry into a cached layer for npm, Yarn, and pnpm < 12. It
+/// is assembled from the composable steps below; a package manager that needs an extra
+/// post-extraction step (such as pnpm 12+) reuses the same steps and inserts its own work into the
+/// layer-population branch rather than extending this function.
 pub(crate) fn install_package_layer(
     layer_name: LayerName,
     context: &BuildpackBuildContext,
@@ -336,19 +345,57 @@ pub(crate) fn install_package_layer(
     package_packument: &PackagePackument,
     node_version: &Version,
 ) -> Result<PathBuf, InstallPackageLayerError> {
-    let package_name = &package_packument.name;
-    let package_version = &package_packument.version;
+    let new_metadata = install_package_layer_metadata(context, package_packument, node_version);
+    let layer = cached_package_layer(layer_name, context, &new_metadata)?;
 
-    let new_metadata = InstallPackageLayerMetadata {
+    if matches!(layer.state, LayerState::Empty { .. }) {
+        extract_package_tarball(
+            &package_packument.dist.tarball,
+            &layer.path(),
+            exclude_package_docs,
+        )
+        .map_err(|e| InstallPackageLayerError::Download(Box::new(package_packument.clone()), e))?;
+
+        link_package_bins(package_packument, &layer.path())?;
+
+        layer
+            .write_metadata(new_metadata)
+            .map_err(|e| InstallPackageLayerError::Layer(Box::new(e)))?;
+    }
+
+    apply_package_layer_env(&layer, env)?;
+
+    Ok(layer.path())
+}
+
+/// Builds the metadata that identifies an installed package layer and drives its cache
+/// invalidation.
+pub(crate) fn install_package_layer_metadata(
+    context: &BuildpackBuildContext,
+    package_packument: &PackagePackument,
+    node_version: &Version,
+) -> InstallPackageLayerMetadata {
+    InstallPackageLayerMetadata {
         node_version: node_version.to_string(),
-        package_name: package_name.clone(),
-        package_version: package_version.to_string(),
+        package_name: package_packument.name.clone(),
+        package_version: package_packument.version.to_string(),
         layer_version: INSTALL_PACKAGE_LAYER_VERSION.to_string(),
         arch: context.target.arch.clone(),
         os: context.target.os.clone(),
-    };
+    }
+}
 
-    let install_package_layer = context
+/// Defines (or restores) the cached layer a package is installed into and reports its cache state
+/// to the build log. The caller populates the returned layer when its state is
+/// [`LayerState::Empty`].
+pub(crate) fn cached_package_layer(
+    layer_name: LayerName,
+    context: &BuildpackBuildContext,
+    new_metadata: &InstallPackageLayerMetadata,
+) -> Result<InstallPackageLayerRef, InstallPackageLayerError> {
+    let package_name = &new_metadata.package_name;
+
+    let layer = context
         .cached_layer(
             layer_name,
             CachedLayerDefinition {
@@ -356,12 +403,12 @@ pub(crate) fn install_package_layer(
                 launch: true,
                 invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
                 restored_layer_action: &|old_metadata: &InstallPackageLayerMetadata, _| {
-                    if old_metadata == &new_metadata {
+                    if old_metadata == new_metadata {
                         Ok((RestoredLayerAction::KeepLayer, vec![]))
                     } else {
                         Ok((
                             RestoredLayerAction::DeleteLayer,
-                            install_layer_changed_metadata_fields(old_metadata, &new_metadata),
+                            install_layer_changed_metadata_fields(old_metadata, new_metadata),
                         ))
                     }
                 },
@@ -369,71 +416,86 @@ pub(crate) fn install_package_layer(
         )
         .map_err(|e| InstallPackageLayerError::Layer(Box::new(e)))?;
 
-    match install_package_layer.state {
+    match &layer.state {
         LayerState::Restored { .. } => {
             print::sub_bullet(format!("Using cached version of {package_name}"));
         }
-        LayerState::Empty { ref cause } => {
-            if let EmptyLayerCause::RestoredLayerAction { cause } = cause {
-                print::sub_bullet(format!(
-                    "Invalidating cached {package_name} ({} changed)",
-                    cause.join(", ")
-                ));
-            }
-
-            download(
-                &DownloadTask::builder(
-                    &package_packument.dist.tarball,
-                    install_package_layer.path(),
-                )
-                .extractor(Extractor::Gzip(GzipOptions {
-                    strip_components: 1,
-                    exclude: Box::new(|path| {
-                        path.components()
-                            .take(1)
-                            .next()
-                            .is_some_and(|c| c.as_os_str() == "docs" || c.as_os_str() == "man")
-                    }),
-                }))
-                .build(),
-            )
-            .map_err(|e| {
-                InstallPackageLayerError::Download(Box::new(package_packument.clone()), e)
-            })?;
-
-            // Create symlinks for all binaries declared in packument's `bin` field
-            let bins = package_packument.bin.as_ref().ok_or_else(|| {
-                InstallPackageLayerError::MissingBins(Box::new(package_packument.clone()))
-            })?;
-            for (name, script) in bins {
-                let bin_path = install_package_layer.path().join("bin").join(name);
-                let script_path = install_package_layer.path().join(script);
-                match std::fs::remove_file(&bin_path) {
-                    Ok(()) => Ok(()),
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-                    Err(e) => Err(InstallPackageLayerError::WriteBin(
-                        Box::new(package_packument.clone()),
-                        e,
-                    )),
-                }?;
-                std::os::unix::fs::symlink(script_path, bin_path).map_err(|e| {
-                    InstallPackageLayerError::WriteBin(Box::new(package_packument.clone()), e)
-                })?;
-            }
-
-            install_package_layer
-                .write_metadata(new_metadata)
-                .map_err(|e| InstallPackageLayerError::Layer(Box::new(e)))?;
+        LayerState::Empty {
+            cause: EmptyLayerCause::RestoredLayerAction { cause },
+        } => {
+            print::sub_bullet(format!(
+                "Invalidating cached {package_name} ({} changed)",
+                cause.join(", ")
+            ));
         }
+        LayerState::Empty { .. } => {}
     }
 
-    let layer_env = &install_package_layer
+    Ok(layer)
+}
+
+/// Downloads a package tarball from the npm registry and extracts it into `destination`, stripping
+/// the leading archive directory and skipping any path matched by `exclude`.
+pub(crate) fn extract_package_tarball(
+    tarball_url: &str,
+    destination: &Path,
+    exclude: impl Fn(&Path) -> bool + 'static,
+) -> Result<(), DownloadError> {
+    download(
+        &DownloadTask::builder(tarball_url, destination)
+            .extractor(Extractor::Gzip(GzipOptions {
+                strip_components: 1,
+                exclude: Box::new(exclude),
+            }))
+            .build(),
+    )
+}
+
+/// The default exclusion for an extracted package tarball: documentation and man pages are not
+/// needed at runtime.
+pub(crate) fn exclude_package_docs(path: &Path) -> bool {
+    path.components()
+        .next()
+        .is_some_and(|c| c.as_os_str() == "docs" || c.as_os_str() == "man")
+}
+
+/// Symlinks every binary declared in the packument's `bin` field into `<layer>/bin`, replacing any
+/// pre-existing entry.
+pub(crate) fn link_package_bins(
+    package_packument: &PackagePackument,
+    layer_dir: &Path,
+) -> Result<(), InstallPackageLayerError> {
+    let bins = package_packument.bin.as_ref().ok_or_else(|| {
+        InstallPackageLayerError::MissingBins(Box::new(package_packument.clone()))
+    })?;
+    for (name, script) in bins {
+        let bin_path = layer_dir.join("bin").join(name);
+        let script_path = layer_dir.join(script);
+        match std::fs::remove_file(&bin_path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(InstallPackageLayerError::WriteBin(
+                Box::new(package_packument.clone()),
+                e,
+            )),
+        }?;
+        std::os::unix::fs::symlink(script_path, bin_path).map_err(|e| {
+            InstallPackageLayerError::WriteBin(Box::new(package_packument.clone()), e)
+        })?;
+    }
+    Ok(())
+}
+
+/// Applies the installed layer's build environment to `env`.
+pub(crate) fn apply_package_layer_env(
+    layer: &InstallPackageLayerRef,
+    env: &mut Env,
+) -> Result<(), InstallPackageLayerError> {
+    let layer_env = layer
         .read_env()
         .map_err(|e| InstallPackageLayerError::Layer(Box::new(e)))?;
-
     env.clone_from(&layer_env.apply(Scope::Build, env));
-
-    Ok(install_package_layer.path().clone())
+    Ok(())
 }
 
 pub(crate) enum InstallPackageLayerError {

--- a/tests/fixtures/pnpm-12-workspace/package.json
+++ b/tests/fixtures/pnpm-12-workspace/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pnpm-workspace-test",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@12.1.0",
+  "scripts": {
+    "start": "node packages/server/index.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": "22.x"
+  }
+}

--- a/tests/fixtures/pnpm-12-workspace/packages/client/index.js
+++ b/tests/fixtures/pnpm-12-workspace/packages/client/index.js
@@ -1,0 +1,6 @@
+const _ = require('lodash');
+
+const data = _.map([1, 2, 3], n => n * 2);
+console.log('Client data:', data);
+
+module.exports = { data };

--- a/tests/fixtures/pnpm-12-workspace/packages/client/package.json
+++ b/tests/fixtures/pnpm-12-workspace/packages/client/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.202",
+    "prettier": "^3.0.0"
+  }
+}

--- a/tests/fixtures/pnpm-12-workspace/packages/server/index.js
+++ b/tests/fixtures/pnpm-12-workspace/packages/server/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('pnpm-12-workspace');
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/tests/fixtures/pnpm-12-workspace/packages/server/package.json
+++ b/tests/fixtures/pnpm-12-workspace/packages/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21"
+  }
+}

--- a/tests/fixtures/pnpm-12-workspace/pnpm-lock.yaml
+++ b/tests/fixtures/pnpm-12-workspace/pnpm-lock.yaml
@@ -1,0 +1,819 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.1.0
+        version: 12.1.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.1.0':
+    resolution: {integrity: sha512-9K+uSnTsJe9zD/YCMPiQDiwU8IiQRp+ZEE9IyVSr0Ppzfg5/xC0pwet2R320ifDIMroT3WYLkCEolV6XxtSS/g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.1.0':
+    resolution: {integrity: sha512-JcOc77W/KLg5ZZXr7q0WN8UDKirxQTuoaTkqRfMNkGyUHc/4bfNxLwjoZBilRQV6xmhJvU79ZUg++eYohzJhog==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.1.0':
+    resolution: {integrity: sha512-RVJlfI4T2l6XXA5s/Wv9HHEq4ztIq79fiZXDVHyHaKEbp+11ZM5k61z0gaGzXCEGUp5anW2Uc3UgQpmjAR+IPw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.1.0':
+    resolution: {integrity: sha512-iLEE0ykaRZ3/OBhIjwe/Zo96ac0c7pY7toyf6+jUN8gOsIIwJTS+AqSyOy+U1Zyhuuec8nJiRQ4URl60nRxTwA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.1.0':
+    resolution: {integrity: sha512-k+NUTRbz2CR9DBvGyAdtXU5HHPXytxi9MQ79uQRYNLF8nr/l1qHo++TvZ0OUuEpRxhg9B3n84Itv6MAHJR7TQQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.1.0':
+    resolution: {integrity: sha512-GTi1DEM8vwIWpgC8P+xhw3Y2Ko2V88WtKAjbNwdeJAzMpzmcBeE4f0c2QKmeKpvi8/eYarxSIvBhYkTjA1BAcQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.1.0':
+    resolution: {integrity: sha512-cK6kklZY8rs3d9gg8akGUgjDenFy65ZSAANXojs98d7Ne7gbzZYzU2joHRRilfpzCfawgG+lpPsh46a4xu55jQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.1.0':
+    resolution: {integrity: sha512-Pk7Lvq3E5PWQFRJLLnLgW2qJAphtgPYCaaODB+FZRRvKksn8IPnF8Aj+/AT4+52GmckiANTbKwCsL18naJhohw==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.1.0:
+    resolution: {integrity: sha512-2bgnbZf27IbkmBWHf5Hun2PO5h8gY7ME5Dttq4+gfOipr9RtL6zTn5Ieap0Gs8dagTSce4iMLSKIa64CKZAQNw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.1.0':
+    optional: true
+
+  pnpm@12.1.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.1.0
+      '@pnpm/exe.darwin-x64': 12.1.0
+      '@pnpm/exe.linux-arm64': 12.1.0
+      '@pnpm/exe.linux-arm64-musl': 12.1.0
+      '@pnpm/exe.linux-x64': 12.1.0
+      '@pnpm/exe.linux-x64-musl': 12.1.0
+      '@pnpm/exe.win32-arm64': 12.1.0
+      '@pnpm/exe.win32-x64': 12.1.0
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+  packages/client:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.18.1
+    devDependencies:
+      '@types/lodash':
+        specifier: ^4.14.202
+        version: 4.17.25
+      prettier:
+        specifier: ^3.0.0
+        version: 3.9.6
+
+  packages/server:
+    dependencies:
+      express:
+        specifier: ^4.19.2
+        version: 4.22.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+
+packages:
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/express-serve-static-core@4.19.9':
+    resolution: {integrity: sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/lodash@4.17.25':
+    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/node@26.4.0':
+    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
+    engines: {node: '>= 0.10.0'}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+snapshots:
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 26.4.0
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 26.4.0
+
+  '@types/express-serve-static-core@4.19.9':
+    dependencies:
+      '@types/node': 26.4.0
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.9
+      '@types/qs': 6.15.1
+      '@types/serve-static': 1.15.10
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/lodash@4.17.25': {}
+
+  '@types/mime@1.3.5': {}
+
+  '@types/node@26.4.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 26.4.0
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 26.4.0
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 26.4.0
+      '@types/send': 0.17.6
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
+  array-flatten@1.1.1: {}
+
+  body-parser@1.20.6:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  express@4.22.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.6
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  lodash@4.18.1: {}
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  ms@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  negotiator@0.6.3: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  parseurl@1.3.3: {}
+
+  path-to-regexp@0.1.13: {}
+
+  prettier@3.9.6: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  statuses@2.0.2: {}
+
+  toidentifier@1.0.1: {}
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  typescript@5.9.3: {}
+
+  undici-types@8.3.0: {}
+
+  unpipe@1.0.0: {}
+
+  utils-merge@1.0.1: {}
+
+  vary@1.1.2: {}

--- a/tests/fixtures/pnpm-12-workspace/pnpm-workspace.yaml
+++ b/tests/fixtures/pnpm-12-workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/tests/fixtures/pnpm-12/package.json
+++ b/tests/fixtures/pnpm-12/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pnpm-12",
+  "private": true,
+  "scripts": {},
+  "packageManager": "pnpm@12.1.0",
+  "dependencies": {
+    "dotenv": "16.4.5"
+  },
+  "devDependencies": {
+    "environment": "^1.1.0"
+  },
+  "engines": {
+    "node": "22.x"
+  }
+}

--- a/tests/fixtures/pnpm-12/pnpm-lock.yaml
+++ b/tests/fixtures/pnpm-12/pnpm-lock.yaml
@@ -1,0 +1,134 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.1.0
+        version: 12.1.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.1.0':
+    resolution: {integrity: sha512-9K+uSnTsJe9zD/YCMPiQDiwU8IiQRp+ZEE9IyVSr0Ppzfg5/xC0pwet2R320ifDIMroT3WYLkCEolV6XxtSS/g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.1.0':
+    resolution: {integrity: sha512-JcOc77W/KLg5ZZXr7q0WN8UDKirxQTuoaTkqRfMNkGyUHc/4bfNxLwjoZBilRQV6xmhJvU79ZUg++eYohzJhog==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.1.0':
+    resolution: {integrity: sha512-RVJlfI4T2l6XXA5s/Wv9HHEq4ztIq79fiZXDVHyHaKEbp+11ZM5k61z0gaGzXCEGUp5anW2Uc3UgQpmjAR+IPw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.1.0':
+    resolution: {integrity: sha512-iLEE0ykaRZ3/OBhIjwe/Zo96ac0c7pY7toyf6+jUN8gOsIIwJTS+AqSyOy+U1Zyhuuec8nJiRQ4URl60nRxTwA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.1.0':
+    resolution: {integrity: sha512-k+NUTRbz2CR9DBvGyAdtXU5HHPXytxi9MQ79uQRYNLF8nr/l1qHo++TvZ0OUuEpRxhg9B3n84Itv6MAHJR7TQQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.1.0':
+    resolution: {integrity: sha512-GTi1DEM8vwIWpgC8P+xhw3Y2Ko2V88WtKAjbNwdeJAzMpzmcBeE4f0c2QKmeKpvi8/eYarxSIvBhYkTjA1BAcQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.1.0':
+    resolution: {integrity: sha512-cK6kklZY8rs3d9gg8akGUgjDenFy65ZSAANXojs98d7Ne7gbzZYzU2joHRRilfpzCfawgG+lpPsh46a4xu55jQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.1.0':
+    resolution: {integrity: sha512-Pk7Lvq3E5PWQFRJLLnLgW2qJAphtgPYCaaODB+FZRRvKksn8IPnF8Aj+/AT4+52GmckiANTbKwCsL18naJhohw==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.1.0:
+    resolution: {integrity: sha512-2bgnbZf27IbkmBWHf5Hun2PO5h8gY7ME5Dttq4+gfOipr9RtL6zTn5Ieap0Gs8dagTSce4iMLSKIa64CKZAQNw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.1.0':
+    optional: true
+
+  pnpm@12.1.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.1.0
+      '@pnpm/exe.darwin-x64': 12.1.0
+      '@pnpm/exe.linux-arm64': 12.1.0
+      '@pnpm/exe.linux-arm64-musl': 12.1.0
+      '@pnpm/exe.linux-x64': 12.1.0
+      '@pnpm/exe.linux-x64-musl': 12.1.0
+      '@pnpm/exe.win32-arm64': 12.1.0
+      '@pnpm/exe.win32-x64': 12.1.0
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      dotenv:
+        specifier: 16.4.5
+        version: 16.4.5
+    devDependencies:
+      environment:
+        specifier: ^1.1.0
+        version: 1.1.0
+
+packages:
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  dotenv@16.4.5: {}
+
+  environment@1.1.0: {}

--- a/tests/pnpm_integration_test.rs
+++ b/tests/pnpm_integration_test.rs
@@ -225,6 +225,32 @@ fn test_pnpm_11() {
 
 #[test]
 #[ignore = "integration test"]
+fn test_pnpm_12_workspace() {
+    nodejs_integration_test("./fixtures/pnpm-12-workspace", |ctx| {
+        let build_snapshot = create_build_snapshot(&ctx.pack_stdout);
+        assert_web_response(&ctx, "pnpm-12-workspace");
+        let config = ctx.config.clone();
+        ctx.rebuild(config, |ctx| {
+            build_snapshot.rebuild_output(&ctx.pack_stdout).assert();
+            assert_web_response(&ctx, "pnpm-12-workspace");
+        });
+    });
+}
+
+#[test]
+#[ignore = "integration test"]
+fn test_pnpm_12() {
+    nodejs_integration_test("./fixtures/pnpm-12", |ctx| {
+        let build_snapshot = create_build_snapshot(&ctx.pack_stdout);
+        let config = ctx.config.clone();
+        ctx.rebuild(config, |ctx| {
+            build_snapshot.rebuild_output(&ctx.pack_stdout).assert();
+        });
+    });
+}
+
+#[test]
+#[ignore = "integration test"]
 fn test_pnpm_workspace_prune_skipped_if_lifecycle_scripts_are_present_in_root_project() {
     nodejs_integration_test_with_config(
         "./fixtures/pnpm-10-workspace",

--- a/tests/snapshots/test_pnpm_12.snap
+++ b/tests/snapshots/test_pnpm_12.snap
@@ -1,0 +1,192 @@
+---
+source: crates/test_support/src/lib.rs
+---
+===> ANALYZING
+Image with name "<image-name>" not found
+===> DETECTING
+heroku/nodejs <buildpack-version>
+===> RESTORING
+<restoring-output>
+===> BUILDING
+
+## Heroku Node.js
+
+- Checking Node.js version
+  - Detected Node.js version range: `22.x`
+  - Resolved Node.js version: `22.23.2`
+- Installing Node.js distribution
+  - GET https://nodejs.org/download/release/v22.23.2/node-v22.23.2-<arch>.tar.gz ... (<time_elapsed>)
+  - Validating ... (<time_elapsed>)
+  - Extracting ... (<time_elapsed>)
+  - Verifying checksum
+  - Extracting Node.js `22.23.2 (<arch>)`
+  - Installing Node.js `22.23.2 (<arch>)` ... (<time_elapsed>)
+- Determining pnpm package information
+  - Found `packageManager` set to `pnpm@12.1.0` in `package.json`
+  - GET https://registry.npmjs.org/pnpm ... (<time_elapsed>)
+  - Resolved pnpm version `12.1.0` to `12.1.0`
+- Installing pnpm
+  - GET https://registry.npmjs.org/pnpm/-/pnpm-12.1.0.tgz ... (<time_elapsed>)
+  - Extracting ... (<time_elapsed>)
+  - GET https://registry.npmjs.org/@pnpm/exe.<arch> ... (<time_elapsed>)
+  - GET https://registry.npmjs.org/@pnpm/exe.<arch>/-/exe.<arch>-12.1.0.tgz ... (<time_elapsed>)
+  - Extracting ... (<time_elapsed>)
+  - Successfully installed `pnpm@12.1.0`
+- Setting up pnpm dependency store
+  - Creating new pnpm content-addressable store
+  - Creating pnpm virtual store
+- Installing dependencies
+  - Running `pnpm install --frozen-lockfile`
+
+      ? Verifying lockfile against supply-chain policies (<N> entries)...
+      Packages are hard linked from the content-addressable store to the virtual store.
+        Content-addressable store is at: /layers/heroku_nodejs/addressable/v11
+        Virtual store is at:             ../layers/heroku_nodejs/virtual/store
+      Packages: +2
+      ++
+
+      dependencies:
+      + dotenv 16.4.5
+
+      devDependencies:
+      + environment 1.1.0
+
+      Done in <time_elapsed> using pnpm v12.1.0
+
+  - Done (<time_elapsed>)
+- Pruning unused dependencies from pnpm content-addressable store
+  - Running `pnpm store prune`
+
+  - Done (<time_elapsed>)
+- Running scripts
+  - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm prune --prod --ignore-scripts`
+
+      Already up to date
+
+      devDependencies:
+      - environment 1.1.0
+
+      Done in <time_elapsed> using pnpm v12.1.0
+
+  - Done (<time_elapsed>)
+- Removing non-deterministic build artifacts before export
+  - Removed pnpm metadata file node_modules/.modules.yaml
+- Done (finished in <time_elapsed>)
+===> EXPORTING
+Adding layer 'heroku/nodejs:available_parallelism'
+Adding layer 'heroku/nodejs:dist'
+Adding layer 'heroku/nodejs:pnpm'
+Adding layer 'heroku/nodejs:virtual'
+Adding layer 'heroku/nodejs:web_env'
+Adding layer 'heroku/nodejs:z_node_module_bins'
+Adding layer 'buildpacksio/lifecycle:launch.sbom'
+Added 1/1 app layer(s)
+Adding layer 'buildpacksio/lifecycle:launcher'
+Adding layer 'buildpacksio/lifecycle:config'
+Adding label 'io.buildpacks.lifecycle.metadata'
+Adding label 'io.buildpacks.build.metadata'
+Adding label 'io.buildpacks.project.metadata'
+Adding label 'io.buildpacks.exec-env'
+no default process type
+Saving <image-name>...
+*** Images (<random-hex>):
+      <image-name>
+Adding cache layer 'heroku/nodejs:addressable'
+Adding cache layer 'heroku/nodejs:dist'
+Adding cache layer 'heroku/nodejs:pnpm'
+Adding cache layer 'heroku/nodejs:pnpm_exe_packument'
+Adding cache layer 'heroku/nodejs:pnpm_packument'
+Successfully built image '<image-name>'
+
+--------------------------------------------- REBUILD ---------------------------------------------
+===> ANALYZING
+Restoring data for SBOM from previous image
+===> DETECTING
+heroku/nodejs <buildpack-version>
+===> RESTORING
+<restoring-output>
+===> BUILDING
+
+## Heroku Node.js
+
+- Checking Node.js version
+  - Detected Node.js version range: `22.x`
+  - Resolved Node.js version: `22.23.2`
+- Installing Node.js distribution
+  - Reusing Node.js 22.23.2 (<arch>)
+- Determining pnpm package information
+  - Found `packageManager` set to `pnpm@12.1.0` in `package.json`
+  - GET https://registry.npmjs.org/pnpm ... (Not Modified)
+  - Using cached packument for pnpm
+  - Resolved pnpm version `12.1.0` to `12.1.0`
+- Installing pnpm
+  - Using cached version of pnpm
+  - Successfully installed `pnpm@12.1.0`
+- Setting up pnpm dependency store
+  - Restoring pnpm content-addressable store from cache
+  - Creating pnpm virtual store
+- Installing dependencies
+  - Running `pnpm install --frozen-lockfile`
+
+      ? Verifying lockfile against supply-chain policies (<N> entries)...
+      Packages are hard linked from the content-addressable store to the virtual store.
+        Content-addressable store is at: /layers/heroku_nodejs/addressable/v11
+        Virtual store is at:             ../layers/heroku_nodejs/virtual/store
+      Packages: +2
+      ++
+
+      dependencies:
+      + dotenv 16.4.5
+
+      devDependencies:
+      + environment 1.1.0
+
+      Done in <time_elapsed> using pnpm v12.1.0
+
+  - Done (<time_elapsed>)
+- Running scripts
+  - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm prune --prod --ignore-scripts`
+
+      Already up to date
+
+      devDependencies:
+      - environment 1.1.0
+
+      Done in <time_elapsed> using pnpm v12.1.0
+
+  - Done (<time_elapsed>)
+- Removing non-deterministic build artifacts before export
+  - Removed pnpm metadata file node_modules/.modules.yaml
+- Done (finished in <time_elapsed>)
+===> EXPORTING
+Reusing layer 'heroku/nodejs:available_parallelism'
+Reusing layer 'heroku/nodejs:dist'
+Reusing layer 'heroku/nodejs:pnpm'
+Reusing layer 'heroku/nodejs:virtual'
+Reusing layer 'heroku/nodejs:web_env'
+Reusing layer 'heroku/nodejs:z_node_module_bins'
+Reusing layer 'buildpacksio/lifecycle:launch.sbom'
+Reused 1/1 app layer(s)
+Reusing layer 'buildpacksio/lifecycle:launcher'
+Reusing layer 'buildpacksio/lifecycle:config'
+Adding label 'io.buildpacks.lifecycle.metadata'
+Adding label 'io.buildpacks.build.metadata'
+Adding label 'io.buildpacks.project.metadata'
+Adding label 'io.buildpacks.exec-env'
+no default process type
+Saving <image-name>...
+*** Images (<random-hex>):
+      <image-name>
+Reusing cache layer 'heroku/nodejs:addressable'
+Adding cache layer 'heroku/nodejs:addressable'
+Reusing cache layer 'heroku/nodejs:dist'
+Adding cache layer 'heroku/nodejs:dist'
+Reusing cache layer 'heroku/nodejs:pnpm'
+Adding cache layer 'heroku/nodejs:pnpm'
+Reusing cache layer 'heroku/nodejs:pnpm_packument'
+Adding cache layer 'heroku/nodejs:pnpm_packument'
+Successfully built image '<image-name>'

--- a/tests/snapshots/test_pnpm_12_workspace.snap
+++ b/tests/snapshots/test_pnpm_12_workspace.snap
@@ -1,0 +1,186 @@
+---
+source: crates/test_support/src/lib.rs
+---
+===> ANALYZING
+Image with name "<image-name>" not found
+===> DETECTING
+heroku/nodejs <buildpack-version>
+===> RESTORING
+<restoring-output>
+===> BUILDING
+
+## Heroku Node.js
+
+- Checking Node.js version
+  - Detected Node.js version range: `22.x`
+  - Resolved Node.js version: `22.23.2`
+- Installing Node.js distribution
+  - GET https://nodejs.org/download/release/v22.23.2/node-v22.23.2-<arch>.tar.gz ... (<time_elapsed>)
+  - Validating ... (<time_elapsed>)
+  - Extracting ... (<time_elapsed>)
+  - Verifying checksum
+  - Extracting Node.js `22.23.2 (<arch>)`
+  - Installing Node.js `22.23.2 (<arch>)` ... (<time_elapsed>)
+- Determining pnpm package information
+  - Found `packageManager` set to `pnpm@12.1.0` in `package.json`
+  - GET https://registry.npmjs.org/pnpm ... (<time_elapsed>)
+  - Resolved pnpm version `12.1.0` to `12.1.0`
+- Installing pnpm
+  - GET https://registry.npmjs.org/pnpm/-/pnpm-12.1.0.tgz ... (<time_elapsed>)
+  - Extracting ... (<time_elapsed>)
+  - GET https://registry.npmjs.org/@pnpm/exe.<arch> ... (<time_elapsed>)
+  - GET https://registry.npmjs.org/@pnpm/exe.<arch>/-/exe.<arch>-12.1.0.tgz ... (<time_elapsed>)
+  - Extracting ... (<time_elapsed>)
+  - Successfully installed `pnpm@12.1.0`
+- Setting up pnpm dependency store
+  - Creating new pnpm content-addressable store
+  - Creating pnpm virtual store
+- Installing dependencies
+  - Running `pnpm install --frozen-lockfile`
+
+      Scope: all 3 workspace projects
+      ? Verifying lockfile against supply-chain policies (<N> entries)...
+      Packages are hard linked from the content-addressable store to the virtual store.
+        Content-addressable store is at: /layers/heroku_nodejs/addressable/v11
+        Virtual store is at:             ../layers/heroku_nodejs/virtual/store
+      Packages: +85
+      ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+      devDependencies:
+      + typescript 5.9.3
+
+      Done in <time_elapsed> using pnpm v12.1.0
+
+  - Done (<time_elapsed>)
+- Pruning unused dependencies from pnpm content-addressable store
+  - Running `pnpm store prune`
+
+  - Done (<time_elapsed>)
+- Running scripts
+  - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm install --prod --frozen-lockfile`
+
+      Scope: all 3 workspace projects
+      Already up to date
+      Done in <time_elapsed> using pnpm v12.1.0
+
+  - Done (<time_elapsed>)
+- Removing non-deterministic build artifacts before export
+  - Removed pnpm metadata file node_modules/.modules.yaml
+- Done (finished in <time_elapsed>)
+===> EXPORTING
+Adding layer 'heroku/nodejs:available_parallelism'
+Adding layer 'heroku/nodejs:dist'
+Adding layer 'heroku/nodejs:pnpm'
+Adding layer 'heroku/nodejs:virtual'
+Adding layer 'heroku/nodejs:web_env'
+Adding layer 'heroku/nodejs:z_node_module_bins'
+Adding layer 'buildpacksio/lifecycle:launch.sbom'
+Added 1/1 app layer(s)
+Adding layer 'buildpacksio/lifecycle:launcher'
+Adding layer 'buildpacksio/lifecycle:config'
+Adding layer 'buildpacksio/lifecycle:process-types'
+Adding label 'io.buildpacks.lifecycle.metadata'
+Adding label 'io.buildpacks.build.metadata'
+Adding label 'io.buildpacks.project.metadata'
+Adding label 'io.buildpacks.exec-env'
+Setting default process type 'web'
+Saving <image-name>...
+*** Images (<random-hex>):
+      <image-name>
+Adding cache layer 'heroku/nodejs:addressable'
+Adding cache layer 'heroku/nodejs:dist'
+Adding cache layer 'heroku/nodejs:pnpm'
+Adding cache layer 'heroku/nodejs:pnpm_exe_packument'
+Adding cache layer 'heroku/nodejs:pnpm_packument'
+Successfully built image '<image-name>'
+
+--------------------------------------------- REBUILD ---------------------------------------------
+===> ANALYZING
+Restoring data for SBOM from previous image
+===> DETECTING
+heroku/nodejs <buildpack-version>
+===> RESTORING
+<restoring-output>
+===> BUILDING
+
+## Heroku Node.js
+
+- Checking Node.js version
+  - Detected Node.js version range: `22.x`
+  - Resolved Node.js version: `22.23.2`
+- Installing Node.js distribution
+  - Reusing Node.js 22.23.2 (<arch>)
+- Determining pnpm package information
+  - Found `packageManager` set to `pnpm@12.1.0` in `package.json`
+  - GET https://registry.npmjs.org/pnpm ... (Not Modified)
+  - Using cached packument for pnpm
+  - Resolved pnpm version `12.1.0` to `12.1.0`
+- Installing pnpm
+  - Using cached version of pnpm
+  - Successfully installed `pnpm@12.1.0`
+- Setting up pnpm dependency store
+  - Restoring pnpm content-addressable store from cache
+  - Creating pnpm virtual store
+- Installing dependencies
+  - Running `pnpm install --frozen-lockfile`
+
+      Scope: all 3 workspace projects
+      ? Verifying lockfile against supply-chain policies (<N> entries)...
+      Packages are hard linked from the content-addressable store to the virtual store.
+        Content-addressable store is at: /layers/heroku_nodejs/addressable/v11
+        Virtual store is at:             ../layers/heroku_nodejs/virtual/store
+      Packages: +85
+      ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+      devDependencies:
+      + typescript 5.9.3
+
+      The integrity of <N> files was checked, because their timestamps changed since the store recorded them. A backup tool, an antivirus scan, or a copied store can cause this.
+      Done in <time_elapsed> using pnpm v12.1.0
+
+  - Done (<time_elapsed>)
+- Running scripts
+  - No build scripts found
+- Pruning dev dependencies
+  - Running `pnpm install --prod --frozen-lockfile`
+
+      Scope: all 3 workspace projects
+      Already up to date
+      The integrity of <N> files was checked, because their timestamps changed since the store recorded them. A backup tool, an antivirus scan, or a copied store can cause this.
+      Done in <time_elapsed> using pnpm v12.1.0
+
+  - Done (<time_elapsed>)
+- Removing non-deterministic build artifacts before export
+  - Removed pnpm metadata file node_modules/.modules.yaml
+- Done (finished in <time_elapsed>)
+===> EXPORTING
+Reusing layer 'heroku/nodejs:available_parallelism'
+Reusing layer 'heroku/nodejs:dist'
+Reusing layer 'heroku/nodejs:pnpm'
+Reusing layer 'heroku/nodejs:virtual'
+Reusing layer 'heroku/nodejs:web_env'
+Reusing layer 'heroku/nodejs:z_node_module_bins'
+Reusing layer 'buildpacksio/lifecycle:launch.sbom'
+Reused 1/1 app layer(s)
+Reusing layer 'buildpacksio/lifecycle:launcher'
+Reusing layer 'buildpacksio/lifecycle:config'
+Reusing layer 'buildpacksio/lifecycle:process-types'
+Adding label 'io.buildpacks.lifecycle.metadata'
+Adding label 'io.buildpacks.build.metadata'
+Adding label 'io.buildpacks.project.metadata'
+Adding label 'io.buildpacks.exec-env'
+Setting default process type 'web'
+Saving <image-name>...
+*** Images (<random-hex>):
+      <image-name>
+Reusing cache layer 'heroku/nodejs:addressable'
+Adding cache layer 'heroku/nodejs:addressable'
+Reusing cache layer 'heroku/nodejs:dist'
+Adding cache layer 'heroku/nodejs:dist'
+Reusing cache layer 'heroku/nodejs:pnpm'
+Adding cache layer 'heroku/nodejs:pnpm'
+Reusing cache layer 'heroku/nodejs:pnpm_packument'
+Adding cache layer 'heroku/nodejs:pnpm_packument'
+Successfully built image '<image-name>'


### PR DESCRIPTION
pnpm 12 is a ground-up rewrite that changes how the CLI is distributed: rather than a single JavaScript package, the native executable now ships as a separate platform-specific package (`@pnpm/exe.<target>`) pulled in as an optional dependency. The buildpack's pnpm installer assumed the older single-package layout, so apps pinning pnpm 12 couldn't install it.

These changes allow the buildpack to adapt to the new pnpm 12 distribution model and install the native binary matching the build's target architecture.

W-24059616
